### PR TITLE
feat: log each PR refresh, and accept form-urlencoded webhooks

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -81,7 +81,7 @@ func (s *Server) handlePush(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{keyError: "invalid PR number"})
 		return
 	}
-	if err := s.refreshPR(r.Context(), number); err != nil {
+	if err := s.refreshPR(r.Context(), number, "push"); err != nil {
 		s.log.Warn("push: fetch PR failed", "pr", number, "error", err)
 		writeJSON(w, http.StatusBadGateway, map[string]string{keyError: "could not fetch PR from forge"})
 		return
@@ -92,7 +92,7 @@ func (s *Server) handlePush(w http.ResponseWriter, r *http.Request) {
 // refreshPR fetches a single PR from the forge and enqueues its diff. Shared by
 // the push endpoint (synchronous, surfaces fetch errors) and the webhook
 // (fire-and-forget).
-func (s *Server) refreshPR(ctx context.Context, number int) error {
+func (s *Server) refreshPR(ctx context.Context, number int, reason string) error {
 	pr, err := s.prov.GetPR(ctx, number)
 	if err != nil {
 		return err
@@ -104,6 +104,7 @@ func (s *Server) refreshPR(ctx context.Context, number int) error {
 		return nil
 	}
 	s.store.upsertPR(pr)
+	s.log.Info("queuing render", "pr", number, "reason", reason)
 	s.queue.enqueue(pr)
 	return nil
 }
@@ -127,7 +128,7 @@ func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	// open-PR set may have changed (opened/closed/...) or the payload is opaque.
 	if ev := webhook.Parse(s.cfg.Forge.Kind, r.Header, body); ev.PR > 0 && !ev.Relist {
 		go func() {
-			if err := s.refreshPR(s.runCtx, ev.PR); err != nil {
+			if err := s.refreshPR(s.runCtx, ev.PR, "webhook"); err != nil {
 				s.log.Warn("webhook: refresh PR failed", "pr", ev.PR, "error", err)
 			}
 		}()
@@ -161,6 +162,11 @@ func (s *Server) refreshList(ctx context.Context) {
 		prev, known := s.store.get(pr.Number)
 		s.store.upsertPR(pr)
 		if !known || prev.PR.HeadSHA != pr.HeadSHA {
+			reason := "head advanced"
+			if !known {
+				reason = "new PR"
+			}
+			s.log.Info("queuing render", "pr", pr.Number, "reason", reason)
 			s.queue.enqueue(pr) // new PR, or its head advanced → (re)render now
 		}
 	}

--- a/internal/server/queue.go
+++ b/internal/server/queue.go
@@ -109,6 +109,7 @@ func (q *queue) run(pr api.PR) {
 	for {
 		q.store.setStatus(pr, api.JobRunning)
 		q.emit(pr.Number, api.JobRunning, "")
+		q.log.Debug("rendering diff", "pr", pr.Number, "head", pr.HeadSHA)
 
 		start := time.Now()
 		res, err := q.renderWithRecover(pr)
@@ -131,6 +132,9 @@ func (q *queue) run(pr api.PR) {
 		} else {
 			q.metrics.diffTotal.WithLabelValues("success").Inc()
 			q.store.setResult(pr.Number, res)
+			sig := computeSignals(&res)
+			q.log.Info("diff rendered", "pr", pr.Number, "duration", time.Since(start).Round(time.Millisecond),
+				"resources", sig.Resources, "danger", sig.Danger, "images", sig.Images, "failures", sig.Failures)
 			q.emit(pr.Number, api.JobReady, "")
 		}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -140,6 +140,7 @@ func (s *Server) refreshLoop(ctx context.Context) {
 // refresh interval — the backstop for an inbound webhook that never arrived.
 func (s *Server) refreshStale(now time.Time) {
 	for _, pr := range s.store.stalePRs(now, s.cfg.RefreshInterval) {
+		s.log.Info("queuing render", "pr", pr.Number, "reason", "stale")
 		s.queue.enqueue(pr)
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"slices"
 	"strings"
 	"sync"
@@ -554,6 +555,32 @@ func TestServer_WebhookPerPR(t *testing.T) {
 	if _, ok := s.store.get(6); ok {
 		t.Error("webhook re-listed PRs (#6 appeared); expected a per-PR refresh of #5 only")
 	}
+}
+
+func TestServer_WebhookFormEncoded(t *testing.T) {
+	t.Parallel()
+	cfg := ghCfg("tok")
+	cfg.WebhookSecret = "shh"
+	s := newTestServer(t, cfg, &fakeProvider{prs: []api.PR{{Number: 5, Open: true, HeadRef: "f5", BaseRef: "main"}}}, okEngine())
+	h := s.mainHandler()
+
+	// GitHub's default content type wraps the JSON in a `payload=` form field; the
+	// signature is over that raw form body. The per-PR path must still run rather
+	// than degrade to a full re-list.
+	body := "payload=" + url.QueryEscape(`{"action":"synchronize","number":5,"pull_request":{"number":5}}`)
+	mac := hmac.New(sha256.New, []byte("shh"))
+	mac.Write([]byte(body))
+	sig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+
+	rec := do(h, "POST", "/hooks", strings.NewReader(body), map[string]string{
+		"X-GitHub-Event":      "pull_request",
+		"Content-Type":        "application/x-www-form-urlencoded",
+		"X-Hub-Signature-256": sig,
+	})
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("webhook: got %d, want 202", rec.Code)
+	}
+	waitFor(t, s, 5) // rendered via the per-PR path despite the form content type
 }
 
 func TestServer_HealthAndSecurityHeaders(t *testing.T) {

--- a/internal/webhook/parse.go
+++ b/internal/webhook/parse.go
@@ -1,10 +1,13 @@
 package webhook
 
 import (
+	"bytes"
 	"cmp"
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"slices"
+	"strings"
 
 	"github.com/home-operations/konflate/internal/config"
 )
@@ -23,6 +26,7 @@ type Event struct {
 // cannot confidently interpret yields Relist (a full re-list), which is always
 // safe — at worst it does more work than necessary.
 func Parse(forge config.ForgeKind, header http.Header, body []byte) Event {
+	body = unwrapFormPayload(header, body)
 	switch forge {
 	case config.ForgeGitHub:
 		return parsePullRequest(header.Get("X-GitHub-Event") == "pull_request", body)
@@ -32,6 +36,25 @@ func Parse(forge config.ForgeKind, header http.Header, body []byte) Event {
 		return parseMergeRequest(body)
 	}
 	return Event{Relist: true}
+}
+
+// unwrapFormPayload returns the JSON document from a webhook body. GitHub and
+// Gitea/Forgejo default to the application/x-www-form-urlencoded content type,
+// which wraps the JSON in a `payload=` form field; unwrap it so the parsers
+// always see raw JSON — otherwise a content event fails to parse and degrades to
+// a full re-list. Signature verification runs over the original body upstream,
+// so unwrapping here never affects authentication.
+func unwrapFormPayload(header http.Header, body []byte) []byte {
+	if !strings.HasPrefix(header.Get("Content-Type"), "application/x-www-form-urlencoded") &&
+		!bytes.HasPrefix(body, []byte("payload=")) {
+		return body
+	}
+	if v, err := url.ParseQuery(string(body)); err == nil {
+		if p := v.Get("payload"); p != "" {
+			return []byte(p)
+		}
+	}
+	return body
 }
 
 // parsePullRequest handles GitHub and Forgejo/Gitea, whose "pull_request"

--- a/internal/webhook/parse_test.go
+++ b/internal/webhook/parse_test.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/home-operations/konflate/internal/config"
@@ -32,6 +33,9 @@ func TestParse(t *testing.T) {
 			`{"action":"synchronize","pull_request":{"number":9}}`, 9, false},
 		{"github non-PR event → relist", config.ForgeGitHub, hdr("X-GitHub-Event", "ping"), `{}`, 0, true},
 		{"github malformed → relist", config.ForgeGitHub, hdr("X-GitHub-Event", "pull_request"), `not json`, 0, true},
+		// GitHub's default content type wraps the JSON in a `payload=` form field.
+		{"github form-encoded synchronize → that PR", config.ForgeGitHub, hdr("X-GitHub-Event", "pull_request"),
+			"payload=" + url.QueryEscape(`{"action":"synchronize","number":7,"pull_request":{"number":7}}`), 7, false},
 
 		// Forgejo / Gitea
 		{"forgejo synchronized → that PR", config.ForgeForgejo, hdr("X-Gitea-Event", "pull_request"),


### PR DESCRIPTION
Two small server-side improvements (both came up while reasoning about webhook/refresh behavior).

## 1. feat: log each PR render with its trigger

The render queue only logged *failures*, so a normal refresh left no trace. Now:
- Each trigger logs **why** a PR is queued: `queuing render pr=142 reason=…` — `new PR`, `head advanced`, `webhook`, `push`, or `stale`.
- The queue logs the render **start** (debug) and **completion**: `diff rendered pr=142 duration=2.3s resources=6 danger=1 images=1 failures=0`.

So you can follow a PR end to end: `queuing render (webhook)` → `diff rendered (…counts)`. `refreshPR` now takes a `reason`.

## 2. fix(webhook): accept form-urlencoded payloads

GitHub's webhook UI **defaults to `application/x-www-form-urlencoded`**, which wraps the JSON in a `payload=` form field. `Parse` did a raw `json.Unmarshal`, so under the default content type a content event (e.g. `synchronize`) failed to parse and **degraded to a full re-list** instead of the targeted per-PR re-render. `Parse` now unwraps the `payload` field (detected by content type or a leading `payload=`) before parsing.

Signature verification still runs over the **original** body, so authentication is unaffected — and raw `application/json` webhooks are unchanged.

## Test plan
- New parse test: a form-encoded GitHub `synchronize` resolves to that PR (not a re-list).
- New server test: a form-encoded webhook with a real signature over the form body takes the per-PR path (`waitFor` PR #5).
- Full Go suite green with `-race`; golangci-lint 0; gofmt clean.
