### PR TITLE
perf(server): gzip-compress JSON API responses

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,14 +7,18 @@ package server
 
 import (
 	"bufio"
+	"compress/gzip"
 	"context"
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"net"
 	"net/http"
+	"strings"
+	"sync"
 	"text/template"
 	"time"
 
@@ -190,7 +194,7 @@ func (s *Server) mainHandler() http.Handler {
 
 	mux.Handle("GET /", s.uiHandler())
 
-	return s.recoverer(s.accessLog(s.securityHeaders(mux)))
+	return s.recoverer(s.accessLog(s.securityHeaders(s.gzipJSON(mux))))
 }
 
 // securityHeaders applies a strict CSP and related headers to every response.
@@ -206,6 +210,97 @@ func (s *Server) securityHeaders(next http.Handler) http.Handler {
 		h.Set("Referrer-Policy", "no-referrer")
 		next.ServeHTTP(w, r)
 	})
+}
+
+// gzipPool reuses gzip writers across requests.
+var gzipPool = sync.Pool{New: func() any { return gzip.NewWriter(io.Discard) }}
+
+// gzipJSON compresses application/json responses — the rendered diff is large
+// and highly compressible — when the client accepts gzip. It keys off the
+// Content-Type the handler set, so only JSON is wrapped: the embedded UI (which
+// does its own Range/conditional handling) and the hijacked websocket pass
+// through untouched, as do clients that don't send Accept-Encoding: gzip.
+func (s *Server) gzipJSON(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+			next.ServeHTTP(w, r)
+			return
+		}
+		gz := &gzipResponseWriter{ResponseWriter: w}
+		defer gz.close()
+		next.ServeHTTP(gz, r)
+	})
+}
+
+// gzipResponseWriter starts compressing only once it sees a JSON Content-Type
+// (decided on the first WriteHeader/Write); until then it's a transparent
+// pass-through, so a non-JSON response — or the websocket upgrade, which
+// hijacks before writing — is never wrapped.
+type gzipResponseWriter struct {
+	http.ResponseWriter
+	gz       *gzip.Writer
+	decided  bool
+	compress bool
+}
+
+func (g *gzipResponseWriter) decide() {
+	if g.decided {
+		return
+	}
+	g.decided = true
+	if !strings.HasPrefix(g.Header().Get("Content-Type"), "application/json") {
+		return
+	}
+	g.compress = true
+	h := g.Header()
+	h.Set("Content-Encoding", "gzip")
+	h.Add("Vary", "Accept-Encoding")
+	h.Del("Content-Length") // the compressed length differs; let it chunk
+	g.gz = gzipPool.Get().(*gzip.Writer)
+	g.gz.Reset(g.ResponseWriter)
+}
+
+func (g *gzipResponseWriter) WriteHeader(code int) {
+	g.decide()
+	g.ResponseWriter.WriteHeader(code)
+}
+
+func (g *gzipResponseWriter) Write(b []byte) (int, error) {
+	g.decide()
+	if g.compress {
+		return g.gz.Write(b)
+	}
+	return g.ResponseWriter.Write(b)
+}
+
+// close flushes and returns the gzip writer to the pool; a no-op when
+// compression never started.
+func (g *gzipResponseWriter) close() {
+	if g.gz != nil {
+		_ = g.gz.Close()
+		gzipPool.Put(g.gz)
+		g.gz = nil
+	}
+}
+
+func (g *gzipResponseWriter) Flush() {
+	if g.gz != nil {
+		_ = g.gz.Flush()
+	}
+	if f, ok := g.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (g *gzipResponseWriter) Unwrap() http.ResponseWriter { return g.ResponseWriter }
+
+// Hijack lets the websocket upgrade reach the underlying conn (it hijacks
+// before any write, so compression never started).
+func (g *gzipResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := g.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, errors.New("gzipResponseWriter: underlying ResponseWriter is not a Hijacker")
 }
 
 func (s *Server) accessLog(next http.Handler) http.Handler {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"compress/gzip"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -755,6 +756,63 @@ func TestServer_HealthAndSecurityHeaders(t *testing.T) {
 	}
 	if csp := rec.Header().Get("Content-Security-Policy"); !strings.Contains(csp, "script-src 'self'") {
 		t.Errorf("missing/weak CSP: %q", csp)
+	}
+}
+
+// TestServer_GzipJSON checks that JSON API responses are gzip-compressed when
+// the client accepts it, stay plain when it doesn't, and that a non-JSON
+// response (the text/plain health check) is never compressed.
+func TestServer_GzipJSON(t *testing.T) {
+	t.Parallel()
+	s := newTestServer(t, ghCfg("tok"), &fakeProvider{}, okEngine())
+	h := s.mainHandler()
+
+	// With Accept-Encoding: gzip the JSON response is compressed, advertises it,
+	// drops its Content-Length, and gunzips back to a valid payload.
+	rec := do(h, "GET", "/api/meta", nil, map[string]string{"Accept-Encoding": "gzip"})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("meta: got %d, want 200", rec.Code)
+	}
+	if enc := rec.Header().Get("Content-Encoding"); enc != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", enc)
+	}
+	if vary := rec.Header().Get("Vary"); !strings.Contains(vary, "Accept-Encoding") {
+		t.Errorf("Vary = %q, want it to include Accept-Encoding", vary)
+	}
+	if cl := rec.Header().Get("Content-Length"); cl != "" {
+		t.Errorf("Content-Length = %q, want empty (compressed length differs)", cl)
+	}
+	gr, err := gzip.NewReader(rec.Body)
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	var m api.Meta
+	if err := json.NewDecoder(gr).Decode(&m); err != nil {
+		t.Fatalf("decode gunzipped meta: %v", err)
+	}
+	if m.Repo != "acme/web" {
+		t.Errorf("gunzipped meta = %+v, want repo acme/web", m)
+	}
+
+	// Without Accept-Encoding the same endpoint returns plain (uncompressed) JSON.
+	rec = do(h, "GET", "/api/meta", nil, nil)
+	if enc := rec.Header().Get("Content-Encoding"); enc != "" {
+		t.Errorf("no Accept-Encoding: Content-Encoding = %q, want none", enc)
+	}
+	var plain api.Meta
+	mustJSON(t, rec, &plain) // decodes directly — proves the body isn't gzipped
+	if plain.Repo != "acme/web" {
+		t.Errorf("plain meta = %+v, want repo acme/web", plain)
+	}
+
+	// A non-JSON response (the text/plain health check) is never compressed, even
+	// when the client accepts gzip — the middleware keys off the response type.
+	rec = do(h, "GET", "/healthz", nil, map[string]string{"Accept-Encoding": "gzip"})
+	if enc := rec.Header().Get("Content-Encoding"); enc != "" {
+		t.Errorf("healthz Content-Encoding = %q, want none (text/plain not compressed)", enc)
+	}
+	if !strings.Contains(rec.Body.String(), "ok") {
+		t.Errorf("healthz body = %q, want plain text containing ok", rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
## What

Adds a `gzipJSON` middleware that gzip-compresses `application/json` API
responses when the client sends `Accept-Encoding: gzip`.

The rendered diff payload is the largest thing konflate serves and is highly
compressible — repeated YAML keys, deep indentation, and chroma's HTML span
markup all gzip extremely well (typically 5–10×). It was previously served
uncompressed, so large-diff PRs paid the full byte cost over the wire on every
load and refresh. This is the first of two render-time improvements for large
diffs (lazy-mounting the diff sections is the follow-up).

## How

- New middleware wired into the chain as
  `recoverer(accessLog(securityHeaders(gzipJSON(mux))))`.
- It keys off the **response** `Content-Type`, deciding on the first
  `WriteHeader`/`Write`, and only compresses `application/json`. So:
  - the embedded UI `FileServer` (which does its own `Range`/conditional/`304`
    handling) passes through untouched;
  - the hijacked `/ws` upgrade — which hijacks before any write — is never
    wrapped, and `Hijack`/`Flush`/`Unwrap` are forwarded so the websocket and
    any flushing handler keep working.
- Gated on `Accept-Encoding: gzip`; sets `Content-Encoding: gzip`, adds
  `Vary: Accept-Encoding`, and drops the now-wrong `Content-Length`.
- `gzip.Writer`s are reused via a `sync.Pool` to avoid per-request allocation.

No API shape changes; purely transport-level.

## Test

`TestServer_GzipJSON` covers the three cases: a JSON response is compressed and
gunzips back to a valid `api.Meta` (with `Content-Encoding`/`Vary` set and
`Content-Length` dropped); the same endpoint stays plain JSON without the
header; and the `text/plain` health check is never compressed even when gzip is
accepted. The existing websocket test still passes, confirming the hijack path
is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
