### PR TITLE
feat(chart): optional NetworkPolicy (default/cilium/calico, off by default)

### DIFF
--- a/charts/konflate/README.md
+++ b/charts/konflate/README.md
@@ -96,6 +96,10 @@ Kubernetes: `>=1.25.0-0`
 | monitoring.serviceMonitor.relabelings | list | `[]` | Prometheus relabelings. |
 | monitoring.serviceMonitor.scrapeTimeout | string | `"10s"` | Scrape timeout. |
 | nameOverride | string | `""` | Override the chart name used in resource names. |
+| networkPolicy.allowDNS | bool | `true` | Allow DNS egress (UDP/TCP 53). konflate must resolve forge/registry/git hosts to render, so leave this on unless DNS is handled out-of-band. |
+| networkPolicy.egressPorts | list | `[443]` | TCP ports konflate may egress to fetch sources during a render (forge API + git/OCI/Helm over HTTPS). Add 80 / 22 for plain-HTTP or SSH git sources. |
+| networkPolicy.enabled | bool | `false` | Create a NetworkPolicy for konflate. |
+| networkPolicy.type | string | `"default"` | Policy flavor for your CNI: "default" (networking.k8s.io/v1 NetworkPolicy), "cilium" (CiliumNetworkPolicy), or "calico" (projectcalico.org/v3 NetworkPolicy). |
 | nodeSelector | object | `{}` | Node selector for pod scheduling. |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | PVC access modes. |
 | persistence.annotations | object | `{}` | PVC annotations. |

--- a/charts/konflate/templates/networkpolicy.tpl
+++ b/charts/konflate/templates/networkpolicy.tpl
@@ -1,0 +1,136 @@
+{{- if .Values.networkPolicy.enabled }}
+{{- $np := .Values.networkPolicy }}
+{{- /* konflate's container ports (see deployment.tpl): the HTTP UI/API and the
+       separate metrics server. Ingress is limited to these; egress is shaped to
+       DNS + the configured TCP ports (konflate needs broad egress to render). */}}
+{{- $http := 8080 }}
+{{- $metrics := 9090 }}
+{{- if eq $np.type "cilium" }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "konflate.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "konflate.labels" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      {{- include "konflate.selectorLabels" . | nindent 6 }}
+  ingress:
+    - fromEntities:
+        - all
+      toPorts:
+        - ports:
+            - port: {{ $http | quote }}
+              protocol: TCP
+            - port: {{ $metrics | quote }}
+              protocol: TCP
+  egress:
+    {{- if $np.allowDNS }}
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    {{- end }}
+    {{- with $np.egressPorts }}
+    - toEntities:
+        - cluster
+        - world
+      toPorts:
+        - ports:
+            {{- range . }}
+            - port: {{ . | quote }}
+              protocol: TCP
+            {{- end }}
+    {{- end }}
+{{- else if eq $np.type "calico" }}
+apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
+metadata:
+  name: {{ include "konflate.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "konflate.labels" . | nindent 4 }}
+spec:
+  selector: app.kubernetes.io/name == '{{ include "konflate.name" . }}' && app.kubernetes.io/instance == '{{ .Release.Name }}'
+  types:
+    - Ingress
+    - Egress
+  ingress:
+    - action: Allow
+      protocol: TCP
+      destination:
+        ports:
+          - {{ $http }}
+          - {{ $metrics }}
+  egress:
+    {{- if $np.allowDNS }}
+    - action: Allow
+      protocol: UDP
+      destination:
+        ports:
+          - 53
+    - action: Allow
+      protocol: TCP
+      destination:
+        ports:
+          - 53
+    {{- end }}
+    {{- with $np.egressPorts }}
+    - action: Allow
+      protocol: TCP
+      destination:
+        ports:
+          {{- range . }}
+          - {{ . }}
+          {{- end }}
+    {{- end }}
+{{- else if eq $np.type "default" }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "konflate.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "konflate.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "konflate.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # No `from` — ingress is limited to konflate's ports, reachable by any peer
+    # (lock down per cluster with your own policy if needed).
+    - ports:
+        - port: {{ $http }}
+          protocol: TCP
+        - port: {{ $metrics }}
+          protocol: TCP
+  egress:
+    {{- if $np.allowDNS }}
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    {{- end }}
+    {{- with $np.egressPorts }}
+    - ports:
+        {{- range . }}
+        - port: {{ . }}
+          protocol: TCP
+        {{- end }}
+    {{- end }}
+{{- else }}
+{{- fail (printf "networkPolicy.type must be one of: default, cilium, calico (got %q)" $np.type) }}
+{{- end }}
+{{- end }}

--- a/charts/konflate/tests/networkpolicy_test.yaml
+++ b/charts/konflate/tests/networkpolicy_test.yaml
@@ -1,0 +1,101 @@
+suite: networkPolicy
+templates:
+  - networkpolicy.tpl
+set:
+  config.repo: github://owner/repo
+tests:
+  - it: is not rendered by default (disabled)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a networking.k8s.io NetworkPolicy for type=default
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: NetworkPolicy
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      # Ingress is limited to konflate's HTTP + metrics ports.
+      - contains:
+          path: spec.ingress[0].ports
+          content:
+            port: 8080
+            protocol: TCP
+      - contains:
+          path: spec.ingress[0].ports
+          content:
+            port: 9090
+            protocol: TCP
+      # Egress: DNS first, then the TCP egress ports (443 by default).
+      - contains:
+          path: spec.egress[0].ports
+          content:
+            port: 53
+            protocol: UDP
+      - contains:
+          path: spec.egress[1].ports
+          content:
+            port: 443
+            protocol: TCP
+
+  - it: drops the DNS egress rule when allowDNS is false
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.allowDNS: false
+    asserts:
+      - lengthEqual:
+          path: spec.egress
+          count: 1
+      - contains:
+          path: spec.egress[0].ports
+          content:
+            port: 443
+            protocol: TCP
+
+  - it: renders a CiliumNetworkPolicy for type=cilium
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.type: cilium
+    asserts:
+      - isAPIVersion:
+          of: cilium.io/v2
+      - isKind:
+          of: CiliumNetworkPolicy
+      - contains:
+          path: spec.ingress[0].fromEntities
+          content: all
+      # Egress to the world + cluster on the configured TCP ports.
+      - contains:
+          path: spec.egress[1].toEntities
+          content: world
+
+  - it: renders a Calico NetworkPolicy for type=calico
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.type: calico
+    asserts:
+      - isAPIVersion:
+          of: projectcalico.org/v3
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: spec.egress[2].action
+          value: Allow
+      - contains:
+          path: spec.egress[2].destination.ports
+          content: 443
+
+  - it: fails fast on an unknown type
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.type: bogus
+    asserts:
+      - failedTemplate:
+          errorMessage: 'networkPolicy.type must be one of: default, cilium, calico (got "bogus")'

--- a/charts/konflate/values.schema.json
+++ b/charts/konflate/values.schema.json
@@ -477,6 +477,45 @@
       "title": "nameOverride",
       "type": "string"
     },
+    "networkPolicy": {
+      "description": "NetworkPolicy for konflate (off by default). konflate must reach the forge API\nplus the OCI/Helm/git sources a PR declares to render, so the policy *shapes*\negress to DNS + HTTPS rather than locking it down — still blocking lateral\naccess to other cluster services on other ports — and limits ingress to\nkonflate's own HTTP + metrics ports. Pick the flavor matching your CNI; the\nCilium/Calico variants render that CNI's CRD, so validate against your cluster.",
+      "properties": {
+        "allowDNS": {
+          "default": true,
+          "description": "Allow DNS egress (UDP/TCP 53). konflate must resolve forge/registry/git hosts to render, so leave this on unless DNS is handled out-of-band.",
+          "title": "allowDNS",
+          "type": "boolean"
+        },
+        "egressPorts": {
+          "description": "TCP ports konflate may egress to fetch sources during a render (forge API + git/OCI/Helm over HTTPS). Add 80 / 22 for plain-HTTP or SSH git sources.",
+          "items": {
+            "anyOf": [
+              {
+                "type": "integer"
+              }
+            ],
+            "required": []
+          },
+          "title": "egressPorts",
+          "type": "array"
+        },
+        "enabled": {
+          "default": false,
+          "description": "Create a NetworkPolicy for konflate.",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "type": {
+          "default": "default",
+          "description": "Policy flavor for your CNI: \"default\" (networking.k8s.io/v1 NetworkPolicy), \"cilium\" (CiliumNetworkPolicy), or \"calico\" (projectcalico.org/v3 NetworkPolicy).",
+          "title": "type",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "networkPolicy",
+      "type": "object"
+    },
     "nodeSelector": {
       "description": "Node selector for pod scheduling.",
       "required": [],

--- a/charts/konflate/values.yaml
+++ b/charts/konflate/values.yaml
@@ -239,6 +239,23 @@ httpRoute:
   # -- Redirect HTTP→HTTPS (301) instead of routing to the backend (needs HTTP+HTTPS listeners).
   httpsRedirect: false
 
+# NetworkPolicy for konflate (off by default). konflate must reach the forge API
+# plus the OCI/Helm/git sources a PR declares to render, so the policy *shapes*
+# egress to DNS + HTTPS rather than locking it down — still blocking lateral
+# access to other cluster services on other ports — and limits ingress to
+# konflate's own HTTP + metrics ports. Pick the flavor matching your CNI; the
+# Cilium/Calico variants render that CNI's CRD, so validate against your cluster.
+networkPolicy:
+  # -- Create a NetworkPolicy for konflate.
+  enabled: false
+  # -- Policy flavor for your CNI: "default" (networking.k8s.io/v1 NetworkPolicy), "cilium" (CiliumNetworkPolicy), or "calico" (projectcalico.org/v3 NetworkPolicy).
+  type: default
+  # -- Allow DNS egress (UDP/TCP 53). konflate must resolve forge/registry/git hosts to render, so leave this on unless DNS is handled out-of-band.
+  allowDNS: true
+  # -- TCP ports konflate may egress to fetch sources during a render (forge API + git/OCI/Helm over HTTPS). Add 80 / 22 for plain-HTTP or SSH git sources.
+  egressPorts:
+    - 443
+
 # Persist konflate's on-disk caches and the bare git mirror across restarts; with it disabled they live in an emptyDir and are rebuilt on each restart. Recommended for any non-trivial repo.
 persistence:
   # -- Persist caches + the git mirror across restarts (recommended for any non-trivial repo).


### PR DESCRIPTION
The NetworkPolicy egress-control hardening that was deferred from the fork-PR security review — now with a flavor for whichever CNI the cluster runs.

## What

`networkPolicy` (off by default) renders the policy kind matching your CNI, selected by `networkPolicy.type`:

| `type` | renders |
|--------|---------|
| `default` | `networking.k8s.io/v1` `NetworkPolicy` |
| `cilium` | `cilium.io/v2` `CiliumNetworkPolicy` |
| `calico` | `projectcalico.org/v3` `NetworkPolicy` |

An unknown `type` **fails the render** rather than silently falling back.

### The policy's shape — and why

konflate must reach the forge API plus the OCI/Helm/git **sources a PR declares** to render, so a hard egress lockdown would break rendering. Instead the policy **shapes** egress:
- **Egress**: DNS (toggle `allowDNS`) + the configured TCP ports (`egressPorts`, default `[443]`). This still blocks lateral access to other cluster services on other ports — the real win — while letting renders fetch over HTTPS. Add `80`/`22` for plain-HTTP or SSH git sources.
- **Ingress**: limited to konflate's own ports — `8080` (HTTP UI/API) and `9090` (metrics).

```yaml
networkPolicy:
  enabled: true
  type: cilium     # or default | calico
  allowDNS: true
  egressPorts: [443]
```

## Notes

- **Off by default**, so an install with default values renders no policy — and never references the Cilium/Calico CRDs on a cluster that lacks them.
- The Cilium (`toEntities: [cluster, world]` + kube-dns endpoint) and Calico (selector string + `action: Allow`) variants follow each project's documented schema; **validate against your cluster** as their CRDs aren't lint-checked here.

## Test plan
- `networkpolicy_test.yaml` (helm-unittest): all three flavors render the right kind/rules; disabled → 0 documents; `allowDNS:false` drops the DNS rule; unknown `type` fails.
- `mise run helm-unittest` (28 pass), `helm-lint`, `generate-check` all green; rendered each flavor with `helm template`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)