### PR TITLE
ci: regenerate chart docs in renovate postUpgrade tasks

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -2,6 +2,18 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["local>home-operations/renovate-config"],
   postUpdateOptions: ["gomodTidy", "gomodUpdateImportPaths"],
+  // Regenerate the chart's committed docs after an upgrade so a value bump
+  // doesn't leave README.md / values.schema.json stale and fail generate-check.
+  // Runs the helm-docs + helm-schema binaries shipped in the Renovate container
+  // (mirrors `mise run generate`).
+  postUpgradeTasks: {
+    commands: [
+      "helm-docs --chart-search-root=charts --log-level=warn",
+      "helm-schema --chart-search-root charts/konflate --skip-auto-generation required,additionalProperties --append-newline",
+    ],
+    fileFilters: ["charts/konflate/README.md", "charts/konflate/values.schema.json"],
+    executionMode: "branch",
+  },
   packageRules: [
     {
       description: "Go Toolchain Group",


### PR DESCRIPTION
Adds a Renovate `postUpgradeTask` that regenerates the chart's committed `README.md` + `values.schema.json` after an upgrade, so a Renovate bump to a charted value can't leave them stale and fail the `generate-check` (Lint) gate — the failure seen in #63.

Runs `helm-docs` + `helm-schema` directly (binaries ship in the Renovate container, [home-operations/.github#14](https://github.com/home-operations/.github/pull/14); allowlisted in [#15](https://github.com/home-operations/.github/pull/15)) and commits via `fileFilters`. Mirrors `mise run generate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
