### PR TITLE
feat: gate rendering of fork PRs behind KONFLATE_RENDER_FORK_PRS

### DIFF
--- a/charts/konflate/README.md
+++ b/charts/konflate/README.md
@@ -58,6 +58,7 @@ Kubernetes: `>=1.25.0-0`
 | config.mergeCommand | string | `""` | Optional Go text/template for the copy-to-merge command (only .Number / .Repo). Empty = forge default (gh/glab/tea). konflate never runs it. |
 | config.refreshInterval | string | `"30m"` | How often each open PR re-renders / the PR list reconciles, as a missed-webhook backstop (Go duration). |
 | config.renderConcurrency | string | `""` | Advanced: cap on reconcile goroutines within one render. Empty/"0" = auto (NumCPU*4). |
+| config.renderForkPrs | bool | `false` | Render pull requests from forks. Forks are untrusted external code (SSRF / resource-exhaustion surface), so this is off by default; leave false on public instances. |
 | config.repo | required | `""` | Forge URI of the repository to review (github://owner/repo, gitlab://group/repo, forgejo://host/owner/repo). |
 | config.sourceRetryAttempts | string | `""` | Advanced: tries per source fetch on transient network errors. Empty = default (3); "1" disables retry. |
 | config.stageCacheMb | string | `""` | Advanced: persistent kustomize stage cache in MiB. Empty = default (2048); "0" disables size-based eviction. |

--- a/charts/konflate/templates/deployment.tpl
+++ b/charts/konflate/templates/deployment.tpl
@@ -61,6 +61,10 @@ spec:
             - name: KONFLATE_MAX_DIFF_CONC
               value: {{ .Values.config.maxDiffConcurrency | quote }}
             {{- end }}
+            # Always emitted so the (security-relevant) fork-render posture is
+            # explicit in the rendered manifest, not implied by a default.
+            - name: KONFLATE_RENDER_FORK_PRS
+              value: {{ .Values.config.renderForkPrs | quote }}
             {{- /* toString, not `with`: an explicit 0 (disable a cache) must
                    still emit — `with` would treat int 0 as empty and drop it,
                    silently reviving the default. Empty string = use the default.

--- a/charts/konflate/tests/deployment_test.yaml
+++ b/charts/konflate/tests/deployment_test.yaml
@@ -80,3 +80,21 @@ tests:
       - equal:
           path: spec.template.spec.automountServiceAccountToken
           value: false
+
+  - it: gates fork PRs off by default (KONFLATE_RENDER_FORK_PRS=false)
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KONFLATE_RENDER_FORK_PRS
+            value: "false"
+
+  - it: opts into rendering fork PRs when renderForkPrs is true
+    set:
+      config.renderForkPrs: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KONFLATE_RENDER_FORK_PRS
+            value: "true"

--- a/charts/konflate/values.schema.json
+++ b/charts/konflate/values.schema.json
@@ -90,6 +90,12 @@
           "title": "renderConcurrency",
           "type": "string"
         },
+        "renderForkPrs": {
+          "default": false,
+          "description": "Render pull requests from forks. Forks are untrusted external code (SSRF / resource-exhaustion surface), so this is off by default; leave false on public instances.",
+          "title": "renderForkPrs",
+          "type": "boolean"
+        },
         "repo": {
           "default": "",
           "description": "(required) Forge URI of the repository to review (github://owner/repo, gitlab://group/repo, forgejo://host/owner/repo).",

--- a/charts/konflate/values.yaml
+++ b/charts/konflate/values.yaml
@@ -65,6 +65,15 @@ config:
 
   # -- Max concurrent diff renders; 0 = auto (from the CPU limit, capped at 4).
   maxDiffConcurrency: 0
+  # KONFLATE_RENDER_FORK_PRS — render pull requests from forks (cross-repo, whose
+  # head branch lives in a contributor's repository). These are untrusted
+  # external code: rendering runs their manifests through flate, which fetches
+  # the sources they declare (SSRF, resource exhaustion). Off by default — fork
+  # PRs are listed but shown as "not rendered" until you opt in. Keep this false
+  # on any public/shared instance.
+
+  # -- Render pull requests from forks. Forks are untrusted external code (SSRF / resource-exhaustion surface), so this is off by default; leave false on public instances.
+  renderForkPrs: false
   # --- flate render tuning (advanced) ---------------------------------------
   # Caps for flate's caches plus its fetch behavior. The defaults (shown) match
   # flate's own CLI and suit most setups — leave these empty to use them. The

--- a/internal/api/pr.go
+++ b/internal/api/pr.go
@@ -22,8 +22,12 @@ type PR struct {
 	HeadRef   string    `json:"headRef"` // PR head branch
 	HeadSHA   string    `json:"headSha"` // head commit SHA
 	BaseRef   string    `json:"baseRef"` // target branch
-	Labels    []Label   `json:"labels"`
-	URL       string    `json:"url"`
+	// Fork is true when the head is in a different repository than the base (a
+	// cross-repo / fork PR) — an untrusted external contribution. Rendering of
+	// these is gated on KONFLATE_RENDER_FORK_PRS.
+	Fork   bool    `json:"fork"`
+	Labels []Label `json:"labels"`
+	URL    string  `json:"url"`
 }
 
 // Label is a forge label with its display color (a hex string without '#'; may

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -10,6 +10,10 @@ const (
 	JobRunning JobStatus = "running" // a worker is rendering it
 	JobReady   JobStatus = "ready"   // Diff is populated
 	JobError   JobStatus = "error"   // Error is populated
+	// JobBlocked: not rendered by policy — currently a fork (cross-repo) PR while
+	// KONFLATE_RENDER_FORK_PRS is off. The PR is listed but its untrusted content
+	// is never fetched or rendered.
+	JobBlocked JobStatus = "blocked"
 )
 
 // PRStatus is one pull request plus the state of its diff job. It is the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,15 @@ type Config struct {
 	// once read (see Token).
 	PushToken string `env:"KONFLATE_PUSH_TOKEN,unset"`
 
+	// RenderForkPRs controls whether pull requests from FORKS (cross-repo, whose
+	// head branch lives in a contributor's repository) are rendered. Rendering
+	// runs the PR's manifests/charts through flate, which fetches the sources they
+	// declare — so a fork PR is untrusted external code with real attack surface
+	// (SSRF via attacker-chosen source URLs, resource exhaustion). Off by default:
+	// fork PRs are listed but shown as "not rendered (fork)" until an operator
+	// opts in. Same-repo PRs (the maintainers' own branches) always render.
+	RenderForkPRs bool `env:"KONFLATE_RENDER_FORK_PRS" envDefault:"false"`
+
 	// Port is the main HTTP server listen port (UI, API, /ws, /hooks).
 	Port int `env:"KONFLATE_PORT" envDefault:"8080"`
 

--- a/internal/provider/forgejo.go
+++ b/internal/provider/forgejo.go
@@ -98,5 +98,9 @@ func forgejoToPR(pr *forgejo.PullRequest) api.PR {
 	if pr.Base != nil {
 		out.BaseRef = pr.Base.Ref
 	}
+	// Cross-repo (fork) when the head and base point at different repositories.
+	if pr.Head != nil && pr.Base != nil {
+		out.Fork = pr.Head.RepoID != pr.Base.RepoID
+	}
 	return out
 }

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -76,7 +76,10 @@ func githubToPR(pr *github.PullRequest) api.PR {
 		HeadRef:      pr.GetHead().GetRef(),
 		HeadSHA:      pr.GetHead().GetSHA(),
 		BaseRef:      pr.GetBase().GetRef(),
-		Labels:       labels,
-		URL:          pr.GetHTMLURL(),
+		// Cross-repo when the head repo differs from the base repo. A nil/deleted
+		// head repo yields "" != base, i.e. treated as a fork (fail safe).
+		Fork:   pr.GetHead().GetRepo().GetFullName() != pr.GetBase().GetRepo().GetFullName(),
+		Labels: labels,
+		URL:    pr.GetHTMLURL(),
 	}
 }

--- a/internal/provider/gitlab.go
+++ b/internal/provider/gitlab.go
@@ -82,7 +82,9 @@ func gitlabToPR(mr *gitlab.BasicMergeRequest) api.PR {
 		HeadRef:      mr.SourceBranch,
 		HeadSHA:      mr.SHA,
 		BaseRef:      mr.TargetBranch,
-		Labels:       labels,
-		URL:          mr.WebURL,
+		// Cross-project (fork) when the MR source and target projects differ.
+		Fork:   mr.SourceProjectID != mr.TargetProjectID,
+		Labels: labels,
+		URL:    mr.WebURL,
 	}
 }

--- a/internal/server/queue.go
+++ b/internal/server/queue.go
@@ -42,6 +42,11 @@ type queue struct {
 	sem chan struct{}
 	wg  sync.WaitGroup
 
+	// renderForks gates rendering of fork (cross-repo) PRs. When false (the
+	// default), a fork PR is recorded as JobBlocked and never rendered, so its
+	// untrusted content is never fetched.
+	renderForks bool
+
 	mu       sync.Mutex
 	inflight map[int]struct{}
 	pending  map[int]api.PR
@@ -49,23 +54,32 @@ type queue struct {
 
 func newQueue(
 	ctx context.Context, diff diffFunc, st *store, notify func(api.Event),
-	reconcile func(int), m *metrics, log *slog.Logger, concurrency int,
+	reconcile func(int), m *metrics, log *slog.Logger, concurrency int, renderForks bool,
 ) *queue {
 	if concurrency < 1 {
 		concurrency = 1
 	}
 	return &queue{
 		diff: diff, store: st, notify: notify, reconcile: reconcile, metrics: m, log: log,
-		ctx:      ctx,
-		sem:      make(chan struct{}, concurrency),
-		inflight: map[int]struct{}{},
-		pending:  map[int]api.PR{},
+		ctx:         ctx,
+		sem:         make(chan struct{}, concurrency),
+		inflight:    map[int]struct{}{},
+		pending:     map[int]api.PR{},
+		renderForks: renderForks,
 	}
 }
 
 // enqueue schedules a diff for pr, coalescing with any in-flight job for the
 // same PR number.
 func (q *queue) enqueue(pr api.PR) {
+	// Fork (cross-repo) PRs are untrusted external code. Unless an operator opted
+	// in, record them as blocked and render nothing — the engine never fetches or
+	// renders their content. Same-repo PRs always proceed.
+	if pr.Fork && !q.renderForks {
+		q.store.setStatus(pr, api.JobBlocked)
+		q.emit(pr.Number, api.JobBlocked, "")
+		return
+	}
 	q.mu.Lock()
 	if _, ok := q.inflight[pr.Number]; ok {
 		q.pending[pr.Number] = pr // coalesce; remember the freshest metadata

--- a/internal/server/queue_test.go
+++ b/internal/server/queue_test.go
@@ -44,7 +44,7 @@ func TestQueue_CoalescesRerun(t *testing.T) {
 	}
 
 	st := newStore()
-	q := newQueue(context.Background(), diff, st, nil, nil, newMetrics(), discardLog(), 2)
+	q := newQueue(context.Background(), diff, st, nil, nil, newMetrics(), discardLog(), 2, true)
 	pr := api.PR{Number: 1}
 
 	q.enqueue(pr)
@@ -64,6 +64,52 @@ func TestQueue_CoalescesRerun(t *testing.T) {
 	mu.Unlock()
 	if got != 2 {
 		t.Fatalf("diff called %d times, want exactly 2 (one render + one coalesced re-render)", got)
+	}
+}
+
+// TestQueue_ForkGate verifies fork (cross-repo) PRs are not rendered unless
+// rendering is opted in: with the gate off they are recorded as blocked and the
+// engine is never called; same-repo PRs are unaffected; with the gate on a fork
+// PR renders like any other.
+func TestQueue_ForkGate(t *testing.T) {
+	t.Parallel()
+	var mu sync.Mutex
+	calls := 0
+	diff := func(_ context.Context, pr api.PR) (api.DiffResult, error) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		return api.DiffResult{PRNumber: pr.Number}, nil
+	}
+
+	st := newStore()
+
+	// Gate off: a fork PR is blocked synchronously and never rendered.
+	off := newQueue(context.Background(), diff, st, nil, nil, newMetrics(), discardLog(), 1, false)
+	off.enqueue(api.PR{Number: 1, Open: true, Fork: true})
+	if env, ok := st.get(1); !ok || env.Status != api.JobBlocked {
+		t.Fatalf("fork PR with gate off: status=%q ok=%v, want %q", env.Status, ok, api.JobBlocked)
+	}
+	mu.Lock()
+	zero := calls
+	mu.Unlock()
+	if zero != 0 {
+		t.Fatalf("fork PR was rendered despite the gate (%d calls)", zero)
+	}
+
+	// A same-repo PR is unaffected by the gate.
+	off.enqueue(api.PR{Number: 2, Open: true})
+	waitTerminal(t, st, 2)
+
+	// Gate on: the fork PR renders.
+	on := newQueue(context.Background(), diff, st, nil, nil, newMetrics(), discardLog(), 1, true)
+	on.enqueue(api.PR{Number: 3, Open: true, Fork: true})
+	waitTerminal(t, st, 3)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 2 {
+		t.Fatalf("rendered %d PRs, want 2 (same-repo + opted-in fork)", calls)
 	}
 }
 
@@ -87,7 +133,7 @@ func TestQueue_CoalesceUsesLatestMetadata(t *testing.T) {
 	}
 
 	st := newStore()
-	q := newQueue(context.Background(), diff, st, nil, nil, newMetrics(), discardLog(), 1)
+	q := newQueue(context.Background(), diff, st, nil, nil, newMetrics(), discardLog(), 1, true)
 
 	q.enqueue(api.PR{Number: 1, HeadSHA: "old"})
 	<-started // "old" is rendering
@@ -118,7 +164,7 @@ func TestQueue_RecoversRenderPanic(t *testing.T) {
 	t.Parallel()
 	diff := func(context.Context, api.PR) (api.DiffResult, error) { panic("boom") }
 	st := newStore()
-	q := newQueue(context.Background(), diff, st, nil, nil, newMetrics(), discardLog(), 1)
+	q := newQueue(context.Background(), diff, st, nil, nil, newMetrics(), discardLog(), 1, true)
 
 	st.upsertPR(api.PR{Number: 1})
 	q.enqueue(api.PR{Number: 1})
@@ -142,7 +188,7 @@ func TestQueue_HeadRefGoneReconcilesNotErrors(t *testing.T) {
 	st := newStore()
 	st.upsertPR(api.PR{Number: 1})
 	st.setResult(1, api.DiffResult{PRNumber: 1}) // a diff from when the PR was open
-	q := newQueue(context.Background(), diff, st, nil, func(n int) { reconciled <- n }, newMetrics(), discardLog(), 1)
+	q := newQueue(context.Background(), diff, st, nil, func(n int) { reconciled <- n }, newMetrics(), discardLog(), 1, true)
 
 	q.enqueue(api.PR{Number: 1})
 
@@ -177,7 +223,7 @@ func TestQueue_RunsConcurrently(t *testing.T) {
 	}
 
 	st := newStore()
-	q := newQueue(context.Background(), diff, st, nil, nil, newMetrics(), discardLog(), 2)
+	q := newQueue(context.Background(), diff, st, nil, nil, newMetrics(), discardLog(), 2, true)
 
 	q.enqueue(api.PR{Number: 1})
 	q.enqueue(api.PR{Number: 2})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -73,7 +73,10 @@ func New(cfg *config.Config, prov provider.Provider, eng Engine, ui fs.FS, log *
 // signal-triggered shutdown.
 func (s *Server) Run(ctx context.Context) error {
 	s.runCtx = ctx
-	s.queue = newQueue(ctx, s.engine.Diff, s.store, s.hub.broadcast, s.reconcileHeadGone, s.metrics, s.log, s.cfg.MaxDiffConcurrency)
+	s.queue = newQueue(
+		ctx, s.engine.Diff, s.store, s.hub.broadcast, s.reconcileHeadGone,
+		s.metrics, s.log, s.cfg.MaxDiffConcurrency, s.cfg.RenderForkPRs,
+	)
 
 	mainSrv := &http.Server{
 		Addr:              fmt.Sprintf(":%d", s.cfg.Port),

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -105,7 +105,7 @@ func newTestServer(t *testing.T, cfg *config.Config, prov *fakeProvider, eng Eng
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	s.runCtx = ctx
-	s.queue = newQueue(ctx, s.engine.Diff, s.store, s.hub.broadcast, s.reconcileHeadGone, s.metrics, s.log, cfg.MaxDiffConcurrency)
+	s.queue = newQueue(ctx, s.engine.Diff, s.store, s.hub.broadcast, s.reconcileHeadGone, s.metrics, s.log, cfg.MaxDiffConcurrency, cfg.RenderForkPRs)
 	return s
 }
 

--- a/internal/web/src/lib/List.svelte
+++ b/internal/web/src/lib/List.svelte
@@ -90,7 +90,7 @@
 
   // pending/running render as icons below and ready carries signal badges, so
   // this fallback only labels the terminal error state.
-  const statusLabel: Record<string, string> = { error: 'failed' };
+  const statusLabel: Record<string, string> = { error: 'failed', blocked: 'fork · not rendered' };
 
   // A '#'-prefixed color for a label dot, or '' when the forge gave no usable
   // hex (e.g. GitLab) — validated so a stray value can't reach the style binding.

--- a/internal/web/src/lib/Review.svelte
+++ b/internal/web/src/lib/Review.svelte
@@ -12,6 +12,7 @@
     mdiOpenInNew,
     mdiSourceMerge,
     mdiSourcePull,
+    mdiSourceFork,
     mdiTrayFull,
     mdiClockOutline,
     mdiRefresh,
@@ -91,7 +92,12 @@
     {/if}
 
     <div class="review-body">
-      {#if store.diffError}
+      {#if pr?.status === 'blocked'}
+        <div class="loading-center">
+          <Icon path={mdiSourceFork} size={38} />
+          <p>This PR is from a fork. Rendering of external contributions is disabled on this instance.</p>
+        </div>
+      {:else if store.diffError}
         <p class="error-box">{store.diffError}</p>
       {:else if store.diff}
         <Diffs />

--- a/internal/web/src/lib/icons.ts
+++ b/internal/web/src/lib/icons.ts
@@ -37,6 +37,7 @@ export {
   mdiSortDescending,
   mdiSourceBranch,
   mdiSourcePull,
+  mdiSourceFork,
   mdiFilterOutline,
   mdiTrayFull,
   mdiUnfoldMoreHorizontal,

--- a/internal/web/src/lib/types.ts
+++ b/internal/web/src/lib/types.ts
@@ -1,7 +1,7 @@
 // Mirrors internal/api (pr.go, response.go, diff.go). The Go package doc notes
 // these types are the contract.
 
-export type JobStatus = 'pending' | 'running' | 'ready' | 'error';
+export type JobStatus = 'pending' | 'running' | 'ready' | 'error' | 'blocked';
 
 export interface Label {
   name: string;


### PR DESCRIPTION
## Why

konflate now renders PR heads via the forge pull ref (#72), so pull requests **from forks** — cross-repo contributions whose head branch lives in an outside contributor's repository — are rendered too. That is untrusted external code: rendering runs the PR's manifests/charts through `flate`, which **fetches the sources they declare**. A fork PR is real attack surface — SSRF via attacker-chosen source URLs, resource exhaustion — reachable by anyone who can open a PR against the repo.

This is the primary mitigation from the fork-PR security review: untrusted input doesn't render by default.

## What

- **`KONFLATE_RENDER_FORK_PRS`** config knob (default **`false`**). Off by default, fork PRs are listed but never fetched or rendered; an operator opts in explicitly.
- **Fork detection** in every provider: GitHub head/base repo full name, GitLab source/target project id, Forgejo head/base repo id. A nil/deleted head repo fails safe (treated as a fork).
- **New `blocked` job status.** A gated fork PR is recorded as `blocked` synchronously in `enqueue` — the engine's `Diff` is never called, so nothing is fetched or cloned.
- **UI:** the list shows `fork · not rendered`; the review pane shows an explanatory panel instead of a diff.
- Same-repo PRs (the maintainers' own branches) are unaffected and always render.

## Test plan

- `TestQueue_ForkGate`: gate off → fork PR is `blocked` and the engine is never called; same-repo PR still renders; gate on → fork PR renders.
- `mise run test` (Go), `mise run lint`, `go vet`, `mise run ui-typecheck`, `mise run ui-build`, `mise run ui-test` all green locally.

> The NetworkPolicy / egress-control hardening is intentionally out of scope here and tracked separately; this PR is the default-safe gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)