### PR TITLE
feat(ui): pill-style list summary (open/danger/failed/rendering/merged) + review-header meta icons

### DIFF
--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -424,6 +424,13 @@ body {
 .sum-pill.danger strong {
   color: var(--danger);
 }
+.sum-pill.merged {
+  color: var(--merged);
+  border-color: color-mix(in srgb, var(--merged) 40%, var(--border));
+}
+.sum-pill.merged strong {
+  color: var(--merged);
+}
 .badges {
   display: flex;
   align-items: center;
@@ -506,6 +513,11 @@ body {
   font-size: 12px;
   color: var(--muted);
   margin-top: 2px;
+}
+.rt-author {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
 }
 .sha {
   font-family: ui-monospace, monospace;

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -394,20 +394,35 @@ body {
   white-space: nowrap;
 }
 .list-summary {
-  margin: -2px 0 12px;
-  padding: 0 2px;
-  font-size: 13px;
-  color: var(--muted);
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  max-width: 960px;
+  margin: 12px auto 4px;
+  padding: 0 16px;
 }
-.list-summary strong {
+.sum-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 3px 12px;
+  font-size: 12px;
+  color: var(--muted);
+  background: var(--panel);
+}
+.sum-pill strong {
   color: var(--text);
   font-weight: 600;
 }
-.sum-danger {
+.sum-pill.danger {
   color: var(--danger);
+  border-color: color-mix(in srgb, var(--danger) 40%, var(--border));
 }
-.sum-muted {
-  color: var(--muted);
+.sum-pill.danger strong {
+  color: var(--danger);
 }
 .badges {
   display: flex;

--- a/internal/web/src/lib/List.svelte
+++ b/internal/web/src/lib/List.svelte
@@ -124,12 +124,12 @@
   </div>
 
   {#if store.loaded && openPrs.length}
-    <p class="list-summary">
-      <strong>{summary.open}</strong> open
-      {#if summary.danger}<span class="sum-danger"> · {summary.danger} with danger</span>{/if}
-      {#if summary.failed}<span class="sum-danger"> · {summary.failed} failed to render</span>{/if}
-      {#if summary.rendering}<span class="sum-muted"> · {summary.rendering} rendering…</span>{/if}
-    </p>
+    <div class="list-summary">
+      <span class="sum-pill"><strong>{summary.open}</strong> open</span>
+      {#if summary.danger}<span class="sum-pill danger"><strong>{summary.danger}</strong> danger</span>{/if}
+      {#if summary.failed}<span class="sum-pill danger"><strong>{summary.failed}</strong> failed</span>{/if}
+      {#if summary.rendering}<span class="sum-pill"><strong>{summary.rendering}</strong> rendering</span>{/if}
+    </div>
   {/if}
 
   {#if !store.loaded}

--- a/internal/web/src/lib/List.svelte
+++ b/internal/web/src/lib/List.svelte
@@ -32,6 +32,7 @@
     danger: openPrs.filter((p) => (p.signals?.danger ?? 0) > 0).length,
     failed: openPrs.filter((p) => p.status === 'error').length,
     rendering: openPrs.filter((p) => p.status === 'pending' || p.status === 'running').length,
+    merged: mergedPrs.length,
   }));
 
   // The default base branch is whatever most open PRs target. A PR whose base
@@ -129,6 +130,7 @@
       {#if summary.danger}<span class="sum-pill danger"><strong>{summary.danger}</strong> danger</span>{/if}
       {#if summary.failed}<span class="sum-pill danger"><strong>{summary.failed}</strong> failed</span>{/if}
       {#if summary.rendering}<span class="sum-pill"><strong>{summary.rendering}</strong> rendering</span>{/if}
+      {#if summary.merged}<span class="sum-pill merged"><strong>{summary.merged}</strong> merged</span>{/if}
     </div>
   {/if}
 

--- a/internal/web/src/lib/Review.svelte
+++ b/internal/web/src/lib/Review.svelte
@@ -13,6 +13,8 @@
     mdiOpenInNew,
     mdiSourceMerge,
     mdiTrayFull,
+    mdiAccountOutline,
+    mdiClockOutline,
   } from './icons';
   import Overview from './Overview.svelte';
   import Diffs from './Diffs.svelte';
@@ -44,9 +46,9 @@
               <code class="sha">{pr.headSha.slice(0, 7)}</code>
               <Copy text={pr.headSha} label="Copy full commit SHA" />
             </span>
-            <span>{pr.author}</span>
+            <span class="rt-author"><Icon path={mdiAccountOutline} size={13} /> {pr.author}</span>
             {#if pr.updatedAt}
-              <span class="ago" title={`Last refreshed ${absolute(pr.updatedAt)}`}>{timeAgo(pr.updatedAt, clock.now)}</span>
+              <span class="ago" title={`Last refreshed ${absolute(pr.updatedAt)}`}><Icon path={mdiClockOutline} size={13} /> {timeAgo(pr.updatedAt, clock.now)}</span>
             {/if}
           {/if}
           {#if forgeUrl}

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -63,8 +63,7 @@ test('landing health summary + non-default base branch tag', async ({ page }) =>
   // to render, #138 still rendering.
   const summary = page.locator('.list-summary');
   await expect(summary).toContainText('3 open');
-  await expect(summary).toContainText('1 with danger');
-  await expect(summary).toContainText('1 failed to render');
+  await expect(summary.locator('.sum-pill.danger')).toContainText(['1 danger', '1 failed']);
   await expect(summary).toContainText('1 rendering');
 
   // Most PRs target main, so only #138 (→ staging) is flagged with a base tag.

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -65,6 +65,7 @@ test('landing health summary + non-default base branch tag', async ({ page }) =>
   await expect(summary).toContainText('3 open');
   await expect(summary.locator('.sum-pill.danger')).toContainText(['1 danger', '1 failed']);
   await expect(summary).toContainText('1 rendering');
+  await expect(summary.locator('.sum-pill.merged')).toContainText('1 merged');
 
   // Most PRs target main, so only #138 (→ staging) is flagged with a base tag.
   await expect(page.locator('.card', { hasText: '#138' }).locator('.base-tag')).toContainText('staging');


### PR DESCRIPTION
Polish for the list landing page and the review header.

- **Health summary as centered pills** above the PR list — `open` / `danger` / `failed` / `rendering` / `merged` — matching the Overview impact-bar aesthetic. Danger/failed are red-tinted, merged is purple (matching the merged shelf), the rest neutral.
- **Review (overview) header meta icons** — the same person and clock icons from the list cards now sit beside the author and timestamp.

**Test plan:** summary Playwright assertions updated to the pill structure (incl. the merged pill); svelte-check 0, UI build ok, full Playwright suite green (24); screenshots confirm the centered pills and the review-header icons.

(PR #11, which added the summary, was already merged, so this builds on `main`.)