### PR TITLE
fix: render fork PR heads via the forge pull ref

### DIFF
--- a/internal/config/forge.go
+++ b/internal/config/forge.go
@@ -54,6 +54,20 @@ type ForgeURI struct {
 // CloneURL returns the HTTPS URL for git-cloning the repository.
 func (f ForgeURI) CloneURL() string { return f.WebBase + "/" + f.RepoPath }
 
+// PullHeadRef returns the server-side ref in the BASE repository that points at
+// the head commit of pull/merge request number n. The base repo publishes this
+// ref for every request — including cross-repo (fork) ones, whose head branch
+// lives in the contributor's repo and so is absent from the base repo's
+// refs/heads — so fetching it resolves fork and same-repo PRs alike. GitHub and
+// Forgejo/Gitea expose refs/pull/<n>/head; GitLab exposes
+// refs/merge-requests/<n>/head.
+func (f ForgeURI) PullHeadRef(n int) string {
+	if f.Kind == ForgeGitLab {
+		return fmt.Sprintf("refs/merge-requests/%d/head", n)
+	}
+	return fmt.Sprintf("refs/pull/%d/head", n)
+}
+
 // ParseForgeURI parses raw into a ForgeURI.
 //
 // Go's url.Parse places everything between // and the first / into the host

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -50,6 +50,11 @@ type flateEngine struct {
 	// mirror is the persistent bare clone of the repo; each diff fetches the
 	// base/head refs into it incrementally instead of re-cloning.
 	mirror *gitclone.Mirror
+	// pullHeadRef maps a PR number to the forge's server-side pull head ref
+	// (refs/pull/N/head; refs/merge-requests/N/head on GitLab). The mirror fetches
+	// the head from this ref rather than the head branch, so cross-repo (fork) PRs
+	// — whose branch lives in the contributor's repo — still resolve.
+	pullHeadRef func(number int) string
 	// cache is shared across every diff for this repo instance and, within a
 	// single diff, across the base and head renders — so the head render reuses
 	// the Helm charts / OCI layers / git sources the base render already
@@ -79,6 +84,7 @@ func New(cfg *config.Config) Engine {
 		selfURLs:               []string{cfg.Forge.CloneURL()},
 		cacheDir:               cfg.CacheDir,
 		mirror:                 gitclone.NewMirror(cfg.CacheDir, cfg.CloneDir, cfg.Forge.CloneURL(), cfg.Token),
+		pullHeadRef:            cfg.Forge.PullHeadRef,
 		cache:                  source.NewCache(cacheroot.New(cfg.CacheDir)),
 		stageCacheBytes:        int64(cfg.StageCacheMB) * mib,
 		helmTemplateCacheBytes: int64(cfg.HelmTemplateCacheMB) * mib,
@@ -105,7 +111,7 @@ func (e *flateEngine) Diff(ctx context.Context, pr api.PR) (api.DiffResult, erro
 		defer cancel()
 	}
 
-	clone, err := e.mirror.Trees(ctx, pr.HeadRef, pr.BaseRef)
+	clone, err := e.mirror.Trees(ctx, e.pullHeadRef(pr.Number), pr.BaseRef)
 	if err != nil {
 		return api.DiffResult{}, fmt.Errorf("engine: clone PR #%d: %w", pr.Number, err)
 	}

--- a/internal/gitclone/gitclone.go
+++ b/internal/gitclone/gitclone.go
@@ -26,10 +26,18 @@ import (
 )
 
 // ErrHeadRefGone reports that the PR's head ref no longer exists on the remote —
-// typically the PR was merged or closed and its branch deleted between when a
-// render was enqueued and when it ran. Callers treat this as "the PR left the
-// open set", not a render failure.
+// the pull/merge request was deleted, so the forge dropped its head ref. Callers
+// treat this as "the PR left the open set", not a render failure. (A merge or
+// close alone no longer trips this: the forge keeps refs/pull/N/head after merge,
+// and such PRs are reconciled off the open set by the periodic refresh instead.)
 var ErrHeadRefGone = errors.New("gitclone: head ref no longer exists on remote")
+
+// localHeadRef is the mirror-local ref the PR head is fetched into. The head is
+// taken from the forge's pull head ref (refs/pull/N/head), which isn't a branch,
+// so it's mapped into this private namespace rather than refs/heads. Fetches are
+// serialized under Mirror.mu, and each render resolves its head commit before
+// releasing the lock, so one shared local ref is safe.
+const localHeadRef = "refs/konflate/pull-head"
 
 // Result holds the two extracted working trees plus a cleanup func that
 // removes them. Callers must call Cleanup.
@@ -73,9 +81,11 @@ func NewMirror(cacheDir, cloneDir, cloneURL, token string) *Mirror {
 	}
 }
 
-// Trees fetches headRef and baseRef into the mirror, computes the merge-base of
+// Trees fetches the PR head and base into the mirror, computes the merge-base of
 // the two (GitHub-style), and extracts the head and merge-base trees to a fresh
-// working directory. headRef/baseRef are branch names. Callers must call
+// working directory. headRef is a full server-side ref — the forge's pull head
+// ref (refs/pull/N/head), which the base repo publishes for fork and same-repo
+// PRs alike — and baseRef is the target branch name. Callers must call
 // Result.Cleanup.
 func (m *Mirror) Trees(ctx context.Context, headRef, baseRef string) (_ *Result, err error) {
 	head, base, err := m.fetch(ctx, headRef, baseRef)
@@ -144,19 +154,23 @@ func (m *Mirror) fetch(ctx context.Context, headRef, baseRef string) (head, base
 
 	// Refresh the base branch (a no-op right after the seeding clone). A missing
 	// base is a real error — the PR targets it.
-	if err := fetchRef(ctx, repo, m.auth, baseRef); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
+	baseFull := "refs/heads/" + baseRef
+	if err := fetchSpec(ctx, repo, m.auth, baseFull, baseFull); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
 		return nil, nil, fmt.Errorf("gitclone: fetch base %q: %w", baseRef, err)
 	}
-	// A missing head ref means the branch was deleted (merged/closed PR) — report
-	// it as gone so the caller reconciles the PR rather than failing the render.
-	if err := fetchRef(ctx, repo, m.auth, headRef); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
+	// headRef is the forge's pull head ref (refs/pull/N/head), which the base repo
+	// publishes for every PR — including forks, whose branch isn't in the base
+	// repo. Fetch it into a private local ref. A missing head ref means the
+	// request was deleted — report it as gone so the caller reconciles the PR
+	// rather than failing the render.
+	if err := fetchSpec(ctx, repo, m.auth, headRef, localHeadRef); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
 		if errors.Is(err, git.NoMatchingRefSpecError{}) {
 			return nil, nil, fmt.Errorf("gitclone: fetch head %q: %w", headRef, ErrHeadRefGone)
 		}
 		return nil, nil, fmt.Errorf("gitclone: fetch head %q: %w", headRef, err)
 	}
 
-	head, err = resolveCommit(repo, headRef)
+	head, err = resolveCommit(repo, localHeadRef)
 	if err != nil {
 		return nil, nil, fmt.Errorf("gitclone: head %q: %w", headRef, err)
 	}
@@ -206,11 +220,12 @@ func (m *Mirror) openOrClone(ctx context.Context, baseRef string) (*git.Reposito
 	return repo, nil
 }
 
-// fetchRef force-fetches a single branch into the mirror's refs/heads, pulling
-// only that branch (no tags). An explicit refspec lets the mirror accumulate
-// any base/head branch a PR needs, regardless of the branch it was seeded with.
-func fetchRef(ctx context.Context, repo *git.Repository, auth *githttp.BasicAuth, ref string) error {
-	spec := gitconfig.RefSpec(fmt.Sprintf("+refs/heads/%s:refs/heads/%s", ref, ref))
+// fetchSpec force-fetches a single remote ref (src) into a local ref (dst),
+// pulling only that ref (no tags). An explicit, forced refspec lets the mirror
+// accumulate any base branch or pull head a PR needs, regardless of the ref it
+// was seeded with, and overwrite a stale local copy after a force-push.
+func fetchSpec(ctx context.Context, repo *git.Repository, auth *githttp.BasicAuth, src, dst string) error {
+	spec := gitconfig.RefSpec(fmt.Sprintf("+%s:%s", src, dst))
 	return repo.FetchContext(ctx, &git.FetchOptions{
 		Auth:     auth,
 		RefSpecs: []gitconfig.RefSpec{spec},

--- a/internal/gitclone/gitclone_test.go
+++ b/internal/gitclone/gitclone_test.go
@@ -136,19 +136,52 @@ func assertMergeBaseTrees(t *testing.T, res *Result) {
 	}
 }
 
-// TestMirror_HeadRefGone verifies that a head ref the remote no longer advertises
-// (the PR's branch was deleted after a merge) surfaces as ErrHeadRefGone, so the
-// server can reconcile the PR instead of recording a render failure.
+// TestMirror_HeadRefGone verifies that a pull head ref the remote no longer
+// advertises (the request was deleted) surfaces as ErrHeadRefGone, so the server
+// can reconcile the PR instead of recording a render failure.
 func TestMirror_HeadRefGone(t *testing.T) {
 	t.Parallel()
 	src := buildRepo(t)
 
-	// "master" (the base) exists; "feature" was deleted; fetching it must report
-	// the ref as gone rather than an opaque error.
-	_, err := newTestMirror(t, src).Trees(context.Background(), "deleted-after-merge", "master")
+	// "master" (the base) exists; pull request 999 does not, so its head ref is
+	// absent — fetching it must report the ref as gone rather than an opaque error.
+	_, err := newTestMirror(t, src).Trees(context.Background(), "refs/pull/999/head", "master")
 	if !errors.Is(err, ErrHeadRefGone) {
 		t.Fatalf("Trees with a missing head ref: got %v, want ErrHeadRefGone", err)
 	}
+}
+
+// TestMirror_ForkPullHead verifies the head is fetched via the forge's pull head
+// ref (refs/pull/N/head) — the ref the base repo publishes for a cross-repo
+// (fork) PR, whose branch never lands in the base repo's refs/heads — so such
+// PRs still render.
+func TestMirror_ForkPullHead(t *testing.T) {
+	t.Parallel()
+	src := buildRepo(t)
+
+	// Publish the head at refs/pull/1/head (as a forge does for a fork PR) and
+	// delete refs/heads/feature, so the pull ref is the only way to reach the head.
+	repo, err := git.PlainOpen(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	feat, err := repo.Reference(plumbing.NewBranchReferenceName("feature"), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Storer.SetReference(plumbing.NewHashReference("refs/pull/1/head", feat.Hash())); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Storer.RemoveReference(plumbing.NewBranchReferenceName("feature")); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := newTestMirror(t, src).Trees(context.Background(), "refs/pull/1/head", "master")
+	if err != nil {
+		t.Fatalf("Trees via pull head ref: %v", err)
+	}
+	defer res.Cleanup()
+	assertMergeBaseTrees(t, res)
 }
 
 func TestMirror_MergeBaseTrees(t *testing.T) {
@@ -156,7 +189,7 @@ func TestMirror_MergeBaseTrees(t *testing.T) {
 	src := buildRepo(t)
 
 	// the default branch from PlainInit is "master"
-	res, err := newTestMirror(t, src).Trees(context.Background(), "feature", "master")
+	res, err := newTestMirror(t, src).Trees(context.Background(), "refs/heads/feature", "master")
 	if err != nil {
 		t.Fatalf("Trees: %v", err)
 	}
@@ -172,7 +205,7 @@ func TestMirror_Reuse(t *testing.T) {
 	src := buildRepo(t)
 	m := newTestMirror(t, src)
 
-	first, err := m.Trees(context.Background(), "feature", "master")
+	first, err := m.Trees(context.Background(), "refs/heads/feature", "master")
 	if err != nil {
 		t.Fatalf("Trees (first): %v", err)
 	}
@@ -181,7 +214,7 @@ func TestMirror_Reuse(t *testing.T) {
 		t.Fatalf("mirror bare repo not present after first render: %v", err)
 	}
 
-	second, err := m.Trees(context.Background(), "feature", "master")
+	second, err := m.Trees(context.Background(), "refs/heads/feature", "master")
 	if err != nil {
 		t.Fatalf("Trees (reuse): %v", err)
 	}
@@ -206,7 +239,7 @@ func TestMirror_Concurrent(t *testing.T) {
 	errs := make([]error, n)
 	for i := range n {
 		wg.Go(func() {
-			res, err := m.Trees(context.Background(), "feature", "master")
+			res, err := m.Trees(context.Background(), "refs/heads/feature", "master")
 			if err != nil {
 				errs[i] = err
 				return
@@ -255,7 +288,7 @@ func TestMirror_SkipsOversizedFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := newTestMirror(t, src).Trees(context.Background(), "feature", "master")
+	res, err := newTestMirror(t, src).Trees(context.Background(), "refs/heads/feature", "master")
 	if err != nil {
 		t.Fatalf("Trees: %v", err)
 	}


### PR DESCRIPTION
## The bug

External (fork) PRs sat in **rendering** forever:

```
queuing render pr=11011 reason=webhook
diff skipped: PR head ref gone (merged/closed mid-render) pr=11011
```

The mirror fetched the PR head from `refs/heads/<branch>` in the **base** repo. A cross-repo PR's branch lives in the contributor's fork, so the base repo has no such ref → the fetch matched nothing → `ErrHeadRefGone` → konflate treated an *open* PR as merged/closed and skipped the render, leaving the UI stuck. (Repro: [onedr0p/home-ops#11011](https://github.com/onedr0p/home-ops/pull/11011).)

## The fix

Fetch the head from the forge's **pull head ref** — `refs/pull/N/head` (`refs/merge-requests/N/head` on GitLab) — which the base repo publishes for *every* PR, fork or not, into a private local mirror ref.

- `config`: add `ForgeURI.PullHeadRef(n)`.
- `engine`: thread it in via a `pullHeadRef` field → `mirror.Trees(ctx, pullHeadRef, baseRef)`.
- `gitclone`: `Trees`/`fetch` take the head as a full server ref; generalized `fetchSpec(src, dst)`.

`ErrHeadRefGone` now means the request itself was deleted (its pull head ref dropped). A plain merge/close keeps `refs/pull/N/head`, and those PRs are reconciled off the open set by the periodic refresh — the same mechanism that was already the primary path.

## Tests

- New `TestMirror_ForkPullHead`: publishes the head only at `refs/pull/1/head`, deletes `refs/heads/feature`, and asserts the diff still renders.
- Existing tests updated to pass full head refs; `HeadRefGone` now exercises an absent `refs/pull/999/head`.
- `go build ./...`, `go vet ./...`, full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
