### PR TITLE
fix(chart): pin the helm-test image as tag@digest so renovate updates both

### DIFF
--- a/charts/konflate/README.md
+++ b/charts/konflate/README.md
@@ -118,10 +118,9 @@ Kubernetes: `>=1.25.0-0`
 | serviceAccount.automount | bool | `false` | Automount the ServiceAccount API token (off by default: konflate talks to forges, not the cluster API). |
 | serviceAccount.create | bool | `true` | Create a ServiceAccount. |
 | serviceAccount.name | string | `""` | ServiceAccount name; generated from the release name if empty. |
-| tests.image.digest | string | `"sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028"` | `helm test` image digest (sha256:…); pins immutably and wins over the tag when set. |
 | tests.image.pullPolicy | string | `"IfNotPresent"` | `helm test` image pull policy. |
 | tests.image.repository | string | `"mirror.gcr.io/busybox"` | `helm test` pod image; needs a shell with wget (konflate's own image is distroless). |
-| tests.image.tag | string | `"1.37.0"` | `helm test` image tag. |
+| tests.image.tag | string | `"1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028"` | `helm test` image, pinned as `tag@sha256:digest` so Renovate bumps the tag and its digest together. |
 | tolerations | list | `[]` | Tolerations for pod scheduling. |
 | volumeMounts | list | `[]` | Additional volume mounts on the container. |
 | volumes | list | `[]` | Additional volumes on the Deployment. |

--- a/charts/konflate/templates/_helpers.tpl
+++ b/charts/konflate/templates/_helpers.tpl
@@ -74,15 +74,12 @@ repository:tag, with tag defaulting to the chart appVersion.
 
 {{/*
 Image for the `helm test` connection pod (konflate's own image is distroless, so
-the test uses a small image with a shell). A digest wins over the tag when set.
+the test uses a small image with a shell). The tag is pinned as
+`version@sha256:digest`, so Renovate updates the version and digest together.
 */}}
 {{- define "konflate.testImage" -}}
 {{- $img := .Values.tests.image -}}
-{{- if $img.digest -}}
-{{- printf "%s@%s" $img.repository $img.digest -}}
-{{- else -}}
 {{- printf "%s:%s" $img.repository $img.tag -}}
-{{- end -}}
 {{- end }}
 
 {{/*

--- a/charts/konflate/tests/test-connection_test.yaml
+++ b/charts/konflate/tests/test-connection_test.yaml
@@ -4,7 +4,7 @@ templates:
 set:
   config.repo: github://owner/repo
 tests:
-  - it: is a hardened helm test Pod that probes /readyz with the pinned busybox
+  - it: is a hardened helm test Pod that probes /readyz with the tag+digest-pinned busybox
     asserts:
       - isKind:
           of: Pod
@@ -13,7 +13,7 @@ tests:
           value: test
       - matchRegex:
           path: spec.containers[0].image
-          pattern: busybox@sha256:[0-9a-f]{64}$
+          pattern: busybox:.+@sha256:[0-9a-f]{64}$
       - equal:
           path: spec.securityContext.runAsNonRoot
           value: true

--- a/charts/konflate/values.schema.json
+++ b/charts/konflate/values.schema.json
@@ -745,12 +745,6 @@
       "properties": {
         "image": {
           "properties": {
-            "digest": {
-              "default": "sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028",
-              "description": "`helm test` image digest (sha256:…); pins immutably and wins over the tag when set.",
-              "title": "digest",
-              "type": "string"
-            },
             "pullPolicy": {
               "default": "IfNotPresent",
               "description": "`helm test` image pull policy.",
@@ -764,8 +758,8 @@
               "type": "string"
             },
             "tag": {
-              "default": "1.37.0",
-              "description": "`helm test` image tag.",
+              "default": "1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028",
+              "description": "`helm test` image, pinned as `tag",
               "title": "tag",
               "type": "string"
             }

--- a/charts/konflate/values.yaml
+++ b/charts/konflate/values.yaml
@@ -301,9 +301,7 @@ tests:
   image:
     # -- `helm test` pod image; needs a shell with wget (konflate's own image is distroless).
     repository: mirror.gcr.io/busybox
-    # -- `helm test` image tag.
-    tag: "1.37.0"
-    # -- `helm test` image digest (sha256:…); pins immutably and wins over the tag when set.
-    digest: "sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028"
+    # -- `helm test` image, pinned as `tag@sha256:digest` so Renovate bumps the tag and its digest together.
+    tag: "1.37.0@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028"
     # -- `helm test` image pull policy.
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Fixes Renovate bumping the `helm test` busybox **tag** but not its **digest** (and since the chart made the digest win over the tag, the bump was silently inert — the pod kept running the old image). Same root cause as the stale-docs issue around #63.

## Change

Collapse the test image's separate `tag` + `digest` values into a single pinned reference:

```yaml
tests:
  image:
    repository: mirror.gcr.io/busybox
    tag: "1.37.0@sha256:9532…"   # was: tag + a separate digest field
```

Renovate's `helm-values` manager treats a `version@sha256:…` tag as one docker dependency and updates the version **and** digest together. `konflate.testImage` is simplified to `repository:tag`, and the unit-test assertion + generated docs are updated to match.

## Verified

- `helm template` renders `mirror.gcr.io/busybox:1.37.0@sha256:…` (valid combined ref).
- `helm unittest` 16/16; `mise run generate` idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
