### PR TITLE
feat(ui): move the PR number into the meta row for a readable title

### DIFF
--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -209,8 +209,16 @@ body {
   font-family: ui-monospace, monospace;
   font-size: 12px;
 }
-.pr-num {
+/* The PR number, shown first in the meta row (list + review) behind a
+   pull-request glyph. Kept at full text weight so it reads as the card's
+   identifier amid the muted meta. */
+.pr-id {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
   font-weight: 600;
+  color: var(--text);
+  flex: 0 0 auto;
 }
 .tag {
   display: inline-flex;
@@ -267,13 +275,6 @@ body {
 }
 .dot-merged {
   background: var(--merged);
-}
-.merged-tag {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-  color: var(--merged);
-  border-color: color-mix(in srgb, var(--merged) 40%, var(--border));
 }
 @keyframes pulse {
   50% {
@@ -1164,8 +1165,7 @@ td.side-blank {
     row-gap: 6px;
   }
   /* No hover on touch — keep the per-card copy-merge affordance visible, and
-     reserve a gutter so the top-row title/tags don't slide under it (cards are
-     narrow enough here that the title truncates and tags push to the edge). */
+     reserve a gutter so the title doesn't slide under it. */
   .card-actions {
     opacity: 1;
   }

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -1171,6 +1171,23 @@ td.side-blank {
   }
   .card-top {
     padding-right: 26px;
+    align-items: flex-start; /* dot beside the first title line, not the block centre */
+  }
+  .card-top .dot {
+    margin-top: 5px;
+  }
+  /* The title is what you scan for — on a phone let a long one wrap to two lines
+     (clamped) instead of truncating to one. min-width:0 lets the flex child
+     shrink so the clamp engages. */
+  .card-title,
+  .rt-name {
+    white-space: normal;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
+    min-width: 0;
   }
   /* The review header's meta row (sha · author · opened · refreshed · open) is
      too wide for a phone — let it wrap instead of overflowing. */

--- a/internal/web/src/lib/List.svelte
+++ b/internal/web/src/lib/List.svelte
@@ -16,10 +16,10 @@
     mdiRefresh,
     mdiTagOutline,
     mdiSourceBranch,
+    mdiSourcePull,
     mdiFilterOutline,
     mdiChevronRight,
     mdiChevronDown,
-    mdiSourceMerge,
     mdiTrayFull,
     mdiLoading,
     mdiConsoleLine,
@@ -70,18 +70,17 @@
     <button class="card" class:merged={!pr.open} onclick={() => openPR(pr.number)}>
       <div class="card-top">
         <span class="dot {pr.open ? `dot-${pr.status}` : 'dot-merged'}"></span>
-        <span class="pr-num">#{pr.number}</span>
         <span class="card-title">{pr.title}</span>
+      </div>
+      <div class="card-meta">
+        <span class="pr-id"><Icon path={mdiSourcePull} size={13} /> #{pr.number}</span>
+        <span class="card-author"><Avatar src={pr.authorAvatar} size={15} /> {pr.author || 'unknown'}</span>
         {#if pr.draft}<span class="tag">draft</span>{/if}
         {#if pr.baseRef && defaultBase && pr.baseRef !== defaultBase}
           <span class="tag base-tag" title={`Targets ${pr.baseRef}, not the default branch`}>
             <Icon path={mdiSourceBranch} size={11} /> {pr.baseRef}
           </span>
         {/if}
-        {#if !pr.open}<span class="tag merged-tag"><Icon path={mdiSourceMerge} size={11} /> merged</span>{/if}
-      </div>
-      <div class="card-meta">
-        <span class="card-author"><Avatar src={pr.authorAvatar} size={15} /> {pr.author || 'unknown'}</span>
         {#if !pr.open && pr.closedAt}
           <span class="ago" title={`Merged ${absolute(pr.closedAt)}`}><Icon path={mdiClockOutline} size={12} /> merged {timeAgo(pr.closedAt, clock.now)}</span>
         {:else}

--- a/internal/web/src/lib/Review.svelte
+++ b/internal/web/src/lib/Review.svelte
@@ -13,6 +13,7 @@
     mdiAlertOctagon,
     mdiOpenInNew,
     mdiSourceMerge,
+    mdiSourcePull,
     mdiTrayFull,
     mdiClockOutline,
     mdiRefresh,
@@ -39,16 +40,16 @@
       </button>
       <div class="review-title">
         <div class="rt-line">
-          <span class="pr-num">#{route.pr}</span>
           <span class="rt-name">{pr?.title ?? ''}</span>
         </div>
         <div class="rt-meta">
+          <span class="pr-id"><Icon path={mdiSourcePull} size={14} /> #{route.pr}</span>
           {#if pr}
+            <span class="rt-author"><Avatar src={pr.authorAvatar} size={16} /> {pr.author}</span>
             <span class="sha-wrap">
               <code class="sha">{pr.headSha.slice(0, 7)}</code>
               <Copy text={pr.headSha} label="Copy full commit SHA" />
             </span>
-            <span class="rt-author"><Avatar src={pr.authorAvatar} size={16} /> {pr.author}</span>
             {#if pr.createdAt}
               <span class="ago" title={`Opened ${absolute(pr.createdAt)}`}><Icon path={mdiClockOutline} size={13} /> opened {timeAgo(pr.createdAt, clock.now)}</span>
             {/if}

--- a/internal/web/src/lib/icons.ts
+++ b/internal/web/src/lib/icons.ts
@@ -26,6 +26,7 @@ export {
   mdiAccountOutline,
   mdiTagOutline,
   mdiSourceBranch,
+  mdiSourcePull,
   mdiFilterOutline,
   mdiTrayFull,
   mdiUnfoldMoreHorizontal,

--- a/internal/web/tests/fixtures.ts
+++ b/internal/web/tests/fixtures.ts
@@ -12,7 +12,7 @@ const k = (key: string) => `<span class="nt">${key}</span><span class="p">:</spa
 export const samplePRs: PRStatus[] = [
   {
     number: 142,
-    title: 'feat(rook-ceph): bump operator to v1.15.0',
+    title: 'feat(rook-ceph): bump the rook-ceph operator and cluster chart to v1.15.0',
     author: 'renovate[bot]',
     // Tiny inline PNG so the avatar renders in tests without a network round-trip
     // (real instances get a same-origin /api/avatar path here).

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -33,7 +33,9 @@ test('list → review → diffs flow', async ({ page }) => {
   // The PR number lives in the meta row (behind a PR glyph), so the title owns
   // its own line and carries no "#142".
   await expect(card142.locator('.pr-id')).toContainText('#142');
-  await expect(card142.locator('.card-title')).toHaveText('feat(rook-ceph): bump operator to v1.15.0');
+  await expect(card142.locator('.card-title')).toHaveText(
+    'feat(rook-ceph): bump the rook-ceph operator and cluster chart to v1.15.0',
+  );
   await expect(card142.locator('.badge.danger').first()).toBeVisible();
   await expect(card142.locator('.ago').first()).toHaveText(/ago|just now/); // humanized timestamps
   // Author avatar renders when present; a PR without one falls back to the icon.
@@ -282,6 +284,19 @@ test('mobile: diff header title is not crushed to one char per line (regression)
   // it one character per line (~28 lines tall). Fixed, it's a readable 1–2 rows.
   expect(box?.height ?? 999).toBeLessThan(120);
   expect(box?.width ?? 0).toBeGreaterThan(150);
+});
+
+test('mobile: a long PR title wraps to two lines instead of truncating', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await stubApi(page);
+  await page.goto('/');
+  const title = page.locator('.card', { hasText: '#142' }).locator('.card-title');
+  await title.waitFor();
+  // Two-line clamp is engaged on mobile (single-line truncation uses nowrap).
+  await expect(title).toHaveCSS('white-space', 'normal');
+  const box = await title.boundingBox();
+  expect(box?.height ?? 0).toBeGreaterThan(20); // taller than one line ⇒ it wrapped
+  expect(box?.height ?? 999).toBeLessThan(60); // but clamped — never a tall stack
 });
 
 test('copy buttons copy the full underlying value', async ({ page }) => {

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -30,6 +30,10 @@ test('list → review → diffs flow', async ({ page }) => {
   // Landing list: cards with per-PR signal badges.
   await expect(page.locator('.card')).toHaveCount(3);
   const card142 = page.locator('.card', { hasText: '#142' });
+  // The PR number lives in the meta row (behind a PR glyph), so the title owns
+  // its own line and carries no "#142".
+  await expect(card142.locator('.pr-id')).toContainText('#142');
+  await expect(card142.locator('.card-title')).toHaveText('feat(rook-ceph): bump operator to v1.15.0');
   await expect(card142.locator('.badge.danger').first()).toBeVisible();
   await expect(card142.locator('.ago').first()).toHaveText(/ago|just now/); // humanized timestamps
   // Author avatar renders when present; a PR without one falls back to the icon.
@@ -114,7 +118,8 @@ test('recently-merged PRs are grouped, collapsed, and marked frozen', async ({ p
   await group.click();
   const mergedCard = page.locator('.merged-cards .card.merged', { hasText: '#128' });
   await expect(mergedCard).toBeVisible();
-  await expect(mergedCard.locator('.merged-tag')).toContainText('merged');
+  // No redundant "merged" tag — the group header, dimmed card, purple dot, and
+  // "merged …" timestamp already convey it.
   await expect(mergedCard.locator('.ago')).toContainText('merged');
 
   // Opening a merged PR shows the frozen-diff banner.


### PR DESCRIPTION
## Problem

On a phone the PR **title** — the thing you actually scan for — was the first
thing to get squeezed. On the list, the `#number` + status dot + `draft`/base
tags all shared the title's line and pushed it into an early ellipsis; in the
review header the `#number` sat inline before the title too.

## Change

Move the PR number **into the meta row**, behind a pull-request glyph
(`mdiSourcePull`), in a consistent order across both views:

> **number → author → commit SHA**

…with the commit SHA shown only in the **review** (the list stops after the
author). The title now gets its own line in both places.

Two cleanups that fall out of this (chosen deliberately):

- **`draft` / non-default-base tags** move off the title line into the meta, so
  a draft PR's tags don't re-crowd the title.
- **The `merged` tag is gone** — merged cards already sit under the *Recently
  merged* header, dimmed, with a purple dot and a "merged 2d ago" timestamp, so
  the tag was pure repetition.

Universal (not mobile-only): one layout, and the title-on-its-own-line reads
cleanly on desktop too. Dead CSS (`.pr-num`, `.merged-tag`) and the now-unused
`mdiSourceMerge` import in the list were removed.

## Before / after (mobile)

```
list — before                         list — after
●  #142  feat(rook-ceph): bump op…    ●  feat(rook-ceph): bump operator to v1.15.0
   renovate[bot]  opened 5d ago          ⑂ #142   renovate[bot]   opened 5d ago …

review — before                       review — after
#142  feat(rook-ceph): bump op…       feat(rook-ceph): bump operator to v1.15.0
a1b2c3d⧉  renovate[bot]  opened…      ⑂ #142   renovate[bot]   a1b2c3d⧉   opened…
```

## Testing

- `svelte-check` 0 errors; full Playwright suite green (26 passing).
- Tests updated: assert the number is in `.pr-id` and the title text is clean;
  the merged-card check now relies on the dimmed card + "merged …" timestamp
  instead of the removed tag.
- Eyeballed desktop + mobile screenshots for both list and review — every title
  now fits its own line.

Independent of #20 (asset caching) — no file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
