### PR TITLE
fix(engine): adopt flate v0.3.3 Tree API — make clusterPath work

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/coder/websocket v1.8.14
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/google/go-github/v88 v88.0.0
-	github.com/home-operations/flate v0.3.2
+	github.com/home-operations/flate v0.3.3
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus/client_golang v1.23.2
 	gitlab.com/gitlab-org/api/client-go/v2 v2.36.0

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
-github.com/home-operations/flate v0.3.2 h1:r1aldmgW92jb3OSA3PzIDm7xNr5MJ/Y1SbUm8gI3Qn4=
-github.com/home-operations/flate v0.3.2/go.mod h1:eP1vwZoUceCc9LDdeMzLOcnrA+XlwUxdiJLK2z2kNB4=
+github.com/home-operations/flate v0.3.3 h1:B1GhDdEyUlq8TQcx7iDHpV89aDfiwF9H91KAM2BXJyc=
+github.com/home-operations/flate v0.3.3/go.mod h1:eP1vwZoUceCc9LDdeMzLOcnrA+XlwUxdiJLK2z2kNB4=
 github.com/homeport/dyff v1.12.0 h1:1d4T2vdY0hYeWtAxjMLIX9bI8OijBfOuKH3wzfdYZT8=
 github.com/homeport/dyff v1.12.0/go.mod h1:ArdUQcX099hp+uQ7pnimwU0Xgk2ba7E7nqdFv3WBRr8=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -41,7 +41,12 @@ type Engine interface {
 // renders.
 type flateEngine struct {
 	clusterPath string
-	cacheDir    string
+	// selfURLs is the repo's own remote URL(s). flate aliases a
+	// self-referential GitRepository (a cluster that pulls itself) to the
+	// extracted tree only when its spec.url matches one of these — the
+	// trees carry no .git for flate to read remotes from.
+	selfURLs []string
+	cacheDir string
 	// mirror is the persistent bare clone of the repo; each diff fetches the
 	// base/head refs into it incrementally instead of re-cloning.
 	mirror *gitclone.Mirror
@@ -71,6 +76,7 @@ func New(cfg *config.Config) Engine {
 	}
 	return &flateEngine{
 		clusterPath:            cfg.ClusterPath,
+		selfURLs:               []string{cfg.Forge.CloneURL()},
 		cacheDir:               cfg.CacheDir,
 		mirror:                 gitclone.NewMirror(cfg.CacheDir, cfg.CloneDir, cfg.Forge.CloneURL(), cfg.Token),
 		cache:                  source.NewCache(cacheroot.New(cfg.CacheDir)),
@@ -105,9 +111,6 @@ func (e *flateEngine) Diff(ctx context.Context, pr api.PR) (api.DiffResult, erro
 	}
 	defer clone.Cleanup()
 
-	baseTree := joinPath(clone.BaseDir, e.clusterPath)
-	headTree := joinPath(clone.HeadDir, e.clusterPath)
-
 	// flate's RenderTrees owns the two-orchestrator dance: each side
 	// reconciles changed-only against the other (only resources whose source
 	// files differ between the merge-base and head trees, plus the dependency
@@ -115,12 +118,23 @@ func (e *flateEngine) Diff(ctx context.Context, pr api.PR) (api.DiffResult, erro
 	// cost saver), sharing e.cache so the head render reuses the base render's
 	// fetched charts / OCI layers / git sources, concurrently.
 	//
+	// Each side is a Tree of its extracted repo root (RepoRoot — the anchor
+	// repo-root-relative spec.path values resolve against) and the cluster's
+	// Flux entry point within it (Path = root + clusterPath). Passing the root
+	// explicitly is what makes clusterPath work: the trees have no .git, so
+	// flate can't infer the root, and a repo-root-relative spec.path
+	// (./kubernetes/...) would otherwise double under the entry-point subdir.
+	// selfURLs lets a self-referential GitRepository alias to the tree.
+	//
 	// Per flate's contract the returned err is advisory: a side's Result is nil
 	// only on a fatal Bootstrap error, whereas per-resource reconcile failures
 	// keep Result non-nil and ARE the diff's render failures — they must flow to
 	// renderFailures below, not abort the whole diff (a PR that breaks a chart is
 	// exactly the one a reviewer needs to see). renderUsable gates on that.
-	base, head, err := orchestrator.RenderTrees(ctx, baseTree, headTree, e.renderCfg())
+	base, head, err := orchestrator.RenderTrees(ctx,
+		orchestrator.Tree{RepoRoot: clone.BaseDir, Path: joinPath(clone.BaseDir, e.clusterPath), SelfURLs: e.selfURLs},
+		orchestrator.Tree{RepoRoot: clone.HeadDir, Path: joinPath(clone.HeadDir, e.clusterPath), SelfURLs: e.selfURLs},
+		e.renderCfg())
 	if !renderUsable(base, head, err) {
 		return api.DiffResult{}, fmt.Errorf("engine: render PR #%d: %w", pr.Number, err)
 	}
@@ -153,8 +167,9 @@ func renderUsable(base, head orchestrator.Rendered, err error) bool {
 }
 
 // renderCfg is the flate render tuning shared by both sides of a
-// RenderTrees comparison (Path/PathOrig are set by RenderTrees). Two flags
-// harden it for a tool that may be exposed:
+// RenderTrees comparison (Path / RepoRoot / PathOrig / SelfURLs are set
+// from the per-side Tree). Two flags harden it for a tool that may be
+// exposed:
 //   - WipeSecrets replaces Secret cleartext with placeholders, so no secret
 //     value can reach the diff (and thus a response) even if a manifest
 //     carries one in cleartext.


### PR DESCRIPTION
## The bug

Setting `KONFLATE_CLUSTER_PATH` broke renders. konflate extracts the PR's trees with **no `.git`**, then handed flate the joined `clusterPath` subdir. flate (pre-v0.3.3) inferred its repo-root anchor by walking up to `.git`; with none, the anchor collapsed to that subdir, so a repo-root-relative Kustomization `spec.path` (`./kubernetes/...`, the `cluster-template` convention) doubled into a nonexistent dir — and changed-only detection over the subdir missed edits living outside it (`kubernetes/apps/...`). Net: empty / "no changes detected".

## The fix

flate **v0.3.3** ([flate#614](https://github.com/home-operations/flate/pull/614)) reworks its path model around an **explicit source root**. `RenderTrees` now takes per-side `Tree{RepoRoot, Path, SelfURLs}`. This adopts it:

- `RepoRoot` = the extracted repo root (`clone.BaseDir` / `HeadDir`) — what `spec.path` resolves against.
- `Path` = the cluster's Flux entry point within it (`root` + `clusterPath`) — the scan scope.
- `SelfURLs` = the repo's clone URL — so a self-referential GitRepository (a cluster that pulls itself) aliases to the extracted tree (it has no `.git/config` for flate to read remotes from — a second latent bug this closes).

`clusterPath` now correctly scopes the scan while `spec.path` anchors at the repo root. No `.git`, no synthetic marker.

## Verification

- `go build` / `go vet` / `go test ./...` / `golangci-lint` all green; flate dep bumped v0.3.2 → v0.3.3.
- flate's `RenderTrees` regression (`TestRenderTrees_RepoRootRelativeNoGit`: no `.git`, entry-point subdir, repo-root-relative `spec.path` → change detected + rendered + diffed) covers the exact `Tree{RepoRoot, Path}` shape this passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)