### PR TITLE
feat(ui): merge Overview/Diffs tabs into a single-page review

### DIFF
--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -210,14 +210,12 @@ body {
   font-size: 12px;
 }
 /* The PR number, shown first in the meta row (list + review) behind a
-   pull-request glyph. Kept at full text weight so it reads as the card's
-   identifier amid the muted meta. */
+   pull-request glyph. Styled like its siblings (author, sha, opened, refreshed)
+   — muted and normal weight — so the whole meta row reads uniformly. */
 .pr-id {
   display: inline-flex;
   align-items: center;
   gap: 3px;
-  font-weight: 600;
-  color: var(--text);
   flex: 0 0 auto;
 }
 .tag {

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -675,46 +675,14 @@ body {
   border-radius: 6px;
   padding: 3px 9px;
 }
-.tabs {
-  display: flex;
-  gap: 4px;
-  padding: 0 14px;
-  border-bottom: 1px solid var(--border);
-  background: var(--panel);
-}
-.tabs button {
-  border: none;
-  background: transparent;
-  color: var(--muted);
-  padding: 10px 12px;
-  font-size: 13px;
-  font-weight: 600;
-  cursor: pointer;
-  border-bottom: 2px solid transparent;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-.tabs button.active {
-  color: var(--text);
-  border-bottom-color: var(--accent);
-}
-.tabs .count {
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--muted);
-  background: var(--panel-alt);
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  padding: 0 6px;
-}
 .review-body {
   flex: 1 1 auto;
   min-height: 0;
+  /* The single-page review (.diffs) is height:100% and scrolls internally — the
+     rail and diff pane each own their scroll — so it never overflows here. auto
+     (not hidden) lets the transient loading/error/empty states scroll instead of
+     clipping a long render error. */
   overflow: auto;
-}
-.review-body.full {
-  overflow: hidden;
 }
 
 /* ---- overview -------------------------------------------------------- */
@@ -873,59 +841,6 @@ body {
   font-size: 11px;
   white-space: pre-wrap;
 }
-.ov-parent {
-  font-weight: 600;
-  font-size: 12px;
-  margin: 10px 0 2px;
-}
-.ov-res {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  text-align: left;
-  font: inherit;
-  color: inherit;
-  background: transparent;
-  border: none;
-  border-radius: 6px;
-  padding: 4px 8px;
-  cursor: pointer;
-}
-.ov-res:hover {
-  background: var(--panel-alt);
-}
-/* Status marker: changed (accent) by default, green added, red removed. */
-.ov-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  flex: 0 0 auto;
-  background: var(--accent);
-}
-.ov-dot.status-added {
-  background: var(--ok);
-}
-.ov-dot.status-removed {
-  background: var(--danger);
-}
-.ov-kind {
-  font-size: 11px;
-  text-transform: uppercase;
-  color: var(--muted);
-  flex: 0 0 auto;
-}
-.ov-name {
-  font-family: ui-monospace, monospace;
-  word-break: break-all;
-}
-.ov-name.status-added {
-  color: var(--ok);
-}
-.ov-name.status-removed {
-  color: var(--danger);
-}
-
 /* ---- diffs (rail + diff) --------------------------------------------- */
 .diffs {
   height: 100%;
@@ -939,15 +854,85 @@ body {
   background: var(--panel);
   min-height: 0;
 }
+.diff-main {
+  /* Column wrapper so the mobile switcher bar can sit above the scrolling pane. */
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--panel);
+}
 .diff-pane {
+  flex: 1 1 auto;
   overflow: auto;
   min-height: 0;
+}
+/* Mobile-only resource switcher. The tree rail is the navigator on wide screens;
+   where it's hidden (the ≤900px media query) this bar takes over, cycling
+   Summary + every resource — the touch counterpart to the j/k keys. */
+.diff-switcher {
+  display: none;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
   background: var(--panel);
+}
+.switcher-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+.switcher-pos {
+  flex: 0 0 auto;
+  font-size: 12px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+.switcher-name {
+  font-family: ui-monospace, monospace;
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* ---- tree rail ------------------------------------------------------- */
 .tree {
   padding: 6px 0 24px;
+}
+/* The Summary node — first entry, set apart from the resource leaves by a rule
+   and a document icon. Selecting it shows the impact/warnings/images panel. */
+.tree-summary {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  margin-bottom: 4px;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+}
+.tree-summary:hover {
+  background: var(--panel-alt);
+}
+.tree-summary.selected {
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+}
+.summary-danger {
+  display: inline-flex;
+  color: var(--danger);
 }
 .tree-parent {
   margin-top: 6px;
@@ -1016,22 +1001,6 @@ body {
   top: 0;
   background: var(--panel);
   z-index: 1;
-}
-/* Prev/next resource nav in the diff header. Hidden by default — the tree rail
-   is the navigator on wide screens — and revealed where the rail is hidden (see
-   the media queries). The j/k actions are surfaced as buttons for touch. */
-.res-nav {
-  display: none;
-  align-items: center;
-  gap: 2px;
-  flex: 0 0 auto;
-}
-.res-pos {
-  font-size: 12px;
-  color: var(--muted);
-  font-variant-numeric: tabular-nums;
-  min-width: 2.5em;
-  text-align: center;
 }
 .res-title {
   font-family: ui-monospace, monospace;
@@ -1188,9 +1157,9 @@ td.side-blank {
   .rail {
     display: none;
   }
-  /* With the tree rail gone, the diff header carries the resource navigation. */
-  .res-nav {
-    display: inline-flex;
+  /* With the tree rail gone, the switcher bar carries the resource navigation. */
+  .diff-switcher {
+    display: flex;
   }
   .review-head {
     flex-wrap: wrap;

--- a/internal/web/src/lib/Diff.svelte
+++ b/internal/web/src/lib/Diff.svelte
@@ -1,22 +1,11 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import type { DiffResource, SideCell } from './types';
-  import { store, adjacentResource } from './store.svelte';
   import Icon from './Icon.svelte';
   import Copy from './Copy.svelte';
-  import {
-    mdiUnfoldMoreHorizontal,
-    mdiUnfoldLessHorizontal,
-    mdiChevronLeft,
-    mdiChevronRight,
-  } from './icons';
+  import { mdiUnfoldMoreHorizontal, mdiUnfoldLessHorizontal } from './icons';
 
   let { resource }: { resource: DiffResource } = $props();
-
-  // The Diffs tree rail is hidden on narrow screens, so surface prev/next
-  // resource navigation (the j/k actions) in the header there.
-  const resources = $derived(store.diff?.resources ?? []);
-  const resIndex = $derived(resources.findIndex((r) => r.id === resource.id));
 
   // Folded-context expanders. Keyed by resource id + fold id so the same gap id
   // ("g0") across different resources never collide, and each resource keeps its
@@ -56,27 +45,6 @@
 </script>
 
 <div class="res-header">
-  <div class="res-nav">
-    <button
-      class="btn btn-icon"
-      onclick={() => adjacentResource(-1)}
-      disabled={resIndex <= 0}
-      title="Previous resource (k)"
-      aria-label="Previous resource"
-    >
-      <Icon path={mdiChevronLeft} size={16} />
-    </button>
-    <span class="res-pos">{resIndex + 1}/{resources.length}</span>
-    <button
-      class="btn btn-icon"
-      onclick={() => adjacentResource(1)}
-      disabled={resIndex >= resources.length - 1}
-      title="Next resource (j)"
-      aria-label="Next resource"
-    >
-      <Icon path={mdiChevronRight} size={16} />
-    </button>
-  </div>
   <span class="res-status status-{resource.status}">{resource.status}</span>
   <span class="res-title">{resource.title}</span>
   <Copy text={resource.title} label="Copy resource identifier" />

--- a/internal/web/src/lib/Diffs.svelte
+++ b/internal/web/src/lib/Diffs.svelte
@@ -1,29 +1,63 @@
 <script lang="ts">
   import { router } from './router.svelte';
-  import { store, selectedResource, openDiffs } from './store.svelte';
+  import { store, adjacentResource, selectables } from './store.svelte';
   import Tree from './Tree.svelte';
   import Diff from './Diff.svelte';
+  import Overview from './Overview.svelte';
+  import Icon from './Icon.svelte';
+  import { mdiChevronLeft, mdiChevronRight } from './icons';
 
-  const res = $derived(selectedResource());
+  // The selection: 'summary', a resource id, or null. A bare #/pr/N (null) lands
+  // on the Summary — the first tree node — so the URL stays clean and a reviewer
+  // sees the impact/warnings before drilling into a diff.
+  const sel = $derived(router.route.name === 'review' ? (router.route.sel ?? 'summary') : 'summary');
+  const res = $derived(
+    sel === 'summary' ? null : (store.diff?.resources?.find((r) => r.id === sel) ?? null),
+  );
 
-  // Entering Diffs without a resource (from the tab or a deep link) selects the
-  // first one once the diff has loaded.
-  $effect(() => {
-    const r = router.route;
-    if (r.name === 'review' && r.tab === 'diffs' && !r.resource) {
-      const first = store.diff?.resources?.[0];
-      if (first) openDiffs(r.pr, first.id);
-    }
-  });
+  // [Summary, ...resources] — the order the switcher and j/k step through.
+  const ids = $derived(selectables());
+  const idx = $derived(Math.max(0, ids.indexOf(sel)));
+  const switchLabel = $derived(sel === 'summary' ? 'Summary' : (res?.title ?? sel));
 </script>
 
 <div class="diffs">
   <aside class="rail"><Tree /></aside>
-  <div class="diff-pane">
-    {#if res}
-      <Diff resource={res} />
-    {:else}
-      <p class="empty">Select a resource from the list.</p>
-    {/if}
+  <div class="diff-main">
+    <!-- The tree rail is hidden on narrow screens; this bar is the navigator
+         there, cycling Summary + every resource. -->
+    <div class="diff-switcher">
+      <button
+        class="btn btn-icon"
+        onclick={() => adjacentResource(-1)}
+        disabled={idx <= 0}
+        title="Previous (k)"
+        aria-label="Previous"
+      >
+        <Icon path={mdiChevronLeft} size={16} />
+      </button>
+      <span class="switcher-label">
+        <span class="switcher-pos">{idx + 1}/{ids.length}</span>
+        <span class="switcher-name">{switchLabel}</span>
+      </span>
+      <button
+        class="btn btn-icon"
+        onclick={() => adjacentResource(1)}
+        disabled={idx >= ids.length - 1}
+        title="Next (j)"
+        aria-label="Next"
+      >
+        <Icon path={mdiChevronRight} size={16} />
+      </button>
+    </div>
+    <div class="diff-pane">
+      {#if sel === 'summary'}
+        <Overview />
+      {:else if res}
+        <Diff resource={res} />
+      {:else}
+        <p class="empty">Select a resource from the list.</p>
+      {/if}
+    </div>
   </div>
 </div>

--- a/internal/web/src/lib/List.svelte
+++ b/internal/web/src/lib/List.svelte
@@ -73,7 +73,7 @@
         <span class="card-title">{pr.title}</span>
       </div>
       <div class="card-meta">
-        <span class="pr-id"><Icon path={mdiSourcePull} size={13} /> #{pr.number}</span>
+        <span class="pr-id"><Icon path={mdiSourcePull} size={12} /> #{pr.number}</span>
         <span class="card-author"><Avatar src={pr.authorAvatar} size={15} /> {pr.author || 'unknown'}</span>
         {#if pr.draft}<span class="tag">draft</span>{/if}
         {#if pr.baseRef && defaultBase && pr.baseRef !== defaultBase}

--- a/internal/web/src/lib/Overview.svelte
+++ b/internal/web/src/lib/Overview.svelte
@@ -1,15 +1,10 @@
 <script lang="ts">
-  import { router } from './router.svelte';
-  import { store, openDiffs } from './store.svelte';
+  import { store } from './store.svelte';
   import Icon from './Icon.svelte';
   import Copy from './Copy.svelte';
   import { mdiAlertOctagon, mdiAlert, mdiPackageVariantClosed, mdiAlertCircleOutline } from './icons';
 
   const d = $derived(store.diff!);
-
-  function open(id: string) {
-    if (router.route.name === 'review') openDiffs(router.route.pr, id);
-  }
 
   // Shorten an "algo:hexdigest" (e.g. sha256:<64 hex>) to "algo:<12 hex>…" so a
   // digest-pinned image doesn't blow out the layout; tags are short already and
@@ -93,23 +88,4 @@
       {/each}
     </section>
   {/if}
-
-  <section class="ov-section">
-    <h3>Changed resources</h3>
-    {#each d.tree ?? [] as parent}
-      <div class="ov-parent">{parent.label}</div>
-      {#each parent.kinds as kind}
-        {#each kind.items as item}
-          <button class="ov-res" onclick={() => open(item.id)}>
-            <span class="ov-dot status-{item.status}" aria-hidden="true"></span>
-            <span class="ov-kind">{kind.kind}</span>
-            <span class="ov-name status-{item.status}">{item.name}</span>
-            <span class="spacer"></span>
-            {#if item.add}<span class="add">+{item.add}</span>{/if}
-            {#if item.del}<span class="del">-{item.del}</span>{/if}
-          </button>
-        {/each}
-      {/each}
-    {/each}
-  </section>
 </div>

--- a/internal/web/src/lib/Review.svelte
+++ b/internal/web/src/lib/Review.svelte
@@ -39,7 +39,7 @@
           <span class="rt-name">{pr?.title ?? ''}</span>
         </div>
         <div class="rt-meta">
-          <span class="pr-id"><Icon path={mdiSourcePull} size={14} /> #{route.pr}</span>
+          <span class="pr-id"><Icon path={mdiSourcePull} size={13} /> #{route.pr}</span>
           {#if pr}
             <span class="rt-author"><Avatar src={pr.authorAvatar} size={16} /> {pr.author}</span>
             <span class="sha-wrap">

--- a/internal/web/src/lib/Review.svelte
+++ b/internal/web/src/lib/Review.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { router } from './router.svelte';
-  import { store, currentPR, goList, setTab, adjacentPR } from './store.svelte';
+  import { store, currentPR, goList, adjacentPR } from './store.svelte';
   import { clock, timeAgo, absolute } from './time.svelte';
   import Icon from './Icon.svelte';
   import Spinner from './Spinner.svelte';
@@ -18,7 +18,6 @@
     mdiRefresh,
     mdiConsoleLine,
   } from './icons';
-  import Overview from './Overview.svelte';
   import Diffs from './Diffs.svelte';
   import Copy from './Copy.svelte';
 
@@ -27,7 +26,6 @@
   const forgeUrl = $derived(pr && /^https?:\/\//i.test(pr.url) ? pr.url : null);
   const merged = $derived(pr ? !pr.open : false);
   const danger = $derived(store.diff?.warnings?.filter((w) => w.level === 'danger') ?? []);
-  const total = $derived(store.diff?.resources?.length ?? 0);
 </script>
 
 {#if route}
@@ -102,14 +100,7 @@
       </div>
     {/if}
 
-    <div class="tabs">
-      <button class:active={route.tab === 'overview'} onclick={() => setTab('overview')}>Overview</button>
-      <button class:active={route.tab === 'diffs'} onclick={() => setTab('diffs')}>
-        Diffs{#if total}<span class="count">{total}</span>{/if}
-      </button>
-    </div>
-
-    <div class="review-body" class:full={route.tab === 'diffs'}>
+    <div class="review-body">
       {#if store.loading || pr?.status === 'running'}
         <div class="loading-center"><Spinner size={46} label="Rendering" /><p>Rendering the diff…</p></div>
       {:else if pr?.status === 'pending'}
@@ -118,8 +109,6 @@
         <p class="error-box">{store.diffError}</p>
       {:else if !store.diff}
         <p class="empty">No diff available.</p>
-      {:else if route.tab === 'overview'}
-        <Overview />
       {:else}
         <Diffs />
       {/if}

--- a/internal/web/src/lib/Tree.svelte
+++ b/internal/web/src/lib/Tree.svelte
@@ -1,22 +1,32 @@
 <script lang="ts">
   import { router } from './router.svelte';
-  import { store, openDiffs } from './store.svelte';
+  import { store, openSel } from './store.svelte';
   import Icon from './Icon.svelte';
-  import { mdiAlertOctagon } from './icons';
+  import { mdiAlertOctagon, mdiFileDocumentOutline } from './icons';
 
   const d = $derived(store.diff!);
-  const sel = $derived(router.route.name === 'review' ? router.route.resource : null);
+  // A null selection (bare #/pr/N) defaults to the Summary node.
+  const sel = $derived(router.route.name === 'review' ? (router.route.sel ?? 'summary') : null);
   // Resources carrying a danger warning, keyed by their "Kind ns/name" label.
   const dangerLabels = $derived(
     new Set((d.warnings ?? []).filter((w) => w.level === 'danger').map((w) => w.resource)),
   );
+  const dangerCount = $derived((d.warnings ?? []).filter((w) => w.level === 'danger').length);
 
   function open(id: string) {
-    if (router.route.name === 'review') openDiffs(router.route.pr, id);
+    if (router.route.name === 'review') openSel(router.route.pr, id);
   }
 </script>
 
 <div class="tree">
+  <button class="tree-summary" class:selected={sel === 'summary'} onclick={() => open('summary')}>
+    <Icon path={mdiFileDocumentOutline} size={14} />
+    <span class="leaf-name">Summary</span>
+    {#if dangerCount}
+      <span class="summary-danger"><Icon path={mdiAlertOctagon} size={13} label="has danger warnings" /></span>
+    {/if}
+  </button>
+
   {#each d.tree ?? [] as parent}
     <div class="tree-parent">
       <div class="tree-parent-label">{parent.label}</div>

--- a/internal/web/src/lib/keyboard.svelte.ts
+++ b/internal/web/src/lib/keyboard.svelte.ts
@@ -1,7 +1,7 @@
 // Keyboard-first navigation. Active only outside text inputs and without
 // modifier keys, so it never fights the browser or the filter box.
 import { router } from './router.svelte';
-import { adjacentPR, adjacentResource, goList, setTab } from './store.svelte';
+import { adjacentPR, adjacentResource, goList, openSel } from './store.svelte';
 
 function isTyping(e: KeyboardEvent): boolean {
   const el = e.target as HTMLElement | null;
@@ -20,7 +20,7 @@ export function initKeyboard(): void {
         goList();
         break;
       case 'j':
-        adjacentResource(1); // also jumps into the Diffs tab
+        adjacentResource(1); // step down through Summary + resources
         break;
       case 'k':
         adjacentResource(-1);
@@ -32,7 +32,7 @@ export function initKeyboard(): void {
         adjacentPR(1);
         break;
       case 'o':
-        setTab(r.tab === 'overview' ? 'diffs' : 'overview');
+        openSel(r.pr, 'summary'); // jump to the Summary panel
         break;
       default:
         return;

--- a/internal/web/src/lib/router.svelte.ts
+++ b/internal/web/src/lib/router.svelte.ts
@@ -1,24 +1,24 @@
 // A tiny hash router so reviews are deep-linkable and survive refresh / browser
 // back. Routes:
 //   #/                       the PR list
-//   #/pr/142                 review, Overview tab
-//   #/pr/142/diffs           review, Diffs tab
-//   #/pr/142/diffs/r0        review, Diffs tab, resource r0 selected
-
-export type Tab = 'overview' | 'diffs';
+//   #/pr/142                 review, default selection (the Summary)
+//   #/pr/142/summary         review, Summary panel (explicit)
+//   #/pr/142/r0              review, resource r0's diff
+//
+// `sel` is the selected tree node: 'summary', a resource id, or null. A bare
+// #/pr/142 (null) renders the Summary — the first tree node — so the default
+// URL stays clean.
 
 export type Route =
   | { name: 'list' }
-  | { name: 'review'; pr: number; tab: Tab; resource: string | null };
+  | { name: 'review'; pr: number; sel: string | null };
 
 function parse(hash: string): Route {
   const parts = hash.replace(/^#\/?/, '').split('/').filter(Boolean);
   if (parts[0] === 'pr' && parts[1]) {
     const pr = Number(parts[1]);
     if (Number.isInteger(pr)) {
-      const tab: Tab = parts[2] === 'diffs' ? 'diffs' : 'overview';
-      const resource = tab === 'diffs' ? (parts[3] ?? null) : null;
-      return { name: 'review', pr, tab, resource };
+      return { name: 'review', pr, sel: parts[2] ?? null };
     }
   }
   return { name: 'list' };
@@ -26,12 +26,7 @@ function parse(hash: string): Route {
 
 function toHash(r: Route): string {
   if (r.name === 'list') return '#/';
-  let h = `#/pr/${r.pr}`;
-  if (r.tab === 'diffs') {
-    h += '/diffs';
-    if (r.resource) h += `/${r.resource}`;
-  }
-  return h;
+  return r.sel ? `#/pr/${r.pr}/${r.sel}` : `#/pr/${r.pr}`;
 }
 
 export const router = $state<{ route: Route }>({ route: parse(location.hash) });
@@ -39,7 +34,7 @@ export const router = $state<{ route: Route }>({ route: parse(location.hash) });
 export function navigate(to: Route): void {
   const next = toHash(to);
   if (location.hash === next) {
-    router.route = to; // same hash (e.g. resource within diffs) — sync anyway
+    router.route = to; // same hash (e.g. re-selecting the current node) — sync anyway
   } else {
     location.hash = next; // triggers hashchange → updates router.route
   }

--- a/internal/web/src/lib/store.svelte.ts
+++ b/internal/web/src/lib/store.svelte.ts
@@ -2,8 +2,8 @@
 // this store owns the data (instance meta, the PR list, the currently-loaded
 // diff) and the actions that mutate it.
 
-import type { DiffEnvelope, DiffResource, DiffResult, Meta, PRStatus, WSEvent } from './types';
-import { router, navigate, type Tab } from './router.svelte';
+import type { DiffEnvelope, DiffResult, Meta, PRStatus, WSEvent } from './types';
+import { router, navigate } from './router.svelte';
 
 interface Store {
   meta: Meta | null;
@@ -52,30 +52,26 @@ export function currentPR(): PRStatus | null {
   return store.prs.find((p) => p.number === r.pr) ?? null;
 }
 
-export function selectedResource(): DiffResource | null {
-  const r = router.route;
-  if (r.name !== 'review' || !r.resource) return null;
-  return store.diff?.resources?.find((res) => res.id === r.resource) ?? null;
-}
-
 // ---- navigation -----------------------------------------------------------
 
 export function openPR(n: number): void {
-  navigate({ name: 'review', pr: n, tab: 'overview', resource: null });
+  navigate({ name: 'review', pr: n, sel: null });
 }
 
-export function openDiffs(n: number, resource: string | null = null): void {
-  navigate({ name: 'review', pr: n, tab: 'diffs', resource });
-}
-
-export function setTab(tab: Tab): void {
-  const r = router.route;
-  if (r.name !== 'review') return;
-  navigate({ name: 'review', pr: r.pr, tab, resource: r.resource });
+// Select a tree node in a review: 'summary', a resource id, or null (a bare
+// #/pr/N, which the review renders as the Summary).
+export function openSel(n: number, sel: string | null = null): void {
+  navigate({ name: 'review', pr: n, sel });
 }
 
 export function goList(): void {
   navigate({ name: 'list' });
+}
+
+// The ordered selection cycle for j/k and the mobile switcher: Summary first,
+// then every resource.
+export function selectables(): string[] {
+  return ['summary', ...(store.diff?.resources ?? []).map((res) => res.id)];
 }
 
 export function adjacentPR(delta: number): void {
@@ -86,14 +82,16 @@ export function adjacentPR(delta: number): void {
   if (i >= 0 && j >= 0 && j < store.prs.length) openPR(store.prs[j].number);
 }
 
+// Move the selection by delta through [Summary, ...resources], clamped at the
+// ends. A null selection (the default landing) sits on Summary, so j from there
+// steps into the first resource.
 export function adjacentResource(delta: number): void {
   const r = router.route;
   if (r.name !== 'review') return;
-  const list = store.diff?.resources ?? [];
-  if (list.length === 0) return;
-  const i = r.resource ? list.findIndex((res) => res.id === r.resource) : -1;
-  const j = Math.min(Math.max(i + delta, 0), list.length - 1);
-  openDiffs(r.pr, list[j].id);
+  const ids = selectables();
+  const i = Math.max(0, ids.indexOf(r.sel ?? 'summary'));
+  const j = Math.min(Math.max(i + delta, 0), ids.length - 1);
+  openSel(r.pr, ids[j]);
 }
 
 // ---- API ------------------------------------------------------------------

--- a/internal/web/tests/review.spec.ts
+++ b/internal/web/tests/review.spec.ts
@@ -44,7 +44,7 @@ for (const vp of viewports) {
 
     test('diffs-unified', async ({ page }) => {
       await stub(page);
-      await page.goto('/#/pr/142/diffs/r0');
+      await page.goto('/#/pr/142/r0');
       // The toggle only exists where split is offered; phones are unified-only,
       // so click it when present, otherwise we're already unified.
       const unified = page.getByRole('button', { name: 'Unified' });
@@ -56,7 +56,7 @@ for (const vp of viewports) {
     test('diffs-split', async ({ page }) => {
       test.skip(vp.tag === 'mobile', 'split view is unavailable at phone width (unified only)');
       await stub(page);
-      await page.goto('/#/pr/142/diffs/r0');
+      await page.goto('/#/pr/142/r0');
       await page.getByRole('button', { name: 'Split' }).click();
       await page.locator('table.diff.split').waitFor();
       await page.screenshot({ path: `screenshots/${vp.tag}-diffs-split.png`, fullPage: true });

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -15,7 +15,7 @@ async function stubApi(page: Page, meta: Meta = defaultMeta) {
   });
 }
 
-test('list → review → diffs flow', async ({ page }) => {
+test('list → review → single-page flow', async ({ page }) => {
   await stubApi(page);
   await page.goto('/');
 
@@ -45,7 +45,8 @@ test('list → review → diffs flow', async ({ page }) => {
   await expect(card142.locator('.ago', { hasText: 'opened' })).toBeVisible();
   await expect(card142.locator('.label-dot')).toBeVisible();
 
-  // Open a PR → summary-first Overview (URL deep-links).
+  // Open a PR → the single-page review lands on the Summary (impact, warnings,
+  // image changes, render failures), with the tree rail alongside it.
   await card142.click();
   await expect(page).toHaveURL(/#\/pr\/142$/);
   await expect(page.locator('.danger-strip')).toContainText('danger');
@@ -53,17 +54,24 @@ test('list → review → diffs flow', async ({ page }) => {
   await expect(page.locator('.warning.danger')).toContainText('StatefulSet');
   await expect(page.locator('.img-list')).toContainText('ghcr.io/rook/ceph');
   await expect(page.locator('.failure')).toContainText('plex');
-  await expect(page.locator('.ov-res')).toHaveCount(3);
-  // Each changed resource carries a status dot (1 added, 1 removed, 1 changed).
-  await expect(page.locator('.ov-dot.status-added')).toHaveCount(1);
-  await expect(page.locator('.ov-dot.status-removed')).toHaveCount(1);
-
-  // Into the Diffs tab → tree rail + wide diff.
-  await page.getByRole('button', { name: /^Diffs/ }).click();
-  await expect(page).toHaveURL(/#\/pr\/142\/diffs/);
+  // The tree: a Summary node (selected by default) + one leaf per changed
+  // resource. The danger warning surfaces a marker on the Summary node.
+  await expect(page.locator('.tree .tree-summary')).toHaveClass(/selected/);
+  await expect(page.locator('.tree-summary .summary-danger')).toBeVisible();
   await expect(page.locator('.tree .tree-item')).toHaveCount(3);
+
+  // Click a resource → its diff renders in the same view (no tab switch) and the
+  // Summary node deselects.
+  await page.locator('.tree .tree-item').first().click();
+  await expect(page).toHaveURL(/#\/pr\/142\/r0$/);
+  await expect(page.locator('.tree .tree-summary')).not.toHaveClass(/selected/);
   await expect(page.locator('table.diff tr.row-add')).toBeVisible();
   await expect(page.locator('table.diff tr.row-del')).toBeVisible();
+
+  // Click the Summary node → back to the overview panel.
+  await page.locator('.tree .tree-summary').click();
+  await expect(page).toHaveURL(/#\/pr\/142\/summary$/);
+  await expect(page.locator('.impact')).toBeVisible();
 });
 
 test('landing health summary + non-default base branch tag', async ({ page }) => {
@@ -99,10 +107,10 @@ test('a failed refresh keeps the diff and flags it (list badge + review strip)',
   await expect(card.locator('.badge[title*="refresh"]')).toBeVisible();
   await expect(card.locator('.badge.danger').first()).toBeVisible();
 
-  // The review shows a banner and still renders the kept diff.
+  // The review shows a banner and still renders the kept diff (tree intact).
   await card.click();
   await expect(page.locator('.refresh-strip')).toContainText("Couldn't refresh");
-  await expect(page.locator('.ov-res')).toHaveCount(3);
+  await expect(page.locator('.tree .tree-item')).toHaveCount(3);
 });
 
 test('recently-merged PRs are grouped, collapsed, and marked frozen', async ({ page }) => {
@@ -134,7 +142,7 @@ test('recently-merged PRs are grouped, collapsed, and marked frozen', async ({ p
 
 test('split diff renders two balanced columns (regression)', async ({ page }) => {
   await stubApi(page);
-  await page.goto('/#/pr/142/diffs/r0');
+  await page.goto('/#/pr/142/r0');
   await page.getByRole('button', { name: 'Split' }).click();
   await expect(page.locator('table.diff.split')).toBeVisible();
   // Both code columns must have real width — the bug collapsed the right cell to
@@ -148,7 +156,7 @@ test('split diff renders two balanced columns (regression)', async ({ page }) =>
 
 test('unified view: word-level highlight + expandable folded context', async ({ page }) => {
   await stubApi(page);
-  await page.goto('/#/pr/142/diffs/r0');
+  await page.goto('/#/pr/142/r0');
   await page.getByRole('button', { name: 'Unified' }).click();
 
   // Word-level highlight: only the changed part of the line is wrapped in .wd.
@@ -205,20 +213,24 @@ test('review body shows a big spinner while a diff is still rendering', async ({
 
 test('deep link opens a specific resource diff', async ({ page }) => {
   await stubApi(page);
-  await page.goto('/#/pr/142/diffs/r0');
+  await page.goto('/#/pr/142/r0');
   await expect(page.locator('.res-title')).toContainText('rook-ceph-operator');
   await expect(page.locator('table.diff tr.row-add')).toBeVisible();
 });
 
-test('keyboard: j selects the next resource', async ({ page }) => {
+test('keyboard: j steps from Summary into resources, o returns to Summary', async ({ page }) => {
   await stubApi(page);
   await page.goto('/#/pr/142');
-  // Resource navigation needs the diff loaded; wait for the overview to render.
+  // Navigation needs the diff loaded; the default landing is the Summary.
   await page.locator('.impact').waitFor();
   await page.locator('body').press('j');
-  await expect(page).toHaveURL(/#\/pr\/142\/diffs\/r0/);
+  await expect(page).toHaveURL(/#\/pr\/142\/r0$/);
   await page.locator('body').press('j');
-  await expect(page).toHaveURL(/#\/pr\/142\/diffs\/r1/);
+  await expect(page).toHaveURL(/#\/pr\/142\/r1$/);
+  // o jumps straight back to the Summary panel.
+  await page.locator('body').press('o');
+  await expect(page).toHaveURL(/#\/pr\/142\/summary$/);
+  await expect(page.locator('.impact')).toBeVisible();
 });
 
 test('auto-update indicator reflects the configured interval, no refresh button', async ({ page }) => {
@@ -275,7 +287,7 @@ test('image changes shorten digest versions (full value on hover + correct copy)
 test('mobile: diff header title is not crushed to one char per line (regression)', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await stubApi(page);
-  await page.goto('/#/pr/142/diffs/r0');
+  await page.goto('/#/pr/142/r0');
   const title = page.locator('.res-title');
   await title.waitFor();
   const box = await title.boundingBox();
@@ -298,29 +310,40 @@ test('mobile: a long PR title wraps to two lines instead of truncating', async (
   expect(box?.height ?? 999).toBeLessThan(60); // but clamped — never a tall stack
 });
 
-test('mobile: the diff header carries a resource switcher (the tree rail is hidden)', async ({ page }) => {
+test('mobile: a switcher cycles Summary + resources (the tree rail is hidden)', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await stubApi(page);
-  await page.goto('/#/pr/142/diffs/r0');
-  const nav = page.locator('.res-nav');
-  await expect(nav).toBeVisible();
-  await expect(nav.locator('.res-pos')).toHaveText('1/3');
-  await expect(page.getByRole('button', { name: 'Previous resource' })).toBeDisabled();
+  await page.goto('/#/pr/142');
+  const sw = page.locator('.diff-switcher');
+  await expect(sw).toBeVisible();
+  // Lands on the Summary: item 1 of 4 (Summary + 3 resources); Previous disabled.
+  await expect(sw.locator('.switcher-pos')).toHaveText('1/4');
+  await expect(sw.locator('.switcher-name')).toHaveText('Summary');
+  await expect(sw.getByRole('button', { name: 'Previous' })).toBeDisabled();
 
-  await page.getByRole('button', { name: 'Next resource' }).click();
-  await expect(page).toHaveURL(/#\/pr\/142\/diffs\/r1/);
-  await expect(nav.locator('.res-pos')).toHaveText('2/3');
+  // Next steps into the first resource's diff.
+  await sw.getByRole('button', { name: 'Next' }).click();
+  await expect(page).toHaveURL(/#\/pr\/142\/r0$/);
+  await expect(sw.locator('.switcher-pos')).toHaveText('2/4');
+  await expect(sw.locator('.switcher-name')).toContainText('rook-ceph-operator');
 
-  await page.getByRole('button', { name: 'Next resource' }).click();
-  await expect(page).toHaveURL(/#\/pr\/142\/diffs\/r2/);
-  await expect(nav.locator('.res-pos')).toHaveText('3/3');
-  await expect(page.getByRole('button', { name: 'Next resource' })).toBeDisabled();
+  // …through to the last resource, where Next disables.
+  await sw.getByRole('button', { name: 'Next' }).click();
+  await expect(page).toHaveURL(/#\/pr\/142\/r1$/);
+  await sw.getByRole('button', { name: 'Next' }).click();
+  await expect(page).toHaveURL(/#\/pr\/142\/r2$/);
+  await expect(sw.locator('.switcher-pos')).toHaveText('4/4');
+  await expect(sw.getByRole('button', { name: 'Next' })).toBeDisabled();
+
+  // Previous walks back toward the Summary.
+  await sw.getByRole('button', { name: 'Previous' }).click();
+  await expect(page).toHaveURL(/#\/pr\/142\/r1$/);
 });
 
 test('mobile: split view is unavailable; diffs render unified', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await stubApi(page);
-  await page.goto('/#/pr/142/diffs/r0');
+  await page.goto('/#/pr/142/r0');
   await expect(page.locator('table.diff.unified')).toBeVisible();
   await expect(page.locator('table.diff.split')).toHaveCount(0);
   await expect(page.getByRole('button', { name: 'Split' })).toHaveCount(0);
@@ -366,7 +389,7 @@ test('copy buttons copy the full underlying value', async ({ page }) => {
   expect(copied).toContain('ghcr.io/rook/ceph:v1.15.0');
 
   // Resource identifier copies from the diff header.
-  await page.goto('/#/pr/142/diffs/r0');
+  await page.goto('/#/pr/142/r0');
   await page.locator('.res-header .copy-btn').click();
   const copied2 = await page.evaluate(() => (window as unknown as { __copied: string[] }).__copied);
   expect(copied2).toContain('Deployment rook-ceph/rook-ceph-operator');
@@ -420,7 +443,7 @@ test('captures list + overview screenshots (light)', async ({ page }) => {
 test('captures diffs screenshot (dark, deep-linked)', async ({ page }) => {
   await stubApi(page);
   await page.addInitScript(() => localStorage.setItem('konflate-theme', 'dark'));
-  await page.goto('/#/pr/142/diffs/r0');
+  await page.goto('/#/pr/142/r0');
   await expect(page.locator('table.diff tr.row-add')).toBeVisible();
   await expect(page.locator('html.dark')).toBeAttached();
   await page.screenshot({ path: 'screenshots/konflate-diffs-dark.png' });


### PR DESCRIPTION
## What

Replaces the **Overview / Diffs tab toggle** with a single tree+diff page.

- The tree rail's first node is a **Summary** (impact, warnings, image changes, render failures); the rest are the changed resources.
- Selecting **Summary** shows the overview panel; selecting a resource shows its diff — all in one view, no tab switching.
- The duplicate "Changed resources" list in the old Overview is **removed** — the tree already is that list.
- A bare `#/pr/N` renders the Summary (the first tree node) so the default URL stays clean.

## Why

The tabs split two halves of the same review across a context switch. Folding them into one page keeps every signal visible, lets you jump straight from a warning to the resource's diff via the tree, and matches the "the page *is* the review" mental model.

## Routing

The `tab` segment is gone:

| URL | Shows |
| --- | --- |
| `#/pr/142` | Summary (default) |
| `#/pr/142/summary` | Summary (explicit) |
| `#/pr/142/r0` | resource `r0`'s diff |

## Mobile / keyboard

- The tree rail is hidden ≤900px; a **switcher bar** takes over there, cycling `[Summary, …resources]` with prev/next + a position indicator (replaces the old in-header `res-nav`).
- `j` / `k` step through the same `[Summary, …resources]` cycle; new `o` jumps straight to the Summary. `[` / `]` (adjacent PR) and `Esc` / `u` (back to list) unchanged.

## Verification

- `mise run ui-typecheck` — 0 errors
- `mise run ui-test` — 29 passed, 1 skipped (mobile split, expected); tests reworked for the new routing, Summary node, switcher, and the dropped tab/Changed-resources markup
- `mise run ui-build` — production bundle builds clean
- Eyeballed desktop + mobile, light + dark screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)