### PR TITLE
fix(ui): on mobile, scroll the review so the diff gets the full screen

### DIFF
--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -1175,6 +1175,9 @@ button.sum-pill:hover {
   content-visibility: auto;
   contain-intrinsic-size: 600px;
   contain-intrinsic-size: auto 600px;
+  /* A jumped-to section lands below the sticky switcher on mobile; --stuck is
+     the switcher's measured height (Diffs.svelte), 0 on desktop. */
+  scroll-margin-top: var(--stuck, 0px);
 }
 .diff-section + .diff-section {
   border-top: 1px solid var(--border);
@@ -1769,16 +1772,53 @@ kbd {
 @media (max-width: 900px) {
   .diffs {
     grid-template-columns: 1fr;
+    height: auto; /* page-scroll: size to content; .review owns the scroll */
   }
   .rail {
     display: none;
   }
-  /* With the tree rail gone, the switcher bar carries the resource navigation. */
+  /* With the tree rail gone, the switcher bar carries the resource navigation,
+     and it's the one bar pinned while the diff scrolls (see below). */
   .diff-switcher {
     display: flex;
+    position: sticky;
+    top: 0;
+    z-index: 6;
   }
   .review-head {
     flex-wrap: wrap;
+  }
+  /* Reclaim the viewport for the diff. On desktop the diff pane scrolls inside
+     fixed chrome, but on a short phone that chrome (topbar + PR title/meta +
+     merge-command) leaves the diff only ~half the screen. So on mobile the
+     whole review column scrolls: the header scrolls away under the sticky
+     switcher and the diff gets the full viewport. The pane and its wrappers
+     stop being scroll containers and size to content; .review scrolls instead.
+     (Diffs.svelte points the scrollspy + lazy-mount observer at .review here.) */
+  .review {
+    overflow-y: auto;
+  }
+  .review-body {
+    flex: 0 0 auto;
+    overflow: visible;
+  }
+  .diff-main {
+    overflow: visible;
+  }
+  .diff-pane {
+    flex: none;
+    overflow: visible;
+  }
+  /* The per-section header isn't sticky on mobile — the switcher (which shows
+     the current resource's name) is the single pinned bar, so there's nothing
+     for a second sticky element to fight or overlap. */
+  .res-header {
+    position: static;
+  }
+  /* The last section can still scroll up under the switcher so it can become
+     the current section (the scrollspy keys off "top crossed the top"). */
+  .diff-section:last-child {
+    min-height: 100dvh;
   }
 }
 

--- a/internal/web/src/lib/Diffs.svelte
+++ b/internal/web/src/lib/Diffs.svelte
@@ -22,6 +22,39 @@
 
   let pane = $state<HTMLElement | null>(null);
 
+  // The element that actually scrolls. On desktop the diff pane scrolls inside
+  // fixed chrome; on mobile (≤900px — where the rail is hidden and the switcher
+  // takes over) the whole review column scrolls instead, so the PR header
+  // scrolls away under the sticky switcher and the diff gets the full viewport
+  // rather than ~half. closest() reaches the .review container that wraps both
+  // the header and this pane (an ancestor, mounted before it). The scrollspy,
+  // lazy-mount observer and scroll listener all key off this.
+  const mobileMQ = '(max-width: 900px)';
+  const layout = $state({
+    mobile: typeof window !== 'undefined' && window.matchMedia(mobileMQ).matches,
+  });
+  $effect(() => {
+    if (typeof window === 'undefined') return;
+    const mq = window.matchMedia(mobileMQ);
+    const sync = () => (layout.mobile = mq.matches);
+    mq.addEventListener('change', sync);
+    return () => mq.removeEventListener('change', sync);
+  });
+  const scroller = $derived(
+    layout.mobile && pane ? ((pane.closest('.review') as HTMLElement | null) ?? pane) : pane,
+  );
+
+  // On mobile the switcher is sticky at the top of the scroll, so it overlaps
+  // the leading edge. A jumped-to section must land below it (scroll-margin, via
+  // the --stuck custom property) and the scrollspy's "crossed the top" line must
+  // sit below it too — both by the switcher's measured height. 0 on desktop
+  // (the switcher is hidden), so that path is unchanged.
+  let switcherEl = $state<HTMLElement | null>(null);
+  let stuckPx = $state(0);
+  $effect(() => {
+    stuckPx = layout.mobile && switcherEl ? switcherEl.offsetHeight : 0;
+  });
+
   // Lazy-mount: every resource's <section> wrapper and its sticky header stay
   // in the DOM (so the tree, scrollspy, deep-links and j/k keep working), but
   // the heavy diff <table> inside only mounts once its section nears the
@@ -36,6 +69,19 @@
   // loading state unmounts it), so this never carries across PRs.
   let spySel = 'summary';
 
+  // After a programmatic jump (tree click, j/k, deep link) the scroll — and any
+  // lazy-mount / content-visibility reflow it triggers — takes a moment to
+  // settle. Suppress the scrollspy briefly so a mid-settle reading can't fight
+  // the jump and bounce the selection around. A genuine user scroll after the
+  // timer clears re-derives normally.
+  let spyLocked = false;
+  let spyLockTimer: ReturnType<typeof setTimeout> | undefined;
+  function lockSpy(): void {
+    spyLocked = true;
+    clearTimeout(spyLockTimer);
+    spyLockTimer = setTimeout(() => (spyLocked = false), 250);
+  }
+
   $effect(() => {
     const target = sel;
     const present = resources; // re-run when the rendered resource set changes
@@ -49,7 +95,8 @@
     const section = pane.querySelector(`[data-sel="${CSS.escape(target)}"]`);
     if (section) {
       section.scrollIntoView({ block: 'start' });
-      spySel = target; // the scroll event re-derives it if the section can't reach the top
+      spySel = target;
+      lockSpy(); // hold the spy off until the scroll + any reflow settle
       return;
     }
     // No section for the target. Only a genuinely-missing resource — the diff
@@ -64,16 +111,18 @@
   });
 
   // Scrollspy: the current section is the last one whose top has crossed the
-  // pane's top — i.e. the one whose sticky header is showing. Every section
-  // can get there: the last one is padded to the pane's height (see CSS).
+  // scroll container's top — i.e. the one the switcher labels. Runs against
+  // `scroller` so it tracks whichever element actually scrolls (the pane on
+  // desktop, the review column on mobile).
   let raf = 0;
   function onScroll(): void {
     cancelAnimationFrame(raf);
     raf = requestAnimationFrame(() => {
-      if (!pane || router.route.name !== 'review') return;
-      const top = pane.getBoundingClientRect().top;
+      const sc = scroller;
+      if (spyLocked || !sc || router.route.name !== 'review') return;
+      const top = sc.getBoundingClientRect().top + stuckPx;
       let cur = 'summary';
-      for (const el of pane.querySelectorAll<HTMLElement>('[data-sel]')) {
+      for (const el of sc.querySelectorAll<HTMLElement>('[data-sel]')) {
         if (el.getBoundingClientRect().top - top <= 2) cur = el.dataset.sel!;
       }
       if (cur !== spySel) {
@@ -83,16 +132,27 @@
     });
   }
 
-  // One observer for every resource section, rooted on the scroll pane. The
-  // generous margin mounts a section a couple of viewports before it scrolls in,
-  // so the real table is ready and there's no skeleton flash in normal reading.
-  // Sections register through the `lazy` action; any that mount before this
-  // effect builds the observer wait in `pending`.
+  // Bind the scrollspy to whatever actually scrolls (see `scroller`), and
+  // re-bind if the breakpoint flips — an inline onscroll can't follow the
+  // element across the desktop/mobile boundary.
+  $effect(() => {
+    const sc = scroller;
+    if (!sc) return;
+    sc.addEventListener('scroll', onScroll, { passive: true });
+    return () => sc.removeEventListener('scroll', onScroll);
+  });
+
+  // Lazy-mount observer, rooted on the scroll container. The generous margin
+  // mounts a section a couple of viewports before it scrolls in, so the real
+  // table is ready and there's no skeleton flash in normal reading. The `io`
+  // and `sections` registry rebuild if `scroller` flips (breakpoint change);
+  // `sections` lets that rebuild re-observe everything still on screen.
   let io: IntersectionObserver | null = null;
-  const pending = new Set<HTMLElement>();
+  const sections = new Set<HTMLElement>();
 
   $effect(() => {
-    if (!pane) return;
+    const sc = scroller;
+    if (!sc) return;
     if (typeof IntersectionObserver === 'undefined') {
       // No observer (an ancient browser, or a non-DOM env): mount everything,
       // i.e. fall back to the previous always-rendered behavior.
@@ -108,26 +168,25 @@
           obs.unobserve(e.target); // mount-once: never tear a mounted table back down
         }
       },
-      { root: pane, rootMargin: '200% 0px' },
+      { root: sc, rootMargin: '200% 0px' },
     );
     io = obs;
-    for (const el of pending) obs.observe(el);
-    pending.clear();
+    for (const node of sections) obs.observe(node);
     return () => {
       obs.disconnect();
       if (io === obs) io = null;
     };
   });
 
-  // Action on each resource <section>: observe it (or queue it until the
-  // observer exists), and stop observing if the section is removed.
+  // Action on each resource <section>: register it (so an observer rebuild can
+  // re-observe it) and observe it now if the observer already exists.
   function lazy(node: HTMLElement) {
-    if (io) io.observe(node);
-    else pending.add(node);
+    sections.add(node);
+    io?.observe(node);
     return {
       destroy() {
+        sections.delete(node);
         io?.unobserve(node);
-        pending.delete(node);
       },
     };
   }
@@ -137,8 +196,9 @@
   <aside class="rail"><Tree /></aside>
   <div class="diff-main">
     <!-- The tree rail is hidden on narrow screens; this bar is the navigator
-         there, jumping between Summary + every resource. -->
-    <div class="diff-switcher">
+         there, jumping between Summary + every resource. On mobile it's the one
+         bar pinned while the header + diff scroll past (see CSS / scroller). -->
+    <div class="diff-switcher" bind:this={switcherEl}>
       <button
         class="btn btn-icon"
         onclick={() => adjacentResource(-1)}
@@ -162,7 +222,7 @@
         <Icon path={mdiChevronRight} size={16} />
       </button>
     </div>
-    <div class="diff-pane" bind:this={pane} onscroll={onScroll}>
+    <div class="diff-pane" bind:this={pane} style="--stuck: {stuckPx}px">
       <section class="diff-section" data-sel="summary">
         <!-- Same sticky container as Diff.svelte's res-header (keep the two in
              step), with a neutral status chip and a quiet title — the Summary

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -803,6 +803,33 @@ test('mobile: back and prev/next share one header row, title below (compact chro
   await expect(page.locator('.kbd-btn:visible')).toHaveCount(0);
 });
 
+test('mobile: the PR header scrolls away and the switcher stays pinned', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await stubApi(page);
+  await page.goto('/#/pr/142');
+  await page.locator('.impact').waitFor();
+
+  // On mobile the whole review column scrolls (not the inner diff pane), so the
+  // header can scroll away and the diff gets the full viewport. The switcher is
+  // the one bar pinned throughout.
+  const review = page.locator('.review');
+  const head = page.locator('.review-head');
+  const switcher = page.locator('.diff-switcher');
+  await expect(switcher).toBeVisible();
+  const headYBefore = (await head.boundingBox())?.y ?? 0;
+
+  await review.evaluate((el) => (el.scrollTop = el.scrollHeight));
+
+  // The scrollspy is wired to .review (not the now-static pane), so scrolling
+  // still drives the selection to the last resource…
+  await expect(page).toHaveURL(/#\/pr\/142\/r2$/);
+  // …the switcher stayed pinned at the top…
+  await expect(switcher).toBeVisible();
+  // …and the header scrolled up out of the way.
+  const headYAfter = (await head.boundingBox())?.y ?? 0;
+  expect(headYAfter).toBeLessThan(headYBefore);
+});
+
 test('captures list + overview screenshots (light)', async ({ page }) => {
   await stubApi(page);
   await page.addInitScript(() => localStorage.setItem('konflate-theme', 'light'));


### PR DESCRIPTION
## What

On mobile, the rendered diff now gets the full screen instead of ~half.

## Why

On a phone the fixed chrome stacked above the diff pane — topbar + the PR
title/meta (which wraps to 2–3 lines) + the merge-command strip + the switcher
— consumed ~45–55% of a short viewport, leaving the diff only about half the
screen to view and scroll.

The flex height-chain was already correct (`min-height: 0` throughout, `100dvh`
on `.app`); the problem was purely how much non-scrolling chrome sat above the
`flex: 1` pane.

## How

On mobile (`≤900px`, where the rail is already hidden and the switcher takes
over) the **whole review column scrolls** instead of the inner diff pane: the PR
header scrolls away under the **sticky switcher** (the one pinned bar), so the
diff gets the full viewport. Desktop is unchanged — the pane stays its own
scroll container there.

- `Diffs.svelte`'s scrollspy, lazy-mount `IntersectionObserver`, and scroll
  listener now key off a `scroller` derived value (the review column on mobile,
  the pane on desktop), re-binding if the breakpoint flips.
- A sticky-switcher offset (`--stuck`, its measured height) keeps jumped-to
  sections landing **below** the switcher and the scrollspy's "crossed the top"
  line in sync (0 on desktop, so that path is untouched).
- A short post-jump **spy lock** stops a mid-reflow reading (lazy-mount /
  `content-visibility` resizing) from fighting a programmatic jump and bouncing
  the selection — the race that first showed up as the switcher cycling back to
  Summary in serial test runs.
- On mobile the per-section `.res-header` is non-sticky (the switcher already
  labels the current resource), so there's no second sticky bar to overlap.

## Test

Adds a mobile Playwright test: after scrolling the review column, the PR header
has scrolled away, the switcher stays pinned, and the scrollspy still drives the
selection to the last resource. Full suite green in **both parallel and serial**
(48 passed, 1 skipped — serial is what surfaced the spy/scroll race), including
the desktop scroll, deep-link, `j`/`k`, and mobile-switcher tests. `svelte-check`
clean. Verified visually at 390×844 (header gone, switcher pinned, diff full).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
