### PR TITLE
chore: apply modern-practices review cleanup

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   versions:
     name: Versions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     outputs:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -16,7 +16,7 @@ permissions: {}
 jobs:
   renovate:
     name: Renovate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate Token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   stale:
     name: Stale
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
       contents: write

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -73,7 +73,7 @@ jobs:
 
   ui-e2e:
     name: UI E2E (headless Chromium)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,8 @@ linters:
   settings:
     goconst:
       ignore-tests: true
+    lll:
+      line-length: 140
     revive:
       rules:
         - name: comment-spacings
@@ -34,9 +36,11 @@ linters:
         linters:
           - goconst
           - dupl
+          - lll
+      # dupl is noisy on the structurally-parallel provider/handler code; lll now
+      # runs on internal/ (see settings.lll) to keep production lines in check.
       - linters:
           - dupl
-          - lll
         path: internal/*
     paths:
       - third_party$

--- a/internal/diff/render.go
+++ b/internal/diff/render.go
@@ -230,11 +230,17 @@ func sideRows(ah, bh []string, groups [][]difflib.OpCode) []api.SideRow {
 				}
 			case 'd':
 				for k := range op.I2 - op.I1 {
-					rows = append(rows, api.SideRow{Left: api.SideCell{Kind: kindDel, No: op.I1 + k + 1, HTML: ah[op.I1+k]}, Right: api.SideCell{Kind: kindBlank}})
+					rows = append(rows, api.SideRow{
+						Left:  api.SideCell{Kind: kindDel, No: op.I1 + k + 1, HTML: ah[op.I1+k]},
+						Right: api.SideCell{Kind: kindBlank},
+					})
 				}
 			case 'i':
 				for k := range op.J2 - op.J1 {
-					rows = append(rows, api.SideRow{Left: api.SideCell{Kind: kindBlank}, Right: api.SideCell{Kind: kindAdd, No: op.J1 + k + 1, HTML: bh[op.J1+k]}})
+					rows = append(rows, api.SideRow{
+						Left:  api.SideCell{Kind: kindBlank},
+						Right: api.SideCell{Kind: kindAdd, No: op.J1 + k + 1, HTML: bh[op.J1+k]},
+					})
 				}
 			case 'r':
 				dn, an := op.I2-op.I1, op.J2-op.J1

--- a/internal/gitclone/gitclone.go
+++ b/internal/gitclone/gitclone.go
@@ -75,7 +75,7 @@ func Clone(ctx context.Context, cloneURL, token, headRef, baseRef string) (_ *Re
 		Auth:     auth,
 		RefSpecs: []gitconfig.RefSpec{headSpec},
 		Tags:     git.NoTags,
-	}); err != nil && err != git.NoErrAlreadyUpToDate {
+	}); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
 		if errors.Is(err, git.NoMatchingRefSpecError{}) {
 			// The branch was deleted (merged/closed PR) — the remote no longer
 			// advertises the ref. Report it as gone so the caller reconciles the

--- a/internal/provider/forgejo.go
+++ b/internal/provider/forgejo.go
@@ -38,6 +38,10 @@ func newForgejo(cfg *config.Config) (*forgejoProvider, error) {
 }
 
 func (p *forgejoProvider) ListPRs(ctx context.Context) ([]api.PR, error) {
+	// The Forgejo SDK's list/get calls take no context.Context, so cancellation
+	// can't be threaded through; ctx is accepted only to satisfy the Provider
+	// interface and is intentionally unused.
+	_ = ctx
 	prs, _, err := p.client.ListRepoPullRequests(p.owner, p.repo, forgejo.ListPullRequestsOptions{
 		State:       forgejo.StateOpen,
 		Sort:        "recentupdate",
@@ -46,7 +50,6 @@ func (p *forgejoProvider) ListPRs(ctx context.Context) ([]api.PR, error) {
 	if err != nil {
 		return nil, fmt.Errorf("forgejo: list PRs: %w", err)
 	}
-	_ = ctx
 	out := make([]api.PR, 0, len(prs))
 	for _, pr := range prs {
 		out = append(out, forgejoToPR(pr))
@@ -55,11 +58,11 @@ func (p *forgejoProvider) ListPRs(ctx context.Context) ([]api.PR, error) {
 }
 
 func (p *forgejoProvider) GetPR(ctx context.Context, number int) (api.PR, error) {
+	_ = ctx // see ListPRs: the Forgejo SDK can't take a context.
 	pr, _, err := p.client.GetPullRequest(p.owner, p.repo, int64(number))
 	if err != nil {
 		return api.PR{}, fmt.Errorf("forgejo: get PR #%d: %w", number, err)
 	}
-	_ = ctx
 	return forgejoToPR(pr), nil
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -35,9 +35,7 @@ func handleHealth(w http.ResponseWriter, _ *http.Request) {
 // handleDisabled is mounted on an inbound endpoint whose secret is not
 // configured, so it is turned off.
 func handleDisabled(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, http.StatusNotImplemented, map[string]string{
-		keyError: "endpoint disabled: konflate is running without the required secret",
-	})
+	writeError(w, http.StatusNotImplemented, "endpoint disabled: konflate is running without the required secret")
 }
 
 // handleMeta serves the instance's non-secret identity (forge + repo + refresh
@@ -81,12 +79,12 @@ func (s *Server) handleListPRs(w http.ResponseWriter, _ *http.Request) {
 func (s *Server) handleDiff(w http.ResponseWriter, r *http.Request) {
 	number, err := strconv.Atoi(r.PathValue("number"))
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{keyError: "invalid PR number"})
+		writeError(w, http.StatusBadRequest, "invalid PR number")
 		return
 	}
 	env, ok := s.store.get(number)
 	if !ok {
-		writeJSON(w, http.StatusNotFound, map[string]string{keyError: "unknown PR"})
+		writeError(w, http.StatusNotFound, "unknown PR")
 		return
 	}
 	env.PR.AuthorAvatar = s.avatarProxyPath(env.PR.AuthorAvatar)
@@ -128,27 +126,27 @@ func (s *Server) handleAvatar(w http.ResponseWriter, r *http.Request) {
 	mac.Write([]byte(raw))
 	got, err := hex.DecodeString(r.URL.Query().Get("s"))
 	if err != nil || !hmac.Equal(got, mac.Sum(nil)) {
-		writeJSON(w, http.StatusForbidden, map[string]string{keyError: "invalid avatar signature"})
+		writeError(w, http.StatusForbidden, "invalid avatar signature")
 		return
 	}
 	if u, err := url.Parse(raw); err != nil || u.Scheme != "https" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{keyError: "avatar must be an https URL"})
+		writeError(w, http.StatusBadRequest, "avatar must be an https URL")
 		return
 	}
 	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, raw, nil)
 	if err != nil {
-		writeJSON(w, http.StatusBadGateway, map[string]string{keyError: "avatar fetch failed"})
+		writeError(w, http.StatusBadGateway, "avatar fetch failed")
 		return
 	}
 	resp, err := avatarClient.Do(req)
 	if err != nil {
-		writeJSON(w, http.StatusBadGateway, map[string]string{keyError: "avatar fetch failed"})
+		writeError(w, http.StatusBadGateway, "avatar fetch failed")
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
 	ct := resp.Header.Get("Content-Type")
 	if resp.StatusCode != http.StatusOK || !strings.HasPrefix(ct, "image/") {
-		writeJSON(w, http.StatusBadGateway, map[string]string{keyError: "avatar unavailable"})
+		writeError(w, http.StatusBadGateway, "avatar unavailable")
 		return
 	}
 	w.Header().Set("Content-Type", ct)
@@ -161,17 +159,17 @@ func (s *Server) handleAvatar(w http.ResponseWriter, r *http.Request) {
 // enabled (authenticated mode + push token set).
 func (s *Server) handlePush(w http.ResponseWriter, r *http.Request) {
 	if !s.authorizedPush(r) {
-		writeJSON(w, http.StatusUnauthorized, map[string]string{keyError: "unauthorized"})
+		writeError(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
 	number, err := strconv.Atoi(r.PathValue("number"))
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{keyError: "invalid PR number"})
+		writeError(w, http.StatusBadRequest, "invalid PR number")
 		return
 	}
 	if err := s.refreshPR(r.Context(), number, "push"); err != nil {
 		s.log.Warn("push: fetch PR failed", "pr", number, "error", err)
-		writeJSON(w, http.StatusBadGateway, map[string]string{keyError: "could not fetch PR from forge"})
+		writeError(w, http.StatusBadGateway, "could not fetch PR from forge")
 		return
 	}
 	writeJSON(w, http.StatusAccepted, map[string]string{keyStatus: "accepted"})
@@ -203,12 +201,12 @@ func (s *Server) refreshPR(ctx context.Context, number int, reason string) error
 func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxWebhookBody))
 	if err != nil {
-		writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{keyError: "payload too large"})
+		writeError(w, http.StatusRequestEntityTooLarge, "payload too large")
 		return
 	}
 	if err := webhook.Verify(s.cfg.Forge.Kind, s.cfg.WebhookSecret, r.Header, body); err != nil {
 		s.log.Warn("webhook verification failed", "error", err)
-		writeJSON(w, http.StatusUnauthorized, map[string]string{keyError: "signature verification failed"})
+		writeError(w, http.StatusUnauthorized, "signature verification failed")
 		return
 	}
 
@@ -244,9 +242,9 @@ func (s *Server) refreshList(ctx context.Context) {
 		return
 	}
 	s.metrics.prsKnown.Set(float64(len(prs)))
-	open := make(map[int]bool, len(prs))
+	open := make(map[int]struct{}, len(prs))
 	for _, pr := range prs {
-		open[pr.Number] = true
+		open[pr.Number] = struct{}{}
 		prev, known := s.store.get(pr.Number)
 		s.store.upsertPR(pr)
 		if !known || prev.PR.HeadSHA != pr.HeadSHA {
@@ -269,9 +267,9 @@ func (s *Server) refreshList(ctx context.Context) {
 // trimmed to the retention bounds (KONFLATE_CLOSED_PR_MAX / _TTL). Every removal
 // is broadcast so connected clients drop the PR live without a reload. open is
 // the set of currently-open PR numbers from the just-completed list.
-func (s *Server) reconcileClosed(ctx context.Context, open map[int]bool) {
+func (s *Server) reconcileClosed(ctx context.Context, open map[int]struct{}) {
 	for _, number := range s.store.activeNumbers() {
-		if open[number] {
+		if _, ok := open[number]; ok {
 			continue
 		}
 		pr, err := s.prov.GetPR(ctx, number)
@@ -321,4 +319,9 @@ func writeJSON(w http.ResponseWriter, code int, v any) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(code)
 	_ = json.NewEncoder(w).Encode(v)
+}
+
+// writeError writes a JSON error body ({"error": msg}) with the given status.
+func writeError(w http.ResponseWriter, code int, msg string) {
+	writeJSON(w, code, map[string]string{keyError: msg})
 }

--- a/internal/server/queue.go
+++ b/internal/server/queue.go
@@ -43,11 +43,14 @@ type queue struct {
 	wg  sync.WaitGroup
 
 	mu       sync.Mutex
-	inflight map[int]bool
+	inflight map[int]struct{}
 	pending  map[int]api.PR
 }
 
-func newQueue(ctx context.Context, diff diffFunc, st *store, notify func(api.Event), reconcile func(int), m *metrics, log *slog.Logger, concurrency int) *queue {
+func newQueue(
+	ctx context.Context, diff diffFunc, st *store, notify func(api.Event),
+	reconcile func(int), m *metrics, log *slog.Logger, concurrency int,
+) *queue {
 	if concurrency < 1 {
 		concurrency = 1
 	}
@@ -55,7 +58,7 @@ func newQueue(ctx context.Context, diff diffFunc, st *store, notify func(api.Eve
 		diff: diff, store: st, notify: notify, reconcile: reconcile, metrics: m, log: log,
 		ctx:      ctx,
 		sem:      make(chan struct{}, concurrency),
-		inflight: map[int]bool{},
+		inflight: map[int]struct{}{},
 		pending:  map[int]api.PR{},
 	}
 }
@@ -64,12 +67,12 @@ func newQueue(ctx context.Context, diff diffFunc, st *store, notify func(api.Eve
 // same PR number.
 func (q *queue) enqueue(pr api.PR) {
 	q.mu.Lock()
-	if q.inflight[pr.Number] {
+	if _, ok := q.inflight[pr.Number]; ok {
 		q.pending[pr.Number] = pr // coalesce; remember the freshest metadata
 		q.mu.Unlock()
 		return
 	}
-	q.inflight[pr.Number] = true
+	q.inflight[pr.Number] = struct{}{}
 	q.setDepthLocked()
 	q.mu.Unlock()
 

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -267,7 +267,10 @@ func (s *store) list() []api.PRStatus {
 			c := j.closedAt
 			closedAt = &c
 		}
-		out = append(out, api.PRStatus{PR: j.pr, Status: j.status, Error: j.errMsg, RefreshError: j.refreshErr, UpdatedAt: j.updated, ClosedAt: closedAt, Signals: j.signals})
+		out = append(out, api.PRStatus{
+			PR: j.pr, Status: j.status, Error: j.errMsg, RefreshError: j.refreshErr,
+			UpdatedAt: j.updated, ClosedAt: closedAt, Signals: j.signals,
+		})
 	}
 	slices.SortFunc(out, func(a, b api.PRStatus) int { return cmp.Compare(b.Number, a.Number) }) // newest first
 	return out

--- a/internal/web/src/lib/store.svelte.ts
+++ b/internal/web/src/lib/store.svelte.ts
@@ -213,9 +213,10 @@ function onEvent(ev: WSEvent): void {
     store.prs = store.prs.filter((p) => p.number !== ev.number);
     return;
   }
+  // ev is narrowed to the 'status' variant here — status is guaranteed present.
   const pr = store.prs.find((p) => p.number === ev.number);
   if (pr) {
-    pr.status = ev.status!;
+    pr.status = ev.status;
     pr.error = ev.error;
   }
   // The list endpoint carries the signal summary; re-pull it so badges update.

--- a/internal/web/src/lib/types.ts
+++ b/internal/web/src/lib/types.ts
@@ -154,12 +154,12 @@ export interface DiffEnvelope {
   mergeCommand?: string; // "copy to merge" CLI command; set only for open PRs when enabled
 }
 
-export interface WSEvent {
-  type: 'status' | 'removed';
-  number: number;
-  status?: JobStatus;
-  error?: string;
-}
+// Discriminated on `type`: a "status" event always carries a status (and maybe
+// an error); a "removed" event is just the PR number. This lets the handler
+// narrow on `ev.type` instead of asserting `status` is present.
+export type WSEvent =
+  | { type: 'status'; number: number; status: JobStatus; error?: string }
+  | { type: 'removed'; number: number };
 
 export interface Meta {
   forge: string;

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -19,14 +20,10 @@ import (
 
 // Verification outcomes. Callers map any non-nil error to HTTP 401.
 var (
-	ErrNoSecret          = errorString("webhook: no secret configured")
-	ErrMissingSignature  = errorString("webhook: missing signature header")
-	ErrSignatureMismatch = errorString("webhook: signature mismatch")
+	ErrNoSecret          = errors.New("webhook: no secret configured")
+	ErrMissingSignature  = errors.New("webhook: missing signature header")
+	ErrSignatureMismatch = errors.New("webhook: signature mismatch")
 )
-
-type errorString string
-
-func (e errorString) Error() string { return string(e) }
 
 // Verify reports whether an inbound webhook request is authentic for forge,
 // given the configured secret, the request headers, and the raw body. It


### PR DESCRIPTION
Small idiom / correctness / hygiene fixes from a modern-practices review of the codebase. **No behavior change** — existing tests pass unchanged.

## Go
- **`gitclone`** — `err != git.NoErrAlreadyUpToDate` → `!errors.Is(...)` (wrap-safe; matches the adjacent `errors.Is`).
- **`webhook`** — replace the hand-rolled `errorString` type with plain `errors.New` sentinels.
- **`server`** — model the in-flight / open-PR sets as `map[int]struct{}` (intent-revealing sets), and add a small `writeError` helper for the ~13 repeated JSON error responses.
- **`forgejo`** — document *why* `ctx` can't be threaded (the Forgejo SDK accepts none) instead of a bare `_ = ctx` that read as an oversight.

## Tooling
- **golangci** — the `dupl`/`lll` exclusion was unanchored, so `lll` was disabled across all of `internal/` (i.e. effectively off). Scoped it: `dupl` stays excluded on `internal/` (the providers are structurally parallel), `lll` now runs at a 140 limit (off on tests), and the few long signatures / composite literals it flagged are wrapped (which matches the existing `SideRow` style).
- **CI** — pin the floating `ubuntu-latest` runners to `ubuntu-24.04`, matching the arm-pinned build/test/lint jobs.

## UI
- **`WSEvent`** is now a discriminated union on `type`, so the `'status'` branch guarantees `status` is present and the lone `ev.status!` assertion is gone.

## Not done
- **`golang.org/x/sync`** was flagged as lagging at v0.20.0, but `go list -m -versions` confirms **v0.20.0 is the latest** — it just releases far less often than `x/text`/`x/net`. No change.
- **Prettier for Svelte/TS** — skipped per your call.

## Testing
`go build`/`vet`/`test -race`/`gofmt` clean; **golangci-lint 0 issues** (confirms `lll` now runs and passes); zizmor clean on the workflow edits. `svelte-check` clean; Playwright **29 pass / 1 skip**.

The broader review verdict, for the record: the codebase was already modern and idiomatic — these are polish items, not corrections of anything outdated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
