### PR TITLE
feat(diff): warn on large change-sets and major image/chart bumps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.4
 require (
 	codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3 v3.0.0
 	github.com/KimMachineGun/automemlimit v0.7.5
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/alecthomas/chroma/v2 v2.26.1
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/coder/websocket v1.8.14
@@ -26,7 +27,6 @@ require (
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/internal/diff/lint.go
+++ b/internal/diff/lint.go
@@ -3,8 +3,9 @@ package diff
 import (
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
+
+	"github.com/Masterminds/semver/v3"
 
 	"github.com/home-operations/konflate/internal/api"
 )
@@ -187,24 +188,18 @@ func isMajorBump(from, to string) bool {
 	return ok1 && ok2 && fm != tm
 }
 
-// majorOf extracts the semver major from a tag, tolerating a leading "v". It
-// returns false for anything that isn't "<major>.<minor>…" (a digest, "latest",
-// a bare integer) and for an implausibly large major (a calendar/date tag like
-// 20240131), so those never read as a "major bump".
-func majorOf(v string) (int, bool) {
-	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
-	i := 0
-	for i < len(v) && v[i] >= '0' && v[i] <= '9' {
-		i++
-	}
-	if i == 0 || i >= len(v) || v[i] != '.' {
-		return 0, false // need "<digits>.<…>"
-	}
-	n, err := strconv.Atoi(v[:i])
-	if err != nil || n >= 1000 {
+// majorOf parses a tag/version's semver major, tolerating the shapes container
+// images and Helm charts use (a leading "v", partials like "1.2", and
+// prerelease/build metadata). It returns false for non-semver values (digests,
+// "latest", name-only tags) and for an implausibly large major — a calendar or
+// date tag like 20240131, or a calver year — so those never read as a major
+// bump. (A bare integer such as a postgres:16 tag does parse, by design.)
+func majorOf(v string) (uint64, bool) {
+	ver, err := semver.NewVersion(strings.TrimSpace(v))
+	if err != nil || ver.Major() >= 1000 {
 		return 0, false
 	}
-	return n, true
+	return ver.Major(), true
 }
 
 // resourceLabel renders "Kind ns/name", or "Kind name" for cluster-scoped

--- a/internal/diff/lint.go
+++ b/internal/diff/lint.go
@@ -1,6 +1,13 @@
 package diff
 
-import "github.com/home-operations/konflate/internal/api"
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/home-operations/konflate/internal/api"
+)
 
 // Change is the minimal view of one changed resource the danger-lint needs:
 // its status and identity plus the pre-image (Old) and post-image (New)
@@ -13,12 +20,19 @@ type Change struct {
 	Parent    string // producing HelmRelease/Kustomization label (for Impact)
 	Old       map[string]any
 	New       map[string]any
+	// OldChart / NewChart are the resource's "helm.sh/chart" label
+	// ("<name>-<version>") before and after, captured before normalize strips it
+	// — used to flag a major chart-version bump. Empty for non-Helm resources or
+	// the absent side of an add/remove.
+	OldChart string
+	NewChart string
 }
 
-// Lint runs the danger-lint rules over the changed resources and returns the
-// warnings, most-severe first (all dangers before all cautions). Advisory only
-// — konflate never blocks on these; they are a reviewer aid.
-func Lint(changes []Change) []api.Warning {
+// Lint runs the danger-lint rules over the changed resources (and the diff's
+// image changes) and returns the warnings, most-severe first (all dangers
+// before all cautions). Advisory only — konflate never blocks on these; they
+// are a reviewer aid.
+func Lint(changes []Change, images []api.ImageChange) []api.Warning {
 	var danger, caution []api.Warning
 	add := func(level, rule, detail string, c Change) {
 		w := api.Warning{Level: level, Rule: rule, Resource: resourceLabel(c), Detail: detail}
@@ -62,7 +76,135 @@ func Lint(changes []Change) []api.Warning {
 		}
 	}
 
+	// Blast-radius / version signals (all caution): an unusually large change
+	// set, and major (semver) chart or container-image bumps — each "review with
+	// extra care", not "destructive".
+	if w, ok := largeChangeSet(changes); ok {
+		caution = append(caution, w)
+	}
+	caution = append(caution, chartBumpWarnings(changes)...)
+	caution = append(caution, imageBumpWarnings(images)...)
+
 	return append(danger, caution...)
+}
+
+// A change set this wide warrants a careful pass — a Renovate-style "update
+// everything" PR, or a sweeping refactor. Tuned to skip ordinary PRs (a handful
+// of resources in one or two apps) while catching bulk updates. Either bound
+// trips it: many apps, or a very large render delta in few.
+const (
+	largeParentCount   = 10 // distinct HelmReleases/Kustomizations touched
+	largeResourceCount = 60 // total changed resources
+)
+
+// largeChangeSet flags an unusually broad change set (caution).
+func largeChangeSet(changes []Change) (api.Warning, bool) {
+	parents := make(map[string]struct{})
+	for _, c := range changes {
+		if c.Parent != "" {
+			parents[c.Parent] = struct{}{}
+		}
+	}
+	n, p := len(changes), len(parents)
+	if p < largeParentCount && n < largeResourceCount {
+		return api.Warning{}, false
+	}
+	return api.Warning{
+		Level:    api.LevelCaution,
+		Rule:     "large-changeset",
+		Resource: fmt.Sprintf("%d resources · %d apps", n, p),
+		Detail:   "large change set — more ground to cover than a typical PR; review with extra care",
+	}, true
+}
+
+// chartBumpWarnings flags major Helm chart version bumps (caution), one per
+// chart, in first-seen order. A chart's children share its helm.sh/chart label,
+// so the bump is deduped by chart name.
+func chartBumpWarnings(changes []Change) []api.Warning {
+	type bump struct{ from, to string }
+	seen := make(map[string]bump)
+	var order []string
+	for _, c := range changes {
+		oldName, oldVer := splitChart(c.OldChart)
+		newName, newVer := splitChart(c.NewChart)
+		if oldName == "" || oldName != newName || !isMajorBump(oldVer, newVer) {
+			continue
+		}
+		if _, ok := seen[oldName]; !ok {
+			seen[oldName] = bump{oldVer, newVer}
+			order = append(order, oldName)
+		}
+	}
+	out := make([]api.Warning, 0, len(order))
+	for _, name := range order {
+		b := seen[name]
+		out = append(out, api.Warning{
+			Level:    api.LevelCaution,
+			Rule:     "major-chart-bump",
+			Resource: name,
+			Detail: fmt.Sprintf("major chart version bump %s → %s — check the chart's upgrade notes for breaking changes",
+				b.from, b.to),
+		})
+	}
+	return out
+}
+
+// imageBumpWarnings flags major container-image version bumps (caution). Images
+// are already deduped and sorted by the engine.
+func imageBumpWarnings(images []api.ImageChange) []api.Warning {
+	var out []api.Warning
+	for _, img := range images {
+		if isMajorBump(img.From, img.To) {
+			out = append(out, api.Warning{
+				Level:    api.LevelCaution,
+				Rule:     "major-image-bump",
+				Resource: img.Name,
+				Detail:   fmt.Sprintf("major image version bump %s → %s — likely breaking changes", img.From, img.To),
+			})
+		}
+	}
+	return out
+}
+
+// chartLabelRe splits a "helm.sh/chart" label ("<name>-<version>") into name and
+// version. The version is the trailing "[v]<major>.<minor>…" run, so a chart
+// name that itself contains hyphens (e.g. "cert-manager") stays intact.
+var chartLabelRe = regexp.MustCompile(`^(.*)-(v?\d+\.\d+[0-9A-Za-z.+-]*)$`)
+
+func splitChart(label string) (name, version string) {
+	m := chartLabelRe.FindStringSubmatch(label)
+	if m == nil {
+		return "", ""
+	}
+	return m[1], m[2]
+}
+
+// isMajorBump reports whether two semver-ish versions differ in their major
+// component. Non-semver values (digests, "latest", date tags) yield no bump.
+func isMajorBump(from, to string) bool {
+	fm, ok1 := majorOf(from)
+	tm, ok2 := majorOf(to)
+	return ok1 && ok2 && fm != tm
+}
+
+// majorOf extracts the semver major from a tag, tolerating a leading "v". It
+// returns false for anything that isn't "<major>.<minor>…" (a digest, "latest",
+// a bare integer) and for an implausibly large major (a calendar/date tag like
+// 20240131), so those never read as a "major bump".
+func majorOf(v string) (int, bool) {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	i := 0
+	for i < len(v) && v[i] >= '0' && v[i] <= '9' {
+		i++
+	}
+	if i == 0 || i >= len(v) || v[i] != '.' {
+		return 0, false // need "<digits>.<…>"
+	}
+	n, err := strconv.Atoi(v[:i])
+	if err != nil || n >= 1000 {
+		return 0, false
+	}
+	return n, true
 }
 
 // resourceLabel renders "Kind ns/name", or "Kind name" for cluster-scoped

--- a/internal/diff/lint_test.go
+++ b/internal/diff/lint_test.go
@@ -1,10 +1,32 @@
 package diff
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/home-operations/konflate/internal/api"
 )
+
+func hasRule(ws []api.Warning, rule string) bool {
+	for _, w := range ws {
+		if w.Rule == rule {
+			return true
+		}
+	}
+	return false
+}
+
+func countRule(ws []api.Warning, rule string) (int, api.Warning) {
+	var n int
+	var last api.Warning
+	for _, w := range ws {
+		if w.Rule == rule {
+			n++
+			last = w
+		}
+	}
+	return n, last
+}
 
 // privilegedDeploymentManifest is a workload post-image with one container
 // running privileged, nested at spec.template.spec.containers (where a
@@ -115,7 +137,7 @@ func TestLint(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := Lint(tt.changes)
+			got := Lint(tt.changes, nil)
 
 			if len(got) != len(tt.want) {
 				t.Fatalf("Lint() = %d warnings, want %d\n got: %+v\nwant: %+v", len(got), len(tt.want), got, tt.want)
@@ -131,5 +153,99 @@ func TestLint(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestLint_LargeChangeSet(t *testing.T) {
+	t.Parallel()
+	// Many distinct apps (parents) trips the caution.
+	many := make([]Change, 0, largeParentCount)
+	for i := range largeParentCount {
+		many = append(many, Change{
+			Status: "changed", Kind: "ConfigMap", Name: fmt.Sprintf("c%d", i),
+			Parent: fmt.Sprintf("HelmRelease app%d", i),
+			Old:    map[string]any{}, New: map[string]any{},
+		})
+	}
+	if !hasRule(Lint(many, nil), "large-changeset") {
+		t.Errorf("%d apps should trip the large-changeset caution", largeParentCount)
+	}
+	// A one-app change does not.
+	few := []Change{{Status: "changed", Kind: "ConfigMap", Name: "c", Parent: "HelmRelease app", Old: map[string]any{}, New: map[string]any{}}}
+	if hasRule(Lint(few, nil), "large-changeset") {
+		t.Error("a one-app change must not be flagged as large")
+	}
+}
+
+func TestLint_MajorImageBump(t *testing.T) {
+	t.Parallel()
+	images := []api.ImageChange{
+		{Name: "ghcr.io/app", From: "v1.9.0", To: "v2.0.0"}, // major → caution
+		{Name: "ghcr.io/lib", From: "1.2.3", To: "1.3.0"},   // minor → none
+	}
+	n, w := countRule(Lint(nil, images), "major-image-bump")
+	if n != 1 {
+		t.Fatalf("major-image-bump count = %d, want 1", n)
+	}
+	if w.Level != api.LevelCaution || w.Resource != "ghcr.io/app" || w.Detail == "" {
+		t.Errorf("major-image-bump = {%s %q %q}, want caution ghcr.io/app with a detail", w.Level, w.Resource, w.Detail)
+	}
+}
+
+func TestLint_MajorChartBump(t *testing.T) {
+	t.Parallel()
+	changes := []Change{
+		// Two children of one chart, major 3→4 → a single (deduped) caution.
+		{Status: "changed", Kind: "Deployment", Name: "a", Parent: "HelmRelease app", OldChart: "app-template-3.5.1", NewChart: "app-template-4.0.0", Old: map[string]any{}, New: map[string]any{}},
+		{Status: "changed", Kind: "Service", Name: "b", Parent: "HelmRelease app", OldChart: "app-template-3.5.1", NewChart: "app-template-4.0.0", Old: map[string]any{}, New: map[string]any{}},
+		// A minor chart bump → none.
+		{Status: "changed", Kind: "ConfigMap", Name: "c", Parent: "HelmRelease other", OldChart: "other-1.2.0", NewChart: "other-1.3.0", Old: map[string]any{}, New: map[string]any{}},
+	}
+	n, w := countRule(Lint(changes, nil), "major-chart-bump")
+	if n != 1 {
+		t.Fatalf("major-chart-bump count = %d, want 1 (deduped by chart)", n)
+	}
+	if w.Level != api.LevelCaution || w.Resource != "app-template" || w.Detail == "" {
+		t.Errorf("major-chart-bump = {%s %q %q}, want caution app-template with a detail", w.Level, w.Resource, w.Detail)
+	}
+}
+
+func TestMajorOf(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want int
+		ok   bool
+	}{
+		{"1.15.0", 1, true},
+		{"v2.0.0", 2, true},
+		{"1.2.3-rc1", 1, true},
+		{"latest", 0, false},
+		{"sha256:deadbeef", 0, false},
+		{"20240131", 0, false},   // date tag (no dot)
+		{"2024.01.31", 0, false}, // calver (major too large)
+		{"3", 0, false},          // bare major (no minor)
+		{"", 0, false},
+	}
+	for _, c := range cases {
+		if got, ok := majorOf(c.in); ok != c.ok || (ok && got != c.want) {
+			t.Errorf("majorOf(%q) = (%d, %v), want (%d, %v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestIsMajorBump(t *testing.T) {
+	t.Parallel()
+	bump := [][2]string{{"v1.0.0", "v2.0.0"}, {"1.9.9", "2.0.0"}, {"2.0.0", "1.0.0"}}
+	noBump := [][2]string{{"1.2.0", "1.3.0"}, {"v1.0.0", "v1.0.1"}, {"latest", "1.0.0"}, {"1.0.0", "sha256:x"}, {"1.0.0", "1.0.0"}}
+	for _, p := range bump {
+		if !isMajorBump(p[0], p[1]) {
+			t.Errorf("isMajorBump(%q, %q) = false, want true", p[0], p[1])
+		}
+	}
+	for _, p := range noBump {
+		if isMajorBump(p[0], p[1]) {
+			t.Errorf("isMajorBump(%q, %q) = true, want false", p[0], p[1])
+		}
 	}
 }

--- a/internal/diff/lint_test.go
+++ b/internal/diff/lint_test.go
@@ -214,17 +214,19 @@ func TestMajorOf(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		in   string
-		want int
+		want uint64
 		ok   bool
 	}{
 		{"1.15.0", 1, true},
 		{"v2.0.0", 2, true},
 		{"1.2.3-rc1", 1, true},
+		{"1.2", 1, true}, // partial
 		{"latest", 0, false},
 		{"sha256:deadbeef", 0, false},
-		{"20240131", 0, false},   // date tag (no dot)
+		{"20240131", 0, false},   // date tag (huge major)
 		{"2024.01.31", 0, false}, // calver (major too large)
-		{"3", 0, false},          // bare major (no minor)
+		{"3", 3, true},           // bare major now parses (postgres:16-style tags)
+		{"16", 16, true},
 		{"", 0, false},
 	}
 	for _, c := range cases {
@@ -236,7 +238,7 @@ func TestMajorOf(t *testing.T) {
 
 func TestIsMajorBump(t *testing.T) {
 	t.Parallel()
-	bump := [][2]string{{"v1.0.0", "v2.0.0"}, {"1.9.9", "2.0.0"}, {"2.0.0", "1.0.0"}}
+	bump := [][2]string{{"v1.0.0", "v2.0.0"}, {"1.9.9", "2.0.0"}, {"2.0.0", "1.0.0"}, {"16", "17"}}
 	noBump := [][2]string{{"1.2.0", "1.3.0"}, {"v1.0.0", "v1.0.1"}, {"latest", "1.0.0"}, {"1.0.0", "sha256:x"}, {"1.0.0", "1.0.0"}}
 	for _, p := range bump {
 		if !isMajorBump(p[0], p[1]) {

--- a/internal/diff/render.go
+++ b/internal/diff/render.go
@@ -53,7 +53,7 @@ func Render(in RenderInput) (api.DiffResult, error) {
 		Impact:    Summarize(in.Changes),
 		Images:    in.Images,
 		Failures:  in.Failures,
-		Warnings:  Lint(in.Changes),
+		Warnings:  Lint(in.Changes, in.Images),
 	}
 
 	for i, c := range in.Changes {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -180,10 +180,12 @@ func joinPath(dir, sub string) string {
 }
 
 // childEntry is one rendered resource together with the parent (HelmRelease /
-// Kustomization) that produced it.
+// Kustomization) that produced it and its helm.sh/chart label (captured before
+// normalize strips it, so a chart-version bump can be flagged).
 type childEntry struct {
 	parent   manifest.NamedResource
 	resource map[string]any
+	chart    string
 }
 
 // pairChanges diffs two flate render outputs into resource-level changes.
@@ -205,11 +207,11 @@ func pairChanges(base, head map[manifest.NamedResource][]map[string]any) []diff.
 			if reflect.DeepEqual(old.resource, nw.resource) {
 				continue // unchanged
 			}
-			changes = append(changes, change("changed", nw.parent, old.resource, nw.resource))
+			changes = append(changes, change("changed", nw.parent, old.resource, nw.resource, old.chart, nw.chart))
 		case inHead:
-			changes = append(changes, change("added", nw.parent, nil, nw.resource))
+			changes = append(changes, change("added", nw.parent, nil, nw.resource, "", nw.chart))
 		default:
-			changes = append(changes, change("removed", old.parent, old.resource, nil))
+			changes = append(changes, change("removed", old.parent, old.resource, nil, old.chart, ""))
 		}
 	}
 
@@ -389,16 +391,32 @@ func indexChildren(m map[manifest.NamedResource][]map[string]any) map[string]chi
 	idx := make(map[string]childEntry)
 	for parent, children := range m {
 		for _, res := range children {
+			chart := chartLabel(res) // before normalize strips helm.sh/chart
 			normalize(res)
 			kind, ns, name := coords(res)
 			key := strings.Join([]string{parentLabel(parent), kind, ns, name}, "\x00")
-			idx[key] = childEntry{parent: parent, resource: res}
+			idx[key] = childEntry{parent: parent, resource: res, chart: chart}
 		}
 	}
 	return idx
 }
 
-func change(status string, parent manifest.NamedResource, old, nw map[string]any) diff.Change {
+// chartLabel returns a manifest's "helm.sh/chart" label ("<name>-<version>"),
+// or "" if absent.
+func chartLabel(m map[string]any) string {
+	meta, ok := m["metadata"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	labels, ok := meta["labels"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	s, _ := labels["helm.sh/chart"].(string)
+	return s
+}
+
+func change(status string, parent manifest.NamedResource, old, nw map[string]any, oldChart, newChart string) diff.Change {
 	src := nw
 	if src == nil {
 		src = old
@@ -412,6 +430,8 @@ func change(status string, parent manifest.NamedResource, old, nw map[string]any
 		Parent:    parentLabel(parent),
 		Old:       old,
 		New:       nw,
+		OldChart:  oldChart,
+		NewChart:  newChart,
 	}
 }
 


### PR DESCRIPTION
Three new **advisory caution** signals on the review, requested via feedback (a Renovate-style bulk PR like onedr0p/home-ops#10973 should announce itself). They sit alongside the existing danger-lint and never block — konflate stays read-only.

## New rules
- **`large-changeset`** — a PR touching **≥10 apps** (distinct HelmReleases/Kustomizations) or producing a **≥60-resource** render delta gets a "review with extra care" heads-up. (Thresholds are constants in `lint.go`, easy to tune.)
- **`major-image-bump`** — a container image whose tag crosses a **semver major** (`v1.x → v2.x`, and bare-major tags like `postgres:16 → 17`) — likely breaking. Digests, `latest`, and date/calver tags are ignored.
- **`major-chart-bump`** — a Helm chart whose version crosses a major. The chart version isn't a diffed resource, so it's read from the `helm.sh/chart` label — which konflate normally **strips as noise** — captured *before* the strip and **deduped to one warning per chart**.

## Version parsing
Major detection uses **`Masterminds/semver/v3`** (already a transitive dep via flate→Helm, so no new binary weight) for correct handling of `v`-prefixes, partials, and prerelease/build metadata, plus a `≥1000` plausibility guard so calendar/date tags (`20240131`, `2024.01.31`) never read as a major bump.

## How it fits
`diff.Lint` now also takes the diff's image changes, so all warning generation stays in one place; `diff.Change` carries the old/new chart labels. Everything is `caution`-level and renders through the existing warnings UI (no client changes needed).

## Tests
New unit coverage for each rule (incl. deduped chart bumps and the bare-int case) and the semver parsing; `go test ./...`, `go vet`, `golangci-lint`, `gofmt`, and `tidy-check` all clean.

## Known limitation
A chart bump that changes *nothing* in the rendered output (only the stripped chart annotation) won't surface — but a real major bump almost always changes rendered content, and an image-tag bump usually rides along with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)