### PR TITLE
chore(deps): update flate to v0.3.0 and align diff normalization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/coder/websocket v1.8.14
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/google/go-github/v88 v88.0.0
-	github.com/home-operations/flate v0.0.0-20260606122622-fdf06b48e591
+	github.com/home-operations/flate v0.3.0
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus/client_golang v1.23.2
 	gitlab.com/gitlab-org/api/client-go/v2 v2.36.0

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
-github.com/home-operations/flate v0.0.0-20260606122622-fdf06b48e591 h1:XYO7HVLpzHshm8mUm/h2GjAPfRQ0K9gT4QPaAiq/qRU=
-github.com/home-operations/flate v0.0.0-20260606122622-fdf06b48e591/go.mod h1:eP1vwZoUceCc9LDdeMzLOcnrA+XlwUxdiJLK2z2kNB4=
+github.com/home-operations/flate v0.3.0 h1:tVto2+0CPnfbzubQ9437m2T90SFNFz2/fuqi3MoGgGE=
+github.com/home-operations/flate v0.3.0/go.mod h1:eP1vwZoUceCc9LDdeMzLOcnrA+XlwUxdiJLK2z2kNB4=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20260505044615-1ff4bf46051f h1:NW3E2QSchEk63/fjeEvWOa2cE02FSv9ox//VE/N4c8g=

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -245,13 +245,23 @@ func unionKeys[K comparable, V any](ms ...map[K]V) []K {
 // They rotate on every Helm chart bump (the chart version, value checksums) and
 // carry no review-relevant signal, so leaving them in surfaces a spurious
 // change on every resource a touched chart renders — even resources the PR
-// doesn't change. Mirrors flate's diff defaults.
+// doesn't change. Mirrors flate's diff defaults (defaultStripAttrs); a trailing
+// "/" is a prefix match, so "checksum/" drops checksum/config, checksum/secret,
+// and any other checksum/<x> a chart emits.
 var stripAttrs = []string{
 	"helm.sh/chart",
-	"checksum/config",
-	"checksum/secret",
+	"checksum/",
 	"app.kubernetes.io/version",
 	"chart",
+}
+
+// stripFields are dotted spec field-paths whose value a chart templates from the
+// render clock, so it rotates on every render. Mirrors flate's diff defaults
+// (defaultStripFields): volsync's spec.restic.unlock ({{ now }}, via the
+// TrueCharts common library) would otherwise show a spurious change on every
+// backed-up app whenever the two sides render a moment apart.
+var stripFields = []string{
+	"spec.restic.unlock",
 }
 
 // normalize rewrites a rendered manifest in place so render-time noise doesn't
@@ -260,10 +270,10 @@ var stripAttrs = []string{
 // as a phantom change on every PR that touches a neighbouring chart. Three
 // classes are scrubbed:
 //
-//   - Chart-bump attributes (helm.sh/chart, checksum/*, …) — stripped from
-//     metadata and nested pod/CronJob/volumeClaimTemplate metadata. Mirrors
-//     flate's own pre-diff normalization (manifest.StripResourceAttributes is
-//     the routine its diff backend uses).
+//   - Chart-bump attributes (helm.sh/chart, checksum/*, …) and render-clock
+//     spec field-paths (spec.restic.unlock) — dropped via flate's
+//     manifest.StripResourceAttributes / StripResourceFields, mirroring its own
+//     pre-diff normalization defaults.
 //   - ConfigMap binaryData — opaque base64 blobs collapsed to a content
 //     summary; the review signal is "did the bytes change", not which base64
 //     character flipped.
@@ -273,6 +283,7 @@ var stripAttrs = []string{
 //     the Secrets it reads for auth, not the ones a chart renders into output.
 func normalize(m map[string]any) {
 	manifest.StripResourceAttributes(m, stripAttrs)
+	manifest.StripResourceFields(m, stripFields)
 	switch manifest.DocKind(m) {
 	case manifest.KindConfigMap:
 		summarizeBinaryData(m)

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -193,6 +193,28 @@ func TestPairChanges_SuppressesRenderNoise(t *testing.T) {
 	}
 }
 
+func TestPairChanges_StripsVolatileChurn(t *testing.T) {
+	t.Parallel()
+	parent := manifest.NamedResource{Kind: "HelmRelease", Namespace: "apps", Name: "vol"}
+	// A volsync ReplicationSource whose only between-render differences are
+	// volatile noise: rotating checksum/* annotations (incl. the plural
+	// checksum/secrets the old exact-match list missed) and the render-clock
+	// spec.restic.unlock timestamp. Both must be stripped, so no change surfaces.
+	src := func(checksum, unlock string) map[manifest.NamedResource][]map[string]any {
+		m := res("ReplicationSource", "apps", "data", map[string]any{
+			"spec": map[string]any{"restic": map[string]any{"repository": "backups", "unlock": unlock}},
+		})
+		m["metadata"].(map[string]any)["annotations"] = map[string]any{
+			"checksum/config":  checksum,
+			"checksum/secrets": checksum,
+		}
+		return map[manifest.NamedResource][]map[string]any{parent: {m}}
+	}
+	if got := pairChanges(src("aaaa", "20240101000000"), src("bbbb", "20240102000000")); len(got) != 0 {
+		t.Errorf("rotating checksum/* + spec.restic.unlock should be stripped, got %d change(s): %+v", len(got), got)
+	}
+}
+
 func deploy(ns, name, image string) map[string]any {
 	return res("Deployment", ns, name, map[string]any{
 		"spec": map[string]any{"template": map[string]any{"spec": map[string]any{


### PR DESCRIPTION
## flate v0.3.0
Pins `github.com/home-operations/flate` to the **v0.3.0** release instead of a digest pseudo-version. The v-prefixed release tags (flate #582) make this a clean semver pin — Go ignores flate's older bare `0.2.x` tags, so `@v0.3.0` resolves unambiguously.

- **No engine changes needed to build.** The `orchestrator.Config` fields konflate sets are unchanged (the only addition is an additive `GitDepth`); `go build ./...` passes untouched.
- **The headline break doesn't affect us.** v0.3.0 removes the `--enable-oci` flag (OCIRepository charts always real-fetch now) — konflate was already on that behavior via the previous digest, and `AllowMissingSecrets` still turns missing registry auth into a skip.
- v0.3.0 also brings, for free, flate-internal wins konflate benefits from: shallow/narrow GitRepository source clones, a process-wide krusty mutex, helm template-cache key fixes, deterministic ResourceSet collisions, and namespace-defaulting fixes.

## Diff-normalization parity
konflate's `normalize()` mirrors flate's pre-diff strips; v0.3.0 expanded them, so I brought konflate to parity (keeps the render diff churn-free):

- `StripResourceAttributes` is now **prefix-aware** — `"checksum/"` replaces the exact `checksum/config` + `checksum/secret` pair and also catches the **plural `checksum/secrets`** (bjw-s/app-template) the old exact-match list silently missed.
- New **`StripResourceFields`** drops render-clock spec paths — mirroring flate's default of **`spec.restic.unlock`** (volsync's `{{ now }}`), which would otherwise show a spurious change on every backed-up app when the two sides render a moment apart.

## Tests
- New engine test for the volatile-churn stripping (`checksum/*` incl. plural + `spec.restic.unlock`).
- `go test ./...`, `go vet`, `golangci-lint`, `gofmt`, `tidy-check` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)