### PR TITLE
feat(ui): restack image changes and shorten digests

### DIFF
--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -641,18 +641,41 @@ body {
   font-size: 12px;
   margin-top: 3px;
 }
-.img-table {
-  border-collapse: collapse;
+/* Each image change is a stacked block (name / from→to / refs) rather than a
+   table row, so a long digest wraps instead of forcing horizontal overflow. */
+.img-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
   font-size: 12px;
-  width: 100%;
 }
-.img-table td {
-  padding: 3px 10px 3px 0;
-  vertical-align: top;
+.img-change {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
-.img-name,
-.img-ver {
+.img-head {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.img-name {
   font-family: ui-monospace, monospace;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+.img-delta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-family: ui-monospace, monospace;
+}
+.img-ver {
+  overflow-wrap: anywhere;
 }
 .img-ver.from {
   color: var(--danger);
@@ -660,19 +683,12 @@ body {
 .img-ver.to {
   color: var(--ok);
 }
-/* Keep the version and its copy button on one line (the button is inline-flex
-   and would otherwise wrap below the version in the narrow cell). */
-.ver-copy {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-}
 .img-arrow {
   color: var(--muted);
 }
 .img-refs {
   color: var(--muted);
-  width: 100%;
+  overflow-wrap: anywhere;
 }
 .failure {
   padding: 4px 0;

--- a/internal/web/src/lib/Overview.svelte
+++ b/internal/web/src/lib/Overview.svelte
@@ -19,6 +19,23 @@
   function open(id: string) {
     if (router.route.name === 'review') openDiffs(router.route.pr, id);
   }
+
+  // Shorten an "algo:hexdigest" (e.g. sha256:<64 hex>) to "algo:<12 hex>…" so a
+  // digest-pinned image doesn't blow out the layout; tags are short already and
+  // shown in full. The full value stays in the title tooltip and the copy button.
+  function shortVer(v: string): string {
+    if (!v) return '∅';
+    const i = v.indexOf(':');
+    if (i < 0) return v; // a tag — no algo prefix
+    const hex = v.slice(i + 1);
+    return /^[0-9a-f]+$/i.test(hex) && hex.length > 12 ? `${v.slice(0, i + 1)}${hex.slice(0, 12)}…` : v;
+  }
+
+  // Reconstruct a pullable reference for the copy button: a digest joins the name
+  // with '@' (a tag can never contain ':', so a ':' in the version means digest).
+  function imageRef(name: string, ver: string): string {
+    return ver.includes(':') ? `${name}@${ver}` : `${name}:${ver}`;
+  }
 </script>
 
 <div class="overview">
@@ -53,26 +70,24 @@
   {#if d.images?.length}
     <section class="ov-section">
       <h3><Icon path={mdiPackageVariantClosed} size={15} /> Image changes</h3>
-      <table class="img-table">
-        <tbody>
-          {#each d.images as img}
-            <tr>
-              <td class="img-name">{img.name}</td>
-              <td class="img-ver from">{img.from || '∅'}</td>
-              <td class="img-arrow">→</td>
-              <td class="img-ver to">
-                <span class="ver-copy"
-                  >{img.to || '∅'}{#if img.to}<Copy
-                      text={`${img.name}:${img.to}`}
-                      label="Copy image reference"
-                    />{/if}</span
-                >
-              </td>
-              <td class="img-refs">{img.refs?.join(', ') ?? ''}</td>
-            </tr>
-          {/each}
-        </tbody>
-      </table>
+      <ul class="img-list">
+        {#each d.images as img}
+          <li class="img-change">
+            <div class="img-head">
+              <span class="img-name">{img.name}</span>
+              {#if img.to}<Copy text={imageRef(img.name, img.to)} label="Copy new image reference" />{/if}
+            </div>
+            <div class="img-delta">
+              <span class="img-ver from" title={img.from || undefined}>{shortVer(img.from)}</span>
+              <span class="img-arrow">→</span>
+              <span class="img-ver to" title={img.to || undefined}>{shortVer(img.to)}</span>
+            </div>
+            {#if img.refs?.length}
+              <div class="img-refs">{img.refs.join(', ')}</div>
+            {/if}
+          </li>
+        {/each}
+      </ul>
     </section>
   {/if}
 

--- a/internal/web/tests/fixtures.ts
+++ b/internal/web/tests/fixtures.ts
@@ -89,6 +89,13 @@ export const sampleDiff: DiffResult = {
       to: 'v1.15.0',
       refs: ['Deployment rook-ceph/rook-ceph-operator'],
     },
+    {
+      // Digest-pinned image: the full sha256 digests must be shortened in the UI.
+      name: 'ghcr.io/thelounge/thelounge:4.5.0',
+      from: 'sha256:9c3667236b1a82cf79b1b35e012ddf58e1e2de46f3596befbc699825c0793680',
+      to: 'sha256:7f2fff6e264411ce8608bd1fdf5142a3cd980677b0479e7e3702aadf18cd1abc',
+      refs: ['Deployment default/thelounge'],
+    },
   ],
   failures: [
     { parent: 'HelmRelease media/plex', message: "values don't meet the schema: .image.tag is required" },

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -39,7 +39,7 @@ test('list → review → diffs flow', async ({ page }) => {
   await expect(page.locator('.danger-strip')).toContainText('danger');
   await expect(page.locator('.impact')).toContainText('resources');
   await expect(page.locator('.warning.danger')).toContainText('StatefulSet');
-  await expect(page.locator('.img-table')).toContainText('ghcr.io/rook/ceph');
+  await expect(page.locator('.img-list')).toContainText('ghcr.io/rook/ceph');
   await expect(page.locator('.failure')).toContainText('plex');
   await expect(page.locator('.ov-res')).toHaveCount(3);
 
@@ -187,6 +187,40 @@ test('filter narrows the PR list', async ({ page }) => {
   await expect(page.locator('.card')).toContainText('#131');
 });
 
+test('image changes shorten digest versions (full value on hover + correct copy)', async ({ page }) => {
+  await page.addInitScript(() => {
+    (window as unknown as { __copied: string[] }).__copied = [];
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: (t: string) => {
+          (window as unknown as { __copied: string[] }).__copied.push(t);
+          return Promise.resolve();
+        },
+      },
+    });
+  });
+  await stubApi(page);
+  await page.goto('/#/pr/142');
+
+  const block = page.locator('.img-change', { hasText: 'thelounge' });
+  // Displayed as sha256:<12 hex>…, never the full 64-hex digest (which blew out the width).
+  await expect(block.locator('.img-ver.to')).toHaveText('sha256:7f2fff6e2644…');
+  await expect(block.locator('.img-ver.from')).toHaveText('sha256:9c3667236b1a…');
+  await expect(block.locator('.img-ver.to')).not.toContainText('aadf18cd1abc'); // the truncated tail
+  // Full digest preserved on hover.
+  await expect(block.locator('.img-ver.to')).toHaveAttribute(
+    'title',
+    'sha256:7f2fff6e264411ce8608bd1fdf5142a3cd980677b0479e7e3702aadf18cd1abc',
+  );
+  // Copy reconstructs a digest reference with '@' (not a malformed second ':').
+  await block.locator('.copy-btn').click();
+  const copied = await page.evaluate(() => (window as unknown as { __copied: string[] }).__copied);
+  expect(copied).toContain(
+    'ghcr.io/thelounge/thelounge:4.5.0@sha256:7f2fff6e264411ce8608bd1fdf5142a3cd980677b0479e7e3702aadf18cd1abc',
+  );
+});
+
 test('mobile: diff header title is not crushed to one char per line (regression)', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await stubApi(page);
@@ -220,7 +254,7 @@ test('copy buttons copy the full underlying value', async ({ page }) => {
   // Head SHA copies the full SHA, not the 7-char display.
   await page.locator('.sha-wrap .copy-btn').click();
   // Image-change row copies the full name:tag reference.
-  await page.locator('.img-table .copy-btn').first().click();
+  await page.locator('.img-change .copy-btn').first().click();
   const copied = await page.evaluate(() => (window as unknown as { __copied: string[] }).__copied);
   expect(copied).toContain('a1b2c3d4e5f6');
   expect(copied).toContain('ghcr.io/rook/ceph:v1.15.0');


### PR DESCRIPTION
## What

Digest-pinned images (Renovate often pins `image@sha256:…`) rendered their full 64-char digest inside the image-changes table, forcing the whole Overview to scroll far past the viewport.

This reworks the **Image changes** section:

- **Stacked layout** — each image is now a block (name / `from → to` / referencing resources) instead of a wide table row, so long values wrap instead of overflowing.
- **Shortened digests** — `sha256:<64 hex>` now displays as `sha256:<12 hex>…` (color-coded red→green); tags are shown in full. The complete digest stays available on hover (`title`) and via the copy button.
- **Copy fix** — for digest images the copy button produced an invalid `name:sha256:…` (double colon); it now joins digests with `@` (`name@sha256:…`) and tags with `:`.

## Test plan

- New Playwright test: digest renders short (`sha256:7f2fff6e2644…`, not the full hex), the full digest is in the element `title`, and copy yields a valid `name@sha256:…` reference.
- `svelte-check` clean, UI build OK, 23 Playwright tests pass.
