### PR TITLE
fix(ui): palette focus containment, diff null guards, chroma CSS sync

### DIFF
--- a/internal/web/src/App.svelte
+++ b/internal/web/src/App.svelte
@@ -128,7 +128,7 @@
     <!-- The backdrop is a real button so closing is keyboard-reachable. -->
     <div class="help-overlay">
       <button class="help-backdrop" aria-label="Close keyboard shortcuts" onclick={toggleHelp}></button>
-      <div class="help-card" role="dialog" aria-label="Keyboard shortcuts" tabindex="-1" use:focusOnMount onkeydown={trapTab}>
+      <div class="help-card" role="dialog" aria-modal="true" aria-label="Keyboard shortcuts" tabindex="-1" use:focusOnMount onkeydown={trapTab}>
         <h2>Keyboard shortcuts</h2>
         <dl class="help-keys">
           <dt><kbd>j</kbd> / <kbd>k</kbd></dt>

--- a/internal/web/src/lib/Copy.svelte
+++ b/internal/web/src/lib/Copy.svelte
@@ -2,6 +2,7 @@
   // A small icon button that copies `text` to the clipboard and briefly flips
   // to a check on success. Used sparingly for values a reviewer commonly lifts
   // out (a head SHA, an image reference, a resource identifier).
+  import { onDestroy } from 'svelte';
   import Icon from './Icon.svelte';
   import { mdiContentCopy, mdiCheck } from './icons';
 
@@ -15,6 +16,7 @@
 
   let copied = $state(false);
   let timer: ReturnType<typeof setTimeout> | undefined;
+  onDestroy(() => clearTimeout(timer));
 
   async function copy() {
     try {

--- a/internal/web/src/lib/Diff.svelte
+++ b/internal/web/src/lib/Diff.svelte
@@ -2,7 +2,10 @@
   // View mode is shared module state: every resource renders stacked in one
   // pane, so the toggle in any sticky header switches them all at once.
   // Default to split on wide screens, unified on narrow; remember the override.
+  // Module state initializers are guarded so importing this file never throws
+  // outside a browser (tests, a future SSR build).
   function defaultMode(): 'unified' | 'split' {
+    if (typeof window === 'undefined') return 'unified';
     const saved = localStorage.getItem('konflate-diffmode');
     if (saved === 'unified' || saved === 'split') return saved;
     return window.innerWidth >= 1400 ? 'split' : 'unified';
@@ -15,12 +18,23 @@
 
   // Side-by-side split is unreadable at phone width — force unified there (and
   // hide the toggle). Tracks the viewport live so a rotate/resize updates it.
-  const mq = window.matchMedia('(max-width: 640px)');
-  const vp = $state({ narrow: mq.matches });
-  mq.addEventListener('change', () => (vp.narrow = mq.matches));
+  const vp = $state({ narrow: false });
+  if (typeof window !== 'undefined') {
+    const mq = window.matchMedia('(max-width: 640px)');
+    vp.narrow = mq.matches;
+    mq.addEventListener('change', () => (vp.narrow = mq.matches));
+  }
 </script>
 
 <script lang="ts">
+  // SECURITY — the {@html} trust boundary. Every {@html} below renders
+  // `row.html` / cell `.html`, which MUST only ever be the server's
+  // Chroma-rendered diff lines: HTML-escaped token text wrapped in
+  // <span class="..."> tags. There is no client-side sanitization — the
+  // guarantees are (1) the server escapes all file content before wrapping it,
+  // and (2) the CSP blocks inline scripts as a backstop. Never route any other
+  // value (PR titles, file paths, warnings — anything forge-controlled) into
+  // these fields, and never relax this without adding client-side sanitization.
   import type { DiffResource, SideCell } from './types';
   import { store } from './store.svelte';
   import Icon from './Icon.svelte';
@@ -107,7 +121,8 @@
               <td class="gutter num">{row.oldNo || ''}</td>
               <td class="gutter num">{row.newNo || ''}</td>
               <td class="gutter sign">{row.kind === 'add' ? '+' : row.kind === 'del' ? '-' : ''}</td>
-              <!-- chroma-produced, HTML-escaped token spans; CSP blocks inline scripts -->
+              <!-- chroma-produced, HTML-escaped token spans; CSP blocks inline
+                   scripts — see the trust-boundary note at the top of this file -->
               <td class="code">{@html row.html ?? ''}</td>
             </tr>
           {/if}

--- a/internal/web/src/lib/Overview.svelte
+++ b/internal/web/src/lib/Overview.svelte
@@ -5,13 +5,13 @@
   import Copy from './Copy.svelte';
   import { mdiAlertOctagon, mdiAlert, mdiPackageVariantClosed, mdiAlertCircleOutline } from './icons';
 
-  const d = $derived(store.diff!);
+  const d = $derived(store.diff);
 
   // A warning's resource ("Kind ns/name") matches the diff resource's title, so
   // a warning can deep-link to the diff it flags. Null when the resource didn't
   // render into the diff (e.g. it only changed indirectly).
   function warningTarget(resource: string): string | null {
-    return d.resources?.find((r) => r.title === resource)?.id ?? null;
+    return d?.resources?.find((r) => r.title === resource)?.id ?? null;
   }
   function openWarning(id: string): void {
     if (router.route.name === 'review') openSel(router.route.pr, id);
@@ -44,6 +44,9 @@
   <span class="warning-detail">{w.detail}</span>
 {/snippet}
 
+<!-- d can briefly be null while a new diff loads (ensureDiff clears it); the
+     parent unmounts this view in the same flush, but guard rather than assert. -->
+{#if d}
 <div class="overview">
   <div class="impact">
     <span class="impact-pill"><strong>{d.impact.resources}</strong> resources</span>
@@ -112,3 +115,4 @@
     </section>
   {/if}
 </div>
+{/if}

--- a/internal/web/src/lib/Palette.svelte
+++ b/internal/web/src/lib/Palette.svelte
@@ -96,6 +96,11 @@
     if (idx >= rows.length) idx = Math.max(0, rows.length - 1);
   });
 
+  // First row of each kind, computed once per rows change — the group labels
+  // render above these.
+  const firstPrIdx = $derived(rows.findIndex((r) => r.kind === 'pr'));
+  const firstSuggestionIdx = $derived(rows.findIndex((r) => r.kind === 'suggestion'));
+
   function commit(row: Row | undefined): void {
     if (!row) return;
     if (row.kind === 'pr') {
@@ -143,14 +148,16 @@
 {#if palette.open}
   <div class="palette-overlay">
     <button class="help-backdrop" aria-label="Close search" onclick={togglePalette}></button>
-    <div class="palette" role="dialog" aria-label="Search pull requests">
+    <!-- The keydown handler lives on the dialog (not the input) so Tab cycles
+         the rows — and never escapes to the page behind — wherever focus sits
+         inside the palette. aria-modal marks the background inert for AT. -->
+    <div class="palette" role="dialog" aria-modal="true" aria-label="Search pull requests" tabindex="-1" onkeydown={onKeydown}>
       <div class="palette-input">
         <Icon path={mdiMagnify} size={16} />
         <!-- svelte-ignore a11y_autofocus -->
         <input
           bind:value={q}
           use:focusOnMount
-          onkeydown={onKeydown}
           oninput={() => (idx = 0)}
           placeholder="Search pull requests… (status: author: base: label:)"
           aria-label="Search pull requests"
@@ -163,10 +170,10 @@
           <div class="group-label">Recent</div>
         {/if}
         {#each rows as row, i (row.kind + (row.kind === 'pr' ? row.pr.number : row.query))}
-          {#if row.kind === 'pr' && i === rows.findIndex((r) => r.kind === 'pr')}
+          {#if i === firstPrIdx}
             <div class="group-label">Pull requests</div>
           {/if}
-          {#if row.kind === 'suggestion' && i === rows.findIndex((r) => r.kind === 'suggestion')}
+          {#if i === firstSuggestionIdx}
             <div class="group-label">Try</div>
           {/if}
           <button

--- a/internal/web/src/lib/Tree.svelte
+++ b/internal/web/src/lib/Tree.svelte
@@ -4,14 +4,15 @@
   import Icon from './Icon.svelte';
   import { mdiAlertOctagon, mdiFileDocumentOutline } from './icons';
 
-  const d = $derived(store.diff!);
+  // d can briefly be null while a new diff loads — every use below tolerates it.
+  const d = $derived(store.diff);
   // A null selection (bare #/pr/N) defaults to the Summary node.
   const sel = $derived(router.route.name === 'review' ? (router.route.sel ?? 'summary') : null);
   // Resources carrying a danger warning, keyed by their "Kind ns/name" label.
   const dangerLabels = $derived(
-    new Set((d.warnings ?? []).filter((w) => w.level === 'danger').map((w) => w.resource)),
+    new Set((d?.warnings ?? []).filter((w) => w.level === 'danger').map((w) => w.resource)),
   );
-  const dangerCount = $derived((d.warnings ?? []).filter((w) => w.level === 'danger').length);
+  const dangerCount = $derived((d?.warnings ?? []).filter((w) => w.level === 'danger').length);
 
   function open(id: string) {
     if (router.route.name === 'review') openSel(router.route.pr, id);
@@ -32,7 +33,7 @@
     {/if}
   </button>
 
-  {#each d.tree ?? [] as parent}
+  {#each d?.tree ?? [] as parent}
     <div class="tree-parent">
       <div class="tree-parent-label">{parent.label}</div>
       {#each parent.kinds as kind}

--- a/internal/web/src/lib/router.svelte.ts
+++ b/internal/web/src/lib/router.svelte.ts
@@ -17,7 +17,9 @@ function parse(hash: string): Route {
   const parts = hash.replace(/^#\/?/, '').split('/').filter(Boolean);
   if (parts[0] === 'pr' && parts[1]) {
     const pr = Number(parts[1]);
-    if (Number.isInteger(pr)) {
+    // PR numbers are positive integers on every forge — anything else is a
+    // malformed deep link and falls through to the list.
+    if (Number.isInteger(pr) && pr > 0) {
       return { name: 'review', pr, sel: parts[2] ?? null };
     }
   }

--- a/internal/web/src/lib/store.svelte.ts
+++ b/internal/web/src/lib/store.svelte.ts
@@ -299,16 +299,21 @@ function applyEnvelope(env: DiffEnvelope): void {
   }
 }
 
-// ---- chroma stylesheet (injected once) ------------------------------------
+// ---- chroma stylesheet -----------------------------------------------------
 
-let chromaInjected = false;
+// injectChroma keeps a single <style id="chroma-css"> in sync with the CSS the
+// server ships alongside each diff. All diffs currently share one theme, but
+// updating on change (rather than injecting once) means a server-side theme
+// change never silently keeps the stale stylesheet.
 function injectChroma(css: string): void {
-  if (chromaInjected || !css) return;
-  const style = document.createElement('style');
-  style.id = 'chroma-css';
-  style.textContent = css;
-  document.head.append(style);
-  chromaInjected = true;
+  if (!css) return;
+  let style = document.getElementById('chroma-css');
+  if (!style) {
+    style = document.createElement('style');
+    style.id = 'chroma-css';
+    document.head.append(style);
+  }
+  if (style.textContent !== css) style.textContent = css;
 }
 
 // ---- websocket ------------------------------------------------------------

--- a/internal/web/src/lib/theme.svelte.ts
+++ b/internal/web/src/lib/theme.svelte.ts
@@ -5,9 +5,12 @@
 export type ThemePref = 'auto' | 'light' | 'dark';
 
 const KEY = 'konflate-theme';
-const mq = window.matchMedia('(prefers-color-scheme: dark)');
+// Guarded so importing this module never throws outside a browser (tests, a
+// future SSR build); in that case the app behaves as auto/light until init.
+const mq = typeof window === 'undefined' ? null : window.matchMedia('(prefers-color-scheme: dark)');
 
 function load(): ThemePref {
+  if (typeof localStorage === 'undefined') return 'auto';
   const v = localStorage.getItem(KEY);
   return v === 'light' || v === 'dark' || v === 'auto' ? v : 'auto';
 }
@@ -15,7 +18,7 @@ function load(): ThemePref {
 export const theme = $state({ pref: load() });
 
 export function effective(): 'light' | 'dark' {
-  if (theme.pref === 'auto') return mq.matches ? 'dark' : 'light';
+  if (theme.pref === 'auto') return mq?.matches ? 'dark' : 'light';
   return theme.pref;
 }
 
@@ -35,5 +38,5 @@ export function cycleTheme(): void {
 
 export function initTheme(): void {
   applyTheme();
-  mq.addEventListener('change', applyTheme);
+  mq?.addEventListener('change', applyTheme);
 }


### PR DESCRIPTION
A pass over the Svelte frontend fixing accessibility gaps, latent null crashes, and a stale-stylesheet path.

## Accessibility
- **Palette**: the dialog now carries `aria-modal="true"` and `tabindex="-1"`, and the keydown handler moved from the input to the dialog root — Tab cycles the rows and can no longer escape to the page behind the overlay
- **Help dialog**: `aria-modal="true"` to match (it already trapped Tab)

## Correctness / robustness
- **Overview & Tree**: dropped the `store.diff!` non-null assertions — Overview guards with `{#if d}`, Tree uses optional chaining, so neither can crash if rendered while a diff is loading
- **store**: `injectChroma` keeps a keyed `<style id="chroma-css">` in sync with each envelope instead of injecting once — a server-side theme change no longer silently keeps the stale stylesheet
- **router**: `#/pr/0` (and other non-positive numbers) now falls through to the list instead of producing a blank review
- **Copy**: the copied-state timer is cleared on destroy

## Hygiene
- **Diff**: the `{@html}` trust boundary is now documented at the top of the file (server-escaped Chroma spans only, CSP as backstop); module-level `window`/`localStorage` access is guarded so importing never throws outside a browser
- **theme**: same guards for module-level `matchMedia`/`localStorage`
- **Palette**: the group-label `findIndex` calls hoisted out of the each-loop into deriveds (was O(n²) per render)

## Verification
- `svelte-check`: 0 errors, 0 warnings
- `vite build`: clean
- Playwright e2e: **47 passed**, 1 skipped (pre-existing)