### PR TITLE
feat(ui): risk-first list triage — clean/images filters + clean flag

### DIFF
--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -738,6 +738,21 @@ button.sum-pill:hover {
 .sum-pill.merged strong {
   color: var(--merged);
 }
+.sum-pill.ok {
+  color: var(--ok);
+  border-color: color-mix(in srgb, var(--ok) 40%, var(--border));
+}
+.sum-pill.ok strong {
+  color: var(--ok);
+}
+.sum-pill.ok.active {
+  border-color: var(--ok);
+  background: color-mix(in srgb, var(--ok) 12%, var(--panel));
+  color: color-mix(in srgb, var(--ok) 75%, var(--text));
+}
+.sum-pill.ok:hover {
+  border-color: var(--ok);
+}
 .badges {
   display: flex;
   align-items: center;
@@ -765,6 +780,10 @@ button.sum-pill:hover {
 .badge.muted {
   color: var(--muted);
   font-weight: 400;
+}
+.badge.ok {
+  color: var(--ok);
+  border-color: color-mix(in srgb, var(--ok) 40%, var(--border));
 }
 .card-status {
   display: inline-flex;

--- a/internal/web/src/lib/List.svelte
+++ b/internal/web/src/lib/List.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { PRStatus } from './types';
-  import { store, filteredPRs, matchesStatus, sortPRs, openPR, type StatusFilter } from './store.svelte';
+  import { store, filteredPRs, matchesStatus, sortPRs, openPR, isClean, type StatusFilter } from './store.svelte';
   import { clock, timeAgo, absolute } from './time.svelte';
   import Icon from './Icon.svelte';
   import Spinner from './Spinner.svelte';
@@ -45,8 +45,10 @@
   // also a toggle that filters the list down to that status.
   const summary = $derived.by(() => ({
     open: openAll.length,
+    clean: openAll.filter(isClean).length,
     danger: openAll.filter((p) => (p.signals?.danger ?? 0) > 0).length,
     failed: openAll.filter((p) => p.status === 'error').length,
+    images: openAll.filter((p) => (p.signals?.images ?? 0) > 0).length,
     rendering: openAll.filter((p) => p.status === 'pending' || p.status === 'running').length,
     merged: prs.length - openAll.length,
   }));
@@ -157,6 +159,9 @@
             {#if pr.refreshError}
               <span class="badge caution" title="Couldn't refresh — showing the last render"><Icon path={mdiRefresh} size={13} /></span>
             {/if}
+            {#if isClean(pr)}
+              <span class="badge ok" title="Rendered with no danger or caution warnings"><Icon path={mdiCheckCircleOutline} size={13} /> clean</span>
+            {/if}
             {#if pr.signals.danger}
               <span class="badge danger" title="danger warnings"><Icon path={mdiAlertOctagon} size={13} /> {pr.signals.danger}</span>
             {/if}
@@ -227,11 +232,17 @@
   {#if store.loaded && openAll.length}
     <div class="list-summary">
       <span class="sum-pill"><strong>{summary.open}</strong> open</span>
+      {#if showPill(summary.clean, 'clean')}
+        {@render pill('clean', summary.clean, 'ok', 'Only PRs rendered with no warnings')}
+      {/if}
       {#if showPill(summary.danger, 'danger')}
         {@render pill('danger', summary.danger, 'danger', 'Only PRs with danger warnings')}
       {/if}
       {#if showPill(summary.failed, 'failed')}
         {@render pill('failed', summary.failed, 'danger', 'Only PRs whose render failed')}
+      {/if}
+      {#if showPill(summary.images, 'images')}
+        {@render pill('images', summary.images, '', 'Only PRs with image changes')}
       {/if}
       {#if showPill(summary.rendering, 'rendering')}
         {@render pill('rendering', summary.rendering, '', 'Only PRs still rendering')}

--- a/internal/web/src/lib/store.svelte.ts
+++ b/internal/web/src/lib/store.svelte.ts
@@ -6,7 +6,7 @@ import type { DiffEnvelope, DiffResult, Meta, PRStatus, Warning, WSEvent } from 
 import { router, navigate } from './router.svelte';
 
 // The status facets a summary pill can filter the list down to ('' = all).
-export type StatusFilter = '' | 'danger' | 'failed' | 'rendering' | 'merged';
+export type StatusFilter = '' | 'danger' | 'failed' | 'rendering' | 'merged' | 'clean' | 'images';
 // List sort: the field to order by, and the direction. The comparator is
 // defined ascending (name A→Z, time oldest-first); 'desc' reverses it.
 export type SortKey = 'created' | 'refreshed' | 'name';
@@ -92,7 +92,7 @@ export interface ParsedQuery {
 }
 
 const FACETS = ['status', 'author', 'base', 'label'];
-const STATUS_VALUES = ['danger', 'failed', 'rendering', 'merged', 'open'];
+const STATUS_VALUES = ['danger', 'failed', 'rendering', 'merged', 'open', 'clean', 'images'];
 
 export function parseQuery(raw: string): ParsedQuery {
   const tokens: ParsedQuery['tokens'] = [];
@@ -151,6 +151,20 @@ export function filteredPRs(): PRStatus[] {
   return store.prs.filter((p) => matchesQuery(p, q));
 }
 
+// isClean reports a successfully-rendered open PR with no flagged risk — the
+// "nothing scary here" set a reviewer can scan (and often merge) fastest. It is
+// not a merge guarantee: a clean render can still carry config changes worth a
+// look, so it flags the absence of warnings, not safety.
+export function isClean(p: PRStatus): boolean {
+  return (
+    p.open &&
+    p.status === 'ready' &&
+    (p.signals?.danger ?? 0) === 0 &&
+    (p.signals?.caution ?? 0) === 0 &&
+    (p.signals?.failures ?? 0) === 0
+  );
+}
+
 // matchesStatus is the per-PR predicate for a summary-pill filter.
 export function matchesStatus(p: PRStatus, f: StatusFilter): boolean {
   switch (f) {
@@ -162,6 +176,10 @@ export function matchesStatus(p: PRStatus, f: StatusFilter): boolean {
       return p.status === 'pending' || p.status === 'running';
     case 'merged':
       return !p.open;
+    case 'clean':
+      return isClean(p);
+    case 'images':
+      return (p.signals?.images ?? 0) > 0;
     default:
       return true;
   }

--- a/internal/web/tests/list-triage.spec.ts
+++ b/internal/web/tests/list-triage.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect, type Page } from '@playwright/test';
+import type { Meta, PRStatus } from '../src/lib/types';
+
+const meta: Meta = { forge: 'github', repo: 'acme/home-ops', refreshIntervalSeconds: 1800 };
+
+// A self-contained PR set covering the triage axes: a clean rendered bump, a
+// PR with danger warnings, and one still rendering. Kept separate from the
+// shared fixture so the existing card-count assertions there stay valid.
+function pr(over: Partial<PRStatus> & { number: number; title: string }): PRStatus {
+  return {
+    author: 'renovate[bot]',
+    state: 'open',
+    open: true,
+    draft: false,
+    headRef: `pr/${over.number}`,
+    headSha: 'abc',
+    baseRef: 'main',
+    createdAt: '2026-06-01T09:00:00Z',
+    updatedAt: '2026-06-04T12:00:00Z',
+    labels: [],
+    url: `https://github.com/acme/home-ops/pull/${over.number}`,
+    status: 'ready',
+    ...over,
+  };
+}
+
+const prs: PRStatus[] = [
+  pr({
+    number: 1,
+    title: 'clean image bump',
+    signals: { resources: 2, danger: 0, caution: 0, images: 1, failures: 0 },
+  }),
+  pr({
+    number: 2,
+    title: 'risky rbac change',
+    signals: { resources: 5, danger: 2, caution: 0, images: 0, failures: 0 },
+  }),
+  pr({ number: 3, title: 'still rendering', status: 'running' }),
+];
+
+async function stubApi(page: Page) {
+  await page.route('**/api/meta', (r) => r.fulfill({ json: meta }));
+  await page.route('**/api/prs', (r) => r.fulfill({ json: prs }));
+  await page.routeWebSocket('**/ws', () => {
+    /* accept */
+  });
+}
+
+const cards = (page: Page) => page.locator('.cards .card');
+
+test('clean filter narrows to warning-free rendered PRs, and the card is flagged', async ({ page }) => {
+  await stubApi(page);
+  await page.goto('/');
+
+  // All three open PRs are listed to start.
+  await expect(cards(page)).toHaveCount(3);
+
+  // Only the clean PR carries the positive "clean" badge.
+  const cleanCard = page.locator('.card', { hasText: 'clean image bump' });
+  const riskyCard = page.locator('.card', { hasText: 'risky rbac change' });
+  await expect(cleanCard.locator('.badge.ok')).toHaveText(/clean/);
+  await expect(riskyCard.locator('.badge.ok')).toHaveCount(0);
+
+  // The clean pill (count 1) filters the list down to just it.
+  const cleanPill = page.locator('button.sum-pill', { hasText: 'clean' });
+  await expect(cleanPill).toContainText('1');
+  await cleanPill.click();
+  await expect(cards(page)).toHaveCount(1);
+  await expect(cards(page).first()).toContainText('clean image bump');
+});
+
+test('images and danger filters select their PRs', async ({ page }) => {
+  await stubApi(page);
+  await page.goto('/');
+
+  await page.locator('button.sum-pill', { hasText: 'images' }).click();
+  await expect(cards(page)).toHaveCount(1);
+  await expect(cards(page).first()).toContainText('clean image bump');
+
+  // Switch to danger: the risky PR, not the clean one.
+  await page.locator('button.sum-pill', { hasText: 'danger' }).click();
+  await expect(cards(page)).toHaveCount(1);
+  await expect(cards(page).first()).toContainText('risky rbac change');
+});
+
+test('status:clean query facet matches the pill filter', async ({ page }) => {
+  await stubApi(page);
+  await page.goto('/');
+
+  await page.locator('input.pr-search').fill('status:clean');
+  await expect(cards(page)).toHaveCount(1);
+  await expect(cards(page).first()).toContainText('clean image bump');
+});


### PR DESCRIPTION
First of the three review-UX improvements. The PR list already covers the **high-risk** end (danger/failed pills, the `status:` query facet). This adds the **low-risk** end — the part triage needs most when you're staring at a wall of Renovate PRs.

## What

- **`clean` filter pill + `status:clean` facet** — open PRs that rendered with **no danger/caution/failures**: the set you can scan (and usually merge) fastest. Honest framing — it flags the *absence of warnings*, not a merge guarantee (a clean render can still carry config worth a look).
- **A green `clean` badge** on those cards, so a safe bump reads at a glance without opening it.
- **`images` filter pill + `status:images` facet** — PRs with image changes: the canonical Renovate-bump review queue.

`isClean()` is shared by the filter predicate, the summary counts, and the card badge. UI-only — no API change.

## Test plan

- New `list-triage.spec.ts`: the clean filter narrows to warning-free PRs and flags the card; `images`/`danger` select their PRs; `status:clean` matches the pill.
- `mise run ui-test` — **53 passed** (3 new + 50), 1 skipped. `ui-typecheck` 0 errors, `ui-build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)