### PR TITLE
fix: keep the last-good diff when a re-render fails

### DIFF
--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -16,9 +16,12 @@ const (
 // element type of the GET /api/prs list that drives the UI's PR list.
 type PRStatus struct {
 	PR
-	Status    JobStatus `json:"status"`
-	Error     string    `json:"error,omitempty"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	Status JobStatus `json:"status"`
+	Error  string    `json:"error,omitempty"`
+	// RefreshError is set when a re-render failed but a previously rendered diff
+	// is still being shown; the UI flags it without dropping the diff.
+	RefreshError string    `json:"refreshError,omitempty"`
+	UpdatedAt    time.Time `json:"updatedAt"`
 	// ClosedAt is set once a PR leaves the forge's open set (merged); the UI
 	// groups these below the open PRs and shows "merged <ago>". Nil while open.
 	ClosedAt *time.Time `json:"closedAt,omitempty"`
@@ -43,6 +46,9 @@ type DiffEnvelope struct {
 	PR     PR          `json:"pr"`
 	Diff   *DiffResult `json:"diff,omitempty"`
 	Error  string      `json:"error,omitempty"`
+	// RefreshError is set when the last re-render failed but Diff is still the
+	// last-good render (the UI shows a "couldn't refresh" banner).
+	RefreshError string `json:"refreshError,omitempty"`
 }
 
 // Meta is the non-secret identity of this konflate instance, served at

--- a/internal/server/queue.go
+++ b/internal/server/queue.go
@@ -126,9 +126,15 @@ func (q *queue) run(pr api.PR) {
 			}
 		} else if err != nil {
 			q.metrics.diffTotal.WithLabelValues("error").Inc()
-			q.store.setError(pr.Number, err.Error())
-			q.emit(pr.Number, api.JobError, err.Error())
-			q.log.Error("diff render failed", "pr", pr.Number, "error", err)
+			if q.store.failRender(pr.Number, err.Error()) {
+				// A previously rendered diff is kept; flag the failed refresh
+				// instead of clobbering it (transient forge/git outage, flaky pull).
+				q.emit(pr.Number, api.JobReady, "")
+				q.log.Warn("diff refresh failed; kept last render", "pr", pr.Number, "error", err)
+			} else {
+				q.emit(pr.Number, api.JobError, err.Error())
+				q.log.Error("diff render failed", "pr", pr.Number, "error", err)
+			}
 		} else {
 			q.metrics.diffTotal.WithLabelValues("success").Inc()
 			q.store.setResult(pr.Number, res)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -391,17 +391,52 @@ func TestStore_ClosedJobRejectsLateWrites(t *testing.T) {
 
 	// The stale in-flight render finishes after the PR was shelved.
 	st.setStatus(api.PR{Number: 1}, api.JobRunning)
-	st.setError(1, "engine: clone PR #1: gitclone: head ref no longer exists on remote")
+	if st.failRender(1, "engine: clone PR #1: gitclone: head ref no longer exists on remote") {
+		t.Error("failRender reported keeping a diff for a shelved PR")
+	}
 
 	env, _ := st.get(1)
 	if env.Status != api.JobReady {
 		t.Errorf("shelved PR status = %q, want ready (late writes ignored)", env.Status)
 	}
-	if env.Error != "" {
-		t.Errorf("shelved PR error = %q, want empty (late setError ignored)", env.Error)
+	if env.Error != "" || env.RefreshError != "" {
+		t.Errorf("shelved PR error = %q/%q, want empty (late failRender ignored)", env.Error, env.RefreshError)
 	}
 	if env.Diff == nil {
 		t.Error("shelved PR lost its frozen diff to a late write")
+	}
+}
+
+func TestStore_FailRenderKeepsLastGoodDiff(t *testing.T) {
+	t.Parallel()
+	st := newStore()
+	st.upsertPR(api.PR{Number: 1, Open: true})
+
+	// Never rendered → a failure flips it to the error state.
+	if st.failRender(1, "boom") {
+		t.Error("failRender kept a diff for a never-rendered PR")
+	}
+	if env, _ := st.get(1); env.Status != api.JobError || env.Error == "" {
+		t.Fatalf("never-rendered failure: status=%q err=%q, want error", env.Status, env.Error)
+	}
+
+	// After a good render, a failure keeps the diff and flags refreshError
+	// instead of clobbering it (a transient forge/git outage must not wipe it).
+	st.setResult(1, api.DiffResult{PRNumber: 1})
+	if !st.failRender(1, "forge down") {
+		t.Error("failRender dropped a good diff on a transient failure")
+	}
+	env, _ := st.get(1)
+	if env.Status != api.JobReady || env.Diff == nil {
+		t.Fatalf("kept-render: status=%q diff=%v, want ready+diff", env.Status, env.Diff)
+	}
+	if env.RefreshError != "forge down" {
+		t.Errorf("refreshError = %q, want %q", env.RefreshError, "forge down")
+	}
+	// A later success clears the refresh-error flag.
+	st.setResult(1, api.DiffResult{PRNumber: 1})
+	if env, _ := st.get(1); env.RefreshError != "" {
+		t.Errorf("refreshError = %q after success, want empty", env.RefreshError)
 	}
 }
 

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -25,6 +25,10 @@ type job struct {
 	// error), zero until the first render. The refresh loop re-renders an open PR
 	// once this is older than the refresh interval — the missed-webhook backstop.
 	renderedAt time.Time
+	// refreshErr holds the message from the most recent failed re-render while an
+	// earlier diff is still shown; empty after a success. Lets the UI flag
+	// "couldn't refresh" without discarding the last-good diff.
+	refreshErr string
 }
 
 // store is the in-memory, concurrency-safe record of every known PR and the
@@ -86,6 +90,7 @@ func (s *store) setResult(number int, result api.DiffResult) {
 		j.signals = computeSignals(&r)
 		j.status = api.JobReady
 		j.errMsg = ""
+		j.refreshErr = ""
 		j.updated = s.now()
 		j.renderedAt = j.updated
 	}
@@ -109,19 +114,28 @@ func computeSignals(d *api.DiffResult) *api.Signals {
 	return s
 }
 
-// setError marks the PR's diff as failed with msg. A PR already frozen on the
-// merged shelf is left untouched (see setStatus).
-func (s *store) setError(number int, msg string) {
+// failRender records a render failure. If the PR still has a previously rendered
+// diff, that diff is kept and the failure is flagged via refreshErr instead — so
+// a transient forge/git outage or a flaky source pull doesn't wipe a good render;
+// the UI keeps showing it with a "couldn't refresh" marker. Only a PR that never
+// rendered flips to the error state. Returns whether a prior diff was kept. A PR
+// frozen on the merged shelf is left untouched (see setStatus).
+func (s *store) failRender(number int, msg string) (kept bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if j := s.jobs[number]; j != nil && j.closedAt.IsZero() {
-		j.status = api.JobError
-		j.errMsg = msg
-		j.result = nil
-		j.signals = nil
-		j.updated = s.now()
-		j.renderedAt = j.updated
+	j := s.jobs[number]
+	if j == nil || !j.closedAt.IsZero() {
+		return false
 	}
+	j.updated = s.now()
+	j.renderedAt = j.updated
+	if j.result != nil {
+		j.refreshErr = msg // keep result/signals and the JobReady status
+		return true
+	}
+	j.status = api.JobError
+	j.errMsg = msg
+	return false
 }
 
 // get returns a snapshot of one PR's job, or false if unknown.
@@ -132,7 +146,7 @@ func (s *store) get(number int) (api.DiffEnvelope, bool) {
 	if j == nil {
 		return api.DiffEnvelope{}, false
 	}
-	return api.DiffEnvelope{Status: j.status, PR: j.pr, Diff: j.result, Error: j.errMsg}, true
+	return api.DiffEnvelope{Status: j.status, PR: j.pr, Diff: j.result, Error: j.errMsg, RefreshError: j.refreshErr}, true
 }
 
 // activeNumbers returns the PRs currently treated as open (not yet marked
@@ -253,7 +267,7 @@ func (s *store) list() []api.PRStatus {
 			c := j.closedAt
 			closedAt = &c
 		}
-		out = append(out, api.PRStatus{PR: j.pr, Status: j.status, Error: j.errMsg, UpdatedAt: j.updated, ClosedAt: closedAt, Signals: j.signals})
+		out = append(out, api.PRStatus{PR: j.pr, Status: j.status, Error: j.errMsg, RefreshError: j.refreshErr, UpdatedAt: j.updated, ClosedAt: closedAt, Signals: j.signals})
 	}
 	slices.SortFunc(out, func(a, b api.PRStatus) int { return cmp.Compare(b.Number, a.Number) }) // newest first
 	return out

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -619,6 +619,17 @@ body {
   font-weight: 600;
   border-bottom: 1px solid color-mix(in srgb, var(--merged) 30%, var(--border));
 }
+.refresh-strip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  background: var(--caution-bg);
+  color: var(--caution);
+  font-size: 13px;
+  font-weight: 600;
+  border-bottom: 1px solid color-mix(in srgb, var(--caution) 30%, var(--border));
+}
 .tabs {
   display: flex;
   gap: 4px;

--- a/internal/web/src/lib/List.svelte
+++ b/internal/web/src/lib/List.svelte
@@ -96,6 +96,9 @@
         <span class="spacer"></span>
         {#if pr.signals}
           <span class="badges">
+            {#if pr.refreshError}
+              <span class="badge caution" title="Couldn't refresh — showing the last render"><Icon path={mdiRefresh} size={13} /></span>
+            {/if}
             {#if pr.signals.danger}
               <span class="badge danger" title="danger warnings"><Icon path={mdiAlertOctagon} size={13} /> {pr.signals.danger}</span>
             {/if}

--- a/internal/web/src/lib/Review.svelte
+++ b/internal/web/src/lib/Review.svelte
@@ -79,6 +79,12 @@
       </div>
     {/if}
 
+    {#if store.diffRefreshError}
+      <div class="refresh-strip" title={store.diffRefreshError}>
+        <Icon path={mdiRefresh} size={15} /> Couldn't refresh — showing the last successful render
+      </div>
+    {/if}
+
     {#if danger.length}
       <div class="danger-strip">
         <Icon path={mdiAlertOctagon} size={15} />

--- a/internal/web/src/lib/store.svelte.ts
+++ b/internal/web/src/lib/store.svelte.ts
@@ -13,6 +13,7 @@ interface Store {
   diff: DiffResult | null;
   diffFor: number | null; // PR number the diff/loading belongs to
   diffError: string;
+  diffRefreshError: string; // last re-render of the shown diff failed (last-good kept)
   loading: boolean;
   connected: boolean;
 }
@@ -25,6 +26,7 @@ export const store: Store = $state({
   diff: null,
   diffFor: null,
   diffError: '',
+  diffRefreshError: '',
   loading: false,
   connected: false,
 });
@@ -148,6 +150,7 @@ function applyEnvelope(env: DiffEnvelope): void {
     store.diff = env.diff;
     injectChroma(env.diff.chromaCss);
     store.diffError = '';
+    store.diffRefreshError = env.refreshError ?? '';
   } else if (env.status === 'error') {
     store.diffError = env.error ?? 'render failed';
   }

--- a/internal/web/src/lib/types.ts
+++ b/internal/web/src/lib/types.ts
@@ -36,6 +36,7 @@ export interface Signals {
 export interface PRStatus extends PR {
   status: JobStatus;
   error?: string;
+  refreshError?: string; // last re-render failed, but a prior diff is still shown
   updatedAt: string;
   closedAt?: string; // set once merged; UI groups these below open PRs
   signals?: Signals;
@@ -148,6 +149,7 @@ export interface DiffEnvelope {
   pr: PR;
   diff?: DiffResult;
   error?: string;
+  refreshError?: string; // last re-render failed; diff is the last-good render
 }
 
 export interface WSEvent {

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -78,6 +78,28 @@ test('landing health summary + non-default base branch tag', async ({ page }) =>
   await expect(page.locator('.card', { hasText: '#142' }).locator('.base-tag')).toHaveCount(0);
 });
 
+test('a failed refresh keeps the diff and flags it (list badge + review strip)', async ({ page }) => {
+  await page.route('**/api/meta', (r) => r.fulfill({ json: defaultMeta }));
+  await page.route('**/api/prs', (r) =>
+    r.fulfill({ json: [{ ...samplePRs[0], refreshError: 'forge unreachable' }] }),
+  );
+  await page.route('**/api/prs/142/diff', (r) =>
+    r.fulfill({ json: { ...diffEnvelope, refreshError: 'forge unreachable' } }),
+  );
+  await page.routeWebSocket('**/ws', () => {});
+  await page.goto('/');
+
+  // The card flags the failed refresh but still shows the last-good signal badges.
+  const card = page.locator('.card', { hasText: '#142' });
+  await expect(card.locator('.badge[title*="refresh"]')).toBeVisible();
+  await expect(card.locator('.badge.danger').first()).toBeVisible();
+
+  // The review shows a banner and still renders the kept diff.
+  await card.click();
+  await expect(page.locator('.refresh-strip')).toContainText("Couldn't refresh");
+  await expect(page.locator('.ov-res')).toHaveCount(3);
+});
+
 test('recently-merged PRs are grouped, collapsed, and marked frozen', async ({ page }) => {
   await stubApi(page);
   await page.goto('/');


### PR DESCRIPTION
## What

When a re-render failed, konflate called `setError`, which **cleared the PR's rendered diff** and flipped it to "failed". The periodic staleness loop (`refreshStale`) runs every cycle regardless of forge reachability, so during a transient forge/git outage open PRs would progressively lose their good diffs and the UI degraded to a wall of "failed render" — recovering only when the forge came back.

## Fix

`failRender` now **keeps a previously rendered diff** and records the failure in `refreshErr` (surfaced via `PRStatus.RefreshError` / `DiffEnvelope.RefreshError`) instead of discarding it. Only a PR that has *never* rendered flips to the error state. A subsequent success clears the flag.

The UI surfaces it without hiding the diff:
- **List**: a caution badge on the card (tooltip "Couldn't refresh — showing the last render"), while the last-good signal badges still show.
- **Review**: a `Couldn't refresh — showing the last successful render` banner above the diff.

So a stale-but-shown diff is never silently passed off as current, and a forge blip no longer wipes the board. This also covers any one-off transient render failure (e.g. a flaky OCI pull), not just full outages.

## Test plan
- Store test: a never-rendered PR errors; a good render then a failure keeps the diff + sets `RefreshError`; a later success clears it.
- The frozen-shelf test now exercises `failRender` (a shelved PR rejects the late write).
- UI test: a `refreshError` PR shows the caution badge + keeps its danger badge, and the review shows the banner with the diff still rendered.
- Full Go suite green with `-race`; golangci-lint 0; gofmt clean; svelte-check 0; Playwright 25 pass.
