### PR TITLE
fix(ui): manage modal focus and guard stale deep links

### DIFF
--- a/internal/web/src/App.svelte
+++ b/internal/web/src/App.svelte
@@ -56,6 +56,13 @@
   function focusOnMount(node: HTMLElement): void {
     node.focus();
   }
+
+  // The help dialog is informational (no focusable controls), so keep Tab from
+  // escaping to the page behind the backdrop — focus stays on the card. Escape
+  // (global handler) and the backdrop close it.
+  function trapTab(e: KeyboardEvent): void {
+    if (e.key === 'Tab') e.preventDefault();
+  }
 </script>
 
 <div class="app">
@@ -121,7 +128,7 @@
     <!-- The backdrop is a real button so closing is keyboard-reachable. -->
     <div class="help-overlay">
       <button class="help-backdrop" aria-label="Close keyboard shortcuts" onclick={toggleHelp}></button>
-      <div class="help-card" role="dialog" aria-label="Keyboard shortcuts" tabindex="-1" use:focusOnMount>
+      <div class="help-card" role="dialog" aria-label="Keyboard shortcuts" tabindex="-1" use:focusOnMount onkeydown={trapTab}>
         <h2>Keyboard shortcuts</h2>
         <dl class="help-keys">
           <dt><kbd>j</kbd> / <kbd>k</kbd></dt>

--- a/internal/web/src/lib/Diffs.svelte
+++ b/internal/web/src/lib/Diffs.svelte
@@ -30,19 +30,25 @@
 
   $effect(() => {
     const target = sel;
+    const present = resources; // re-run when the rendered resource set changes
     if (!pane || target === spySel) return;
     // CSS.escape: `sel` comes from the URL hash, and an unescaped quote/bracket
     // would make querySelector throw inside the effect.
     const section = pane.querySelector(`[data-sel="${CSS.escape(target)}"]`);
-    if (!section) {
-      // Stale deep link — the resource is gone from the re-rendered diff. Land
-      // on the Summary and fix the URL so it doesn't claim a missing resource.
-      spySel = 'summary';
-      if (router.route.name === 'review') replace({ name: 'review', pr: router.route.pr, sel: null });
+    if (section) {
+      section.scrollIntoView({ block: 'start' });
+      spySel = target; // the scroll event re-derives it if the section can't reach the top
       return;
     }
-    section.scrollIntoView({ block: 'start' });
-    spySel = target; // the scroll event re-derives it if the section can't reach the top
+    // No section for the target. Only a genuinely-missing resource — the diff
+    // finished loading and doesn't contain it (a stale deep link) — bounces to
+    // the Summary; if the sections just haven't rendered yet (a future change
+    // that mounts during loading), wait for the next run rather than redirect.
+    const stale = target !== 'summary' && !store.loading && !present.some((r) => r.id === target);
+    if (stale && router.route.name === 'review') {
+      spySel = 'summary';
+      replace({ name: 'review', pr: router.route.pr, sel: null });
+    }
   });
 
   // Scrollspy: the current section is the last one whose top has crossed the

--- a/internal/web/src/lib/keyboard.svelte.ts
+++ b/internal/web/src/lib/keyboard.svelte.ts
@@ -3,18 +3,40 @@
 import { router } from './router.svelte';
 import { adjacentPR, adjacentResource, goList, openSel } from './store.svelte';
 
-// The shortcuts help overlay — toggled by '?' (and the topbar button), closed
-// by Escape or a backdrop click.
+// Two overlays: the shortcuts help (toggled by '?' or the topbar button) and the
+// command palette (Cmd/Ctrl+K). They are mutually exclusive, and opening either
+// remembers the focused element so closing restores it (WCAG 2.4.3 focus order).
 export const help = $state({ open: false });
-export function toggleHelp(): void {
-  help.open = !help.open;
+export const palette = $state({ open: false });
+
+let restoreFocus: HTMLElement | null = null;
+
+// open shows one overlay, closing the other first and recording the element to
+// restore focus to on close.
+function open(show: () => void): void {
+  const active = document.activeElement;
+  restoreFocus = active instanceof HTMLElement ? active : null;
+  help.open = false;
+  palette.open = false;
+  show();
 }
 
-// The command palette — Cmd/Ctrl+K from anywhere (even inside an input).
-// It owns its other keys (arrows, Enter, Escape) locally.
-export const palette = $state({ open: false });
+// closeOverlays shuts both overlays and returns focus to whatever opened them.
+function closeOverlays(): void {
+  help.open = false;
+  palette.open = false;
+  restoreFocus?.focus();
+  restoreFocus = null;
+}
+
+export function toggleHelp(): void {
+  if (help.open) closeOverlays();
+  else open(() => (help.open = true));
+}
+
 export function togglePalette(): void {
-  palette.open = !palette.open;
+  if (palette.open) closeOverlays();
+  else open(() => (palette.open = true));
 }
 
 function isTyping(e: KeyboardEvent): boolean {
@@ -42,7 +64,7 @@ export function initKeyboard(): void {
       return;
     }
     if (help.open && e.key === 'Escape') {
-      help.open = false;
+      closeOverlays();
       e.preventDefault();
       return;
     }

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -673,6 +673,51 @@ test('keyboard help: ? toggles the overlay, Esc closes it, / focuses the filter'
   await expect(page.getByPlaceholder('Filter pull requests…')).toBeFocused();
 });
 
+test('deep link to a missing resource lands on the Summary', async ({ page }) => {
+  await stubApi(page);
+  // The diff has r0/r1/r2; rZZZ is gone → the URL is corrected to the PR root
+  // and the Summary is shown rather than an empty, broken selection.
+  await page.goto('/#/pr/142/rZZZ');
+  await expect(page).toHaveURL(/#\/pr\/142$/);
+  await expect(page.locator('[data-sel="summary"] .impact')).toBeVisible();
+});
+
+test('palette returns focus to its trigger on close', async ({ page }) => {
+  await stubApi(page);
+  await page.goto('/');
+  const search = page.getByRole('button', { name: 'Search pull requests' });
+  await search.click();
+  const dialog = page.getByRole('dialog', { name: 'Search pull requests' });
+  await expect(dialog.getByRole('textbox')).toBeFocused();
+  await page.keyboard.press('Escape');
+  await expect(dialog).toHaveCount(0);
+  await expect(search).toBeFocused(); // focus returns, not dropped to <body>
+});
+
+test('help dialog: focus return, Tab trap, and Ctrl+K swaps to the palette', async ({ page }) => {
+  await stubApi(page);
+  await page.goto('/');
+  const helpBtn = page.getByRole('button', { name: 'Keyboard shortcuts' });
+  const help = page.getByRole('dialog', { name: 'Keyboard shortcuts' });
+
+  // Open from the button → Esc → focus returns to the button.
+  await helpBtn.click();
+  await expect(help).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(help).toHaveCount(0);
+  await expect(helpBtn).toBeFocused();
+
+  // Tab is trapped — focus stays on the dialog, not the page behind the backdrop.
+  await helpBtn.click();
+  await page.keyboard.press('Tab');
+  await expect(help).toBeFocused();
+
+  // Ctrl+K from the open help closes it and opens the palette (mutually exclusive).
+  await page.keyboard.press('Control+k');
+  await expect(help).toHaveCount(0);
+  await expect(page.getByRole('dialog', { name: 'Search pull requests' })).toBeVisible();
+});
+
 test('list footer: project links, version, license, year — and no topbar GitHub button', async ({ page }) => {
   await stubApi(page);
   await page.goto('/');


### PR DESCRIPTION
Small follow-up to **#33** (Erwan's ui/ux work — nice change), tightening three findings from a review of it. All low-severity polish; no behavior change to the happy paths.

## What

1. **Focus management for the palette & help dialogs.** Closing either (Esc / backdrop) now restores focus to whatever opened it, instead of dropping it to `<body>` (WCAG 2.4.3). The two overlays are also made **mutually exclusive** — ⌘/Ctrl+K while the help dialog is open swaps to the palette rather than stacking both at the same `z-index`.

2. **Help-dialog Tab trap.** The help dialog is informational (no controls), so Tab now stays on the card instead of wandering to the topbar/cards behind the backdrop. (The palette already trapped Tab via its input.)

3. **Deep-link guard in the diff view.** `Diffs.svelte`'s scroll/selection effect only redirects to the Summary when a resource is *genuinely* absent from the loaded diff. If the sections simply haven't rendered yet, it waits — so a future change that mounts the view during loading can't silently bounce a valid deep link to the Summary. (Today this is masked by mount ordering; this makes it robust.)

## Tests
Adds Playwright coverage for: palette focus-return on close, help focus-return + Tab trap + help→palette swap, and the stale-deep-link → Summary redirect.

- `svelte-check` — 0 errors
- `mise run ui-test` — **45 passed, 1 skip** (the 42 prior + 3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)