### PR TITLE
fix(engine): surface per-resource render failures instead of aborting the diff

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -12,6 +12,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"runtime"
 	"slices"
@@ -112,11 +113,15 @@ func (e *flateEngine) Diff(ctx context.Context, pr api.PR) (api.DiffResult, erro
 	// files differ between the merge-base and head trees, plus the dependency
 	// closure flate computes — not the whole cluster, the dominant cold-start
 	// cost saver), sharing e.cache so the head render reuses the base render's
-	// fetched charts / OCI layers / git sources, concurrently. A nil Result
-	// means a fatal Bootstrap error; per-resource render failures keep the
-	// Result non-nil and are surfaced via renderFailures below.
+	// fetched charts / OCI layers / git sources, concurrently.
+	//
+	// Per flate's contract the returned err is advisory: a side's Result is nil
+	// only on a fatal Bootstrap error, whereas per-resource reconcile failures
+	// keep Result non-nil and ARE the diff's render failures — they must flow to
+	// renderFailures below, not abort the whole diff (a PR that breaks a chart is
+	// exactly the one a reviewer needs to see). renderUsable gates on that.
 	base, head, err := orchestrator.RenderTrees(ctx, baseTree, headTree, e.renderCfg())
-	if err != nil {
+	if !renderUsable(base, head, err) {
 		return api.DiffResult{}, fmt.Errorf("engine: render PR #%d: %w", pr.Number, err)
 	}
 
@@ -128,6 +133,23 @@ func (e *flateEngine) Diff(ctx context.Context, pr api.PR) (api.DiffResult, erro
 		Images:   imageChanges(changes),
 		Failures: renderFailures(head.Result.Failed),
 	})
+}
+
+// renderUsable reports whether a RenderTrees outcome yields a diff worth
+// returning. flate's err is advisory (see RenderTrees), so this gates on what's
+// actually usable rather than on err being nil:
+//   - A nil Result is a fatal Bootstrap error — that side never rendered, so
+//     there is no diff to show.
+//   - A cancelled or timed-out context (konflate's DiffTimeout) left the render
+//     incomplete: resources that never reconciled would read as missing, so a
+//     partial diff would mislead.
+//   - Otherwise a non-nil err is per-resource reconcile failures: the diff is
+//     real and those failures surface via renderFailures, so proceed.
+func renderUsable(base, head orchestrator.Rendered, err error) bool {
+	if base.Result == nil || head.Result == nil {
+		return false
+	}
+	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
 }
 
 // renderCfg is the flate render tuning shared by both sides of a

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,10 +1,14 @@
 package engine
 
 import (
+	"context"
 	"encoding/base64"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/orchestrator"
 
 	"github.com/home-operations/konflate/internal/diff"
 )
@@ -20,6 +24,44 @@ func res(kind, ns, name string, extra map[string]any) map[string]any {
 		m[k] = v
 	}
 	return m
+}
+
+func TestRenderUsable(t *testing.T) {
+	t.Parallel()
+	ok := &orchestrator.Result{} // a non-nil Result = that side bootstrapped and rendered
+	cases := []struct {
+		name       string
+		base, head orchestrator.Rendered
+		err        error
+		want       bool
+	}{
+		{"clean render", rendered(ok), rendered(ok), nil, true},
+		// Per-resource reconcile failures are advisory: flate still produced a
+		// diff (Result non-nil) and the failures surface via Failures, so the
+		// diff must still render — the regression this guards against.
+		{"per-resource failures still usable", rendered(ok), rendered(ok), errors.New("reconcile completed with 2 failure(s)"), true},
+		// A nil Result is a fatal Bootstrap error on that side — nothing to show.
+		{"fatal base bootstrap", rendered(nil), rendered(ok), errors.New("bootstrap: boom"), false},
+		{"fatal head bootstrap", rendered(ok), rendered(nil), errors.New("bootstrap: boom"), false},
+		// An incomplete render (DiffTimeout / cancellation) would mislead, so a
+		// context error aborts even though Result is non-nil.
+		{"deadline exceeded", rendered(ok), rendered(ok), fmt.Errorf("render: %w", context.DeadlineExceeded), false},
+		{"canceled", rendered(ok), rendered(ok), context.Canceled, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := renderUsable(tc.base, tc.head, tc.err); got != tc.want {
+				t.Errorf("renderUsable(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// rendered wraps a Result in the orchestrator.Rendered shape renderUsable reads
+// (the embedded *Orchestrator is unused by the gate).
+func rendered(result *orchestrator.Result) orchestrator.Rendered {
+	return orchestrator.Rendered{Result: result}
 }
 
 func TestPairChanges(t *testing.T) {


### PR DESCRIPTION
## What

`Diff` now surfaces per-resource render failures instead of aborting the whole diff when flate reports them.

## Why (regression from #47)

#47 swapped the engine onto `orchestrator.RenderTrees` and gated on its returned error:

```go
base, head, err := orchestrator.RenderTrees(...)
if err != nil {
    return api.DiffResult{}, fmt.Errorf("engine: render PR #%d: %w", pr.Number, err)
}
```

But flate's `RenderTrees` error is **advisory**, not fatal. Tracing it at the pinned commit:

`finalize()` → `return o.aggregateFailures(failed)` whenever `len(failed) > 0` → `awaitDrain` → `o.Run` → `o.Render` → `Rendered.Err` → `RenderTrees` returns it via `joinTreeErrors`. The *same* `o.store.FailedResources()` that populates `Result.Failed` is what makes the error non-nil — so **the failure set and the error are the same event**. flate's own contract spells this out: *"callers that still want the partial diff check `Rendered.Result != nil` (nil only on a fatal Bootstrap error) and treat err as advisory,"* and `flate diff` does exactly that (gates on `orig.O == nil`, emits the diff regardless, returns the error only as the exit code).

So on `main` today, a PR that breaks a single chart returns a hard `engine: render PR #N: reconcile completed with N failure(s)…` with **no diff at all**, and `renderFailures(head.Result.Failed)` is unreachable — the entire render-failures surfacing (the `Failures` field, the review-page "render failures" panel, the PR-list failure badge) is dead for real renders. A failing PR is precisely the one a reviewer needs to see.

## How

Gate on what's actually *usable*, via a small `renderUsable(base, head, err)` helper:

- **nil `Result`** on either side → fatal Bootstrap error, nothing to show → abort.
- **cancelled / timed-out context** (konflate's `DiffTimeout`) → the render is incomplete; a partial diff would mislead (un-reconciled resources read as missing) → abort.
- **otherwise** a non-nil err is per-resource reconcile failures → advisory; the diff renders and the failures flow to `Failures`.

The existing `err != nil` guard incidentally prevented a nil-deref of `base.Result`; `renderUsable` preserves that (the `Result == nil` check comes first).

## Test

`TestRenderUsable` covers the clean / advisory-failure / fatal-bootstrap (each side) / deadline / cancel cases. The engine's other tests are pure (they don't drive a real flate render), so this is the regression guard. `go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint`, and `go mod tidy` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
