### PR TITLE
fix(ui): match the auto-refresh pill to the icon buttons on mobile

### DIFF
--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -1209,8 +1209,10 @@ td.side-blank {
     display: none;
   }
   /* Thumb-friendly hit areas for the icon buttons (back, prev/next, theme, the
-     resource nav, etc.). */
-  .btn-icon {
+     resource nav, etc.) — and the same 40px box for the auto-refresh pill so it
+     matches the GitHub/theme buttons once collapsed to just its clock icon. */
+  .btn-icon,
+  .auto {
     min-width: 40px;
     min-height: 40px;
     justify-content: center;

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -335,9 +335,13 @@ test('mobile: topbar keeps the repo name and icon buttons are tappable', async (
   await expect(page.locator('.brand .wordmark')).toBeHidden();
   await expect(page.locator('.auto .auto-text')).toBeHidden();
   await expect(page.locator('.auto svg')).toBeVisible(); // the clock icon stays
-  // Icon buttons are ≥40px tall for thumbs.
-  const box = await page.locator('.actions .btn-icon').last().boundingBox();
-  expect(box?.height ?? 0).toBeGreaterThanOrEqual(40);
+  // Icon buttons are ≥40px tall for thumbs, and the auto-refresh pill matches
+  // them (same box size) once it collapses to just the clock icon.
+  const btn = await page.locator('.actions .btn-icon').last().boundingBox();
+  const auto = await page.locator('.actions .auto').boundingBox();
+  expect(btn?.height ?? 0).toBeGreaterThanOrEqual(40);
+  expect(Math.abs((auto?.height ?? 0) - (btn?.height ?? 0))).toBeLessThanOrEqual(1);
+  expect(Math.abs((auto?.width ?? 0) - (btn?.width ?? 0))).toBeLessThanOrEqual(1);
 });
 
 test('copy buttons copy the full underlying value', async ({ page }) => {


### PR DESCRIPTION
## Problem
On a phone the topbar collapses the auto-refresh indicator from `🕐 auto · 30m` down to just its clock icon (the `auto-text` is hidden). But `.auto` is a `<span>` pill with its own `padding: 5px 10px`, whereas the GitHub and theme controls are `.btn-icon` buttons that get a `40px` min box on mobile. So the clock pill rendered ~25px while the other two were 40px — the three header icons didn't match.

## Fix
Give `.auto` the same `40px` box as `.btn-icon` in the mobile media query, so the clock, GitHub, and theme icons are all the same size.

```css
.btn-icon,
.auto {
  min-width: 40px;
  min-height: 40px;
  justify-content: center;
}
```

(`box-sizing: border-box` is global, so all three render at exactly a 40px box despite the differing paddings.)

## Testing
Extended the existing mobile-topbar test to assert the `.auto` pill's box matches the icon buttons'. Full Playwright suite green (29 passing); regenerated `mobile-list.png` confirms the three header icons are now equal-sized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
