### PR TITLE
feat(ui): link image changes to their registry page

### DIFF
--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -1104,6 +1104,28 @@ button.sum-pill:hover {
   font-weight: 600;
   overflow-wrap: anywhere;
 }
+/* The image name links to its registry page; muted until hovered, then accent +
+   underline + a revealed external-link glyph (matching the topbar repo link). */
+.img-name-link {
+  color: inherit;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+.img-name-link .icon {
+  color: var(--muted);
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+.img-name-link:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+.img-name-link:hover .icon,
+.img-name-link:focus-visible .icon {
+  opacity: 1;
+}
 .img-delta {
   display: flex;
   align-items: center;

--- a/internal/web/src/lib/Overview.svelte
+++ b/internal/web/src/lib/Overview.svelte
@@ -3,7 +3,7 @@
   import { store, diffIndex, openSel } from './store.svelte';
   import Icon from './Icon.svelte';
   import Copy from './Copy.svelte';
-  import { mdiAlertOctagon, mdiAlert, mdiPackageVariantClosed, mdiAlertCircleOutline } from './icons';
+  import { mdiAlertOctagon, mdiAlert, mdiPackageVariantClosed, mdiAlertCircleOutline, mdiOpenInNew } from './icons';
 
   const d = $derived(store.diff);
 
@@ -32,6 +32,46 @@
   // with '@' (a tag can never contain ':', so a ':' in the version means digest).
   function imageRef(name: string, ver: string): string {
     return ver.includes(':') ? `${name}@${ver}` : `${name}:${ver}`;
+  }
+
+  // Best-effort web link for an image repository, so a reviewer can jump from a
+  // bump to the image's registry page (its tags, README, and from there the
+  // upstream source / release notes). Returns null for registries with no
+  // derivable web UI — the name then renders as plain text.
+  function registryUrl(name: string): string | null {
+    if (!name) return null;
+    // Split an optional registry host from the repo path; a bare "org/repo" (no
+    // host) is the implicit Docker Hub registry.
+    const slash = name.indexOf('/');
+    const head = slash === -1 ? '' : name.slice(0, slash);
+    const hasHost = head.includes('.') || head.includes(':') || head === 'localhost';
+    const host = hasHost ? head : 'docker.io';
+    let repo = hasHost ? name.slice(slash + 1) : name;
+    // A digest-pinned image carries its human tag on the name (e.g. x/y:4.5.0),
+    // and a name may carry an @sha256 digest — drop either from the final
+    // segment (the host's :port was already split off above).
+    const lastSlash = repo.lastIndexOf('/');
+    const tail = repo.slice(lastSlash + 1);
+    const cut = tail.search(/[:@]/);
+    if (cut !== -1) repo = repo.slice(0, lastSlash + 1) + tail.slice(0, cut);
+    if (!repo) return null;
+    const segs = repo.split('/');
+    switch (host) {
+      case 'ghcr.io':
+        // ghcr images are overwhelmingly built from the like-named GitHub repo;
+        // link there. Best-effort — a repackaged image may not have one.
+        return segs.length >= 2 ? `https://github.com/${segs[0]}/${segs[1]}` : null;
+      case 'quay.io':
+        return `https://quay.io/repository/${repo}`;
+      case 'docker.io':
+      case 'index.docker.io':
+      case 'registry-1.docker.io':
+        if (segs.length === 1) return `https://hub.docker.com/_/${segs[0]}`;
+        if (segs[0] === 'library') return `https://hub.docker.com/_/${segs.slice(1).join('/')}`;
+        return `https://hub.docker.com/r/${repo}`;
+      default:
+        return null;
+    }
   }
 </script>
 
@@ -92,7 +132,13 @@
         {#each d.images as img}
           <li class="img-change">
             <div class="img-head">
-              <span class="img-name">{img.name}</span>
+              {#if registryUrl(img.name)}
+                <a class="img-name img-name-link" href={registryUrl(img.name)} target="_blank" rel="noopener noreferrer" title={`Open ${img.name} on its registry`}>
+                  {img.name}<Icon path={mdiOpenInNew} size={11} />
+                </a>
+              {:else}
+                <span class="img-name">{img.name}</span>
+              {/if}
               {#if img.to}<Copy text={imageRef(img.name, img.to)} label="Copy new image reference" />{/if}
             </div>
             <!-- ∅ = no reference on that side (image added/removed); tooltip spells it out. -->

--- a/internal/web/tests/image-links.spec.ts
+++ b/internal/web/tests/image-links.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect, type Page } from '@playwright/test';
+import { samplePRs } from './fixtures';
+import type { Meta, DiffEnvelope } from '../src/lib/types';
+
+const meta: Meta = { forge: 'github', repo: 'acme/home-ops', refreshIntervalSeconds: 1800 };
+
+function image(name: string) {
+  return { name, from: 'v1.0', to: 'v1.1', refs: [] };
+}
+
+// One image per registry mapping the Overview can derive, plus one it can't.
+const envelope: DiffEnvelope = {
+  status: 'ready',
+  pr: samplePRs[0],
+  diff: {
+    prNumber: 142,
+    headSha: 'abc',
+    summary: { added: 0, changed: 0, removed: 0 },
+    impact: { resources: 0, parents: 0, namespaces: [], crds: 0 },
+    images: [
+      image('ghcr.io/rook/ceph'), // ghcr → github repo
+      image('ghcr.io/thelounge/thelounge:4.5.0'), // tag on the name is stripped
+      image('quay.io/prometheus/prometheus'), // quay → quay/repository
+      image('nginx'), // bare → Docker Hub library
+      image('grafana/grafana'), // org/repo → Docker Hub r/
+      image('registry.k8s.io/coredns/coredns'), // no derivable web UI → plain text
+    ],
+    failures: [],
+    warnings: [],
+    chromaCss: '',
+    tree: [],
+    resources: [],
+  },
+  mergeCommand: '',
+};
+
+async function stubApi(page: Page) {
+  await page.route('**/api/meta', (r) => r.fulfill({ json: meta }));
+  await page.route('**/api/prs', (r) => r.fulfill({ json: samplePRs }));
+  await page.route('**/api/prs/142/diff', (r) => r.fulfill({ json: envelope }));
+  await page.routeWebSocket('**/ws', () => {
+    /* accept */
+  });
+}
+
+test('image names link to their registry page (and stay plain when undecidable)', async ({ page }) => {
+  await stubApi(page);
+  await page.goto('/#/pr/142');
+
+  // The summary section (Overview) renders the image list.
+  await expect(page.locator('.img-list')).toBeVisible();
+
+  const href = (name: string) =>
+    page.locator('.img-change', { hasText: name }).locator('a.img-name-link');
+
+  await expect(href('ghcr.io/rook/ceph')).toHaveAttribute('href', 'https://github.com/rook/ceph');
+  // A digest-pinned image carries its tag on the name; the link drops it.
+  await expect(href('ghcr.io/thelounge/thelounge')).toHaveAttribute(
+    'href',
+    'https://github.com/thelounge/thelounge',
+  );
+  await expect(href('quay.io/prometheus/prometheus')).toHaveAttribute(
+    'href',
+    'https://quay.io/repository/prometheus/prometheus',
+  );
+  await expect(href('nginx')).toHaveAttribute('href', 'https://hub.docker.com/_/nginx');
+  await expect(href('grafana/grafana')).toHaveAttribute('href', 'https://hub.docker.com/r/grafana/grafana');
+
+  // Links open in a new tab and don't leak the opener.
+  await expect(href('ghcr.io/rook/ceph')).toHaveAttribute('target', '_blank');
+  await expect(href('ghcr.io/rook/ceph')).toHaveAttribute('rel', /noopener/);
+
+  // A registry with no derivable web UI stays plain text — no link.
+  const coredns = page.locator('.img-change', { hasText: 'registry.k8s.io/coredns/coredns' });
+  await expect(coredns.locator('a.img-name-link')).toHaveCount(0);
+  await expect(coredns.locator('.img-name')).toBeVisible();
+});


### PR DESCRIPTION
Second of the three review-UX improvements (the "image → release notes" idea, scoped to what's reliably derivable).

## What

Each image-change name in the Overview becomes a link to the image's **registry page** — tags, README, and from there the upstream source / release notes — opening in a new tab. The external-link glyph stays hidden until hover, matching the topbar repo link, so the list isn't cluttered.

Mappings are derived from the ref:
- **quay.io** → `quay.io/repository/<repo>` and **Docker Hub** (`library/x` → `_/x`, `org/x` → `r/org/x`, bare `x` → `_/x`) — exact.
- **ghcr.io** → the like-named GitHub repo (`github.com/<org>/<repo>`) — best-effort, and the dominant home-ops case.
- A digest-pinned image's tag is stripped from the name first (`x/y:4.5.0` → `x/y`).
- Registries with **no derivable web UI** (e.g. `registry.k8s.io`) stay plain text — no broken links.

## Scope note

The two deferred pieces from the original "release notes / skipped-source banner" idea both need data the render doesn't currently surface:
- **True release notes** need the image's `org.opencontainers.image.source` OCI annotation (flate renders manifests; it doesn't pull image configs).
- **A skipped-source banner** needs flate to expose soft-skipped sources — its `RenderTrees` `Result` only returns `Manifests`/`Failed`/`Orphans`, not the `AllowMissingSecrets` skips. This is the same "flate doesn't expose enough to embedders" gap as the egress ask; I'll fold it into that flate issue.

## Test plan
- New `image-links.spec.ts`: ghcr/quay/Docker Hub hrefs, digest-pinned tag stripping, `target=_blank`+`rel=noopener`, and an unmappable registry staying plain.
- `mise run ui-test` — 51 passed, 1 skipped. `ui-typecheck` 0 errors, `ui-build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)