### PR TITLE
feat(api): serve the PR summary as Markdown for CI comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,17 +160,32 @@ re-renders](#triggering-re-renders)).
 
 Main server (`KONFLATE_PORT`):
 
-| Method & path                 | Purpose                                                                                    |
-| ----------------------------- | ------------------------------------------------------------------------------------------ |
-| `GET /`                       | The web UI.                                                                                |
-| `GET /api/prs`                | Tracked PRs and each one's diff-job status.                                                |
-| `GET /api/prs/{n}/diff`       | A PR's rendered diff (`200` ready/error, `202` still rendering).                           |
-| `POST /api/prs/{n}/refresh`   | **Auth** (bearer `KONFLATE_PUSH_TOKEN`) — re-render one PR. `501` unless the token is set. |
-| `POST /hooks`                 | Verified forge webhook — re-renders the affected PR. `501` unless the secret is set.       |
-| `GET /ws`                     | Websocket stream of diff-job status events.                                                |
-| `GET /healthz`, `GET /readyz` | Liveness / readiness.                                                                      |
+| Method & path                 | Purpose                                                                                                                                                                                                                                                                     |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /`                       | The web UI.                                                                                                                                                                                                                                                                 |
+| `GET /api/prs`                | Tracked PRs and each one's diff-job status.                                                                                                                                                                                                                                 |
+| `GET /api/prs/{n}/diff`       | A PR's rendered diff (`200` ready/error, `202` still rendering).                                                                                                                                                                                                            |
+| `GET /api/prs/{n}/summary`    | The diff's headline facts only — impact, cautions, image bumps, failures — without the per-resource render. JSON by default; `Accept: text/markdown` returns a paste-ready comment body (`?forge=github` for `[!CAUTION]` admonitions, else plain). `200`/`202` as `/diff`. |
+| `POST /api/prs/{n}/refresh`   | **Auth** (bearer `KONFLATE_PUSH_TOKEN`) — re-render one PR. `501` unless the token is set.                                                                                                                                                                                  |
+| `POST /hooks`                 | Verified forge webhook — re-renders the affected PR. `501` unless the secret is set.                                                                                                                                                                                        |
+| `GET /ws`                     | Websocket stream of diff-job status events.                                                                                                                                                                                                                                 |
+| `GET /healthz`, `GET /readyz` | Liveness / readiness.                                                                                                                                                                                                                                                       |
 
 Operational server (`KONFLATE_METRICS_ADDR`): `GET /metrics`.
+
+The summary endpoint doubles as a PR-comment source for CI — ask for Markdown
+and post it straight back (one comment, edited in place on each push):
+
+```bash
+curl -fsS -H 'Accept: text/markdown' \
+  "https://konflate.example.com/api/prs/${PR_NUMBER}/summary" \
+  | gh pr comment "${PR_NUMBER}" --body-file - --edit-last
+```
+
+konflate keeps PRs rendered on its own (webhook/interval), so the diff is
+normally ready when CI asks; a `202` just means "still rendering — try again on
+the next push". The comment carries a `<!-- konflate:pr-N -->` marker so a poster
+can find and update its own comment.
 
 ## Triggering re-renders
 

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -59,6 +59,11 @@ type DiffEnvelope struct {
 	// MergeCommand is the rendered "copy to merge" CLI command, set only for open
 	// PRs when the feature is enabled (see PRStatus.MergeCommand).
 	MergeCommand string `json:"mergeCommand,omitempty"`
+	// ReviewURL is the canonical link to this PR's review in the konflate UI
+	// (e.g. https://konflate.example/#/pr/142), derived from the request. Set by
+	// the summary endpoint for external consumers (a PR-comment bot links back to
+	// it); the SPA never needs it. Absent elsewhere.
+	ReviewURL string `json:"reviewUrl,omitempty"`
 }
 
 // Meta is the non-secret identity of this konflate instance, served at

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -125,6 +125,7 @@ func (s *Server) handleSummary(w http.ResponseWriter, r *http.Request) {
 	}
 	env.PR.AuthorAvatar = s.avatarProxyPath(env.PR.AuthorAvatar)
 	env.MergeCommand = s.mergeCommand(env.PR)
+	env.ReviewURL = reviewURLFromRequest(r, number)
 	if env.Diff != nil {
 		// Shallow-copy then trim, so the cached diff keeps its rendered resources —
 		// only this response is lightened.
@@ -137,6 +138,20 @@ func (s *Server) handleSummary(w http.ResponseWriter, r *http.Request) {
 	code := http.StatusOK
 	if env.Status == api.JobPending || env.Status == api.JobRunning {
 		code = http.StatusAccepted
+	}
+	// Content negotiation: a caller asking for Markdown gets a paste-ready block
+	// (forge flavour from ?forge=, defaulting to this instance's forge — so a
+	// GitHub-watching konflate emits [!CAUTION] admonitions with no param). Every
+	// other caller, the SPA included, gets the JSON envelope unchanged.
+	if strings.Contains(r.Header.Get("Accept"), "text/markdown") {
+		flavor := r.URL.Query().Get("forge")
+		if flavor == "" {
+			flavor = string(s.cfg.Forge.Kind)
+		}
+		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+		w.WriteHeader(code)
+		_, _ = io.WriteString(w, summaryMarkdown(env, env.ReviewURL, flavor == "github"))
+		return
 	}
 	writeJSON(w, code, env)
 }

--- a/internal/server/markdown.go
+++ b/internal/server/markdown.go
@@ -1,0 +1,174 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/home-operations/konflate/internal/api"
+)
+
+// summaryMarkdown renders a PR's diff summary as a paste-ready Markdown block,
+// for a CI job to post back onto the pull request. With admonitions=true it uses
+// GitHub-flavoured alert blocks (> [!CAUTION] / > [!WARNING]); otherwise a plain
+// bold-heading + bullet list that renders anywhere. Every forge-controlled value
+// is escaped (see mdInline/mdCode) so a crafted resource name or a render error
+// can't break the table or inject HTML into the comment.
+func summaryMarkdown(env api.DiffEnvelope, reviewURL string, admonitions bool) string {
+	var b strings.Builder
+	n := env.PR.Number
+	// A stable marker so a poster can find-and-edit its own comment in place
+	// instead of adding a new one on every render.
+	fmt.Fprintf(&b, "<!-- konflate:pr-%d -->\n", n)
+	fmt.Fprintf(&b, "### konflate — rendered diff for #%d\n", n)
+
+	writeLink := func() {
+		if reviewURL != "" {
+			fmt.Fprintf(&b, "\n[View the full rendered diff →](%s)\n", reviewURL)
+		}
+	}
+
+	if env.Status != api.JobReady || env.Diff == nil {
+		switch env.Status {
+		case api.JobError:
+			fmt.Fprintf(&b, "\nRender failed: %s\n", mdInline(env.Error))
+		case api.JobBlocked:
+			b.WriteString("\nNot rendered — fork-PR rendering is disabled for this instance.\n")
+		default:
+			b.WriteString("\n⏳ Still rendering — this updates once the diff is ready.\n")
+		}
+		writeLink()
+		return b.String()
+	}
+
+	d := env.Diff
+	fmt.Fprintf(&b, "\n**+%d added · %d changed · −%d removed** — %d %s",
+		d.Summary.Added, d.Summary.Changed, d.Summary.Removed,
+		d.Impact.Resources, plural(d.Impact.Resources, "resource", "resources"))
+	if d.Impact.Parents > 0 {
+		fmt.Fprintf(&b, " · %d %s", d.Impact.Parents, plural(d.Impact.Parents, "app", "apps"))
+	}
+	if d.Impact.CRDs > 0 {
+		fmt.Fprintf(&b, " · %d %s", d.Impact.CRDs, plural(d.Impact.CRDs, "CRD", "CRDs"))
+	}
+	if d.Truncated > 0 {
+		fmt.Fprintf(&b, " · %d not shown", d.Truncated)
+	}
+	b.WriteString("\n")
+
+	if len(d.Warnings) > 0 {
+		title := fmt.Sprintf("%d %s", len(d.Warnings), plural(len(d.Warnings), "caution", "cautions"))
+		if admonitions {
+			fmt.Fprintf(&b, "\n> [!CAUTION]\n> **%s**\n", title)
+			for _, wn := range d.Warnings {
+				fmt.Fprintf(&b, "> - `%s` — %s\n", mdCode(wn.Resource), mdInline(wn.Detail))
+			}
+		} else {
+			fmt.Fprintf(&b, "\n**⚠ Cautions (%d)**\n", len(d.Warnings))
+			for _, wn := range d.Warnings {
+				fmt.Fprintf(&b, "- `%s` — %s\n", mdCode(wn.Resource), mdInline(wn.Detail))
+			}
+		}
+	}
+
+	if len(d.Failures) > 0 {
+		title := fmt.Sprintf("%d render %s", len(d.Failures), plural(len(d.Failures), "failure", "failures"))
+		if admonitions {
+			fmt.Fprintf(&b, "\n> [!WARNING]\n> **%s**\n", title)
+			for _, f := range d.Failures {
+				fmt.Fprintf(&b, "> - `%s` — %s\n", mdCode(f.Parent), mdInline(f.Message))
+			}
+		} else {
+			fmt.Fprintf(&b, "\n**⛔ Render failures (%d)**\n", len(d.Failures))
+			for _, f := range d.Failures {
+				fmt.Fprintf(&b, "- `%s` — %s\n", mdCode(f.Parent), mdInline(f.Message))
+			}
+		}
+	}
+
+	if len(d.Images) > 0 {
+		b.WriteString("\n**Image changes**\n\n| image | from | to |\n|---|---|---|\n")
+		for _, im := range d.Images {
+			fmt.Fprintf(&b, "| `%s` | `%s` | `%s` |\n",
+				mdCode(im.Name), mdCode(shortVer(im.From)), mdCode(shortVer(im.To)))
+		}
+	}
+
+	writeLink()
+	b.WriteString("\n<sub>konflate · advisory, not a gate</sub>\n")
+	return b.String()
+}
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}
+
+// mdInline escapes free text (warning details, render messages — possibly
+// forge-controlled and multi-line) for safe inline Markdown: newlines collapse
+// to spaces so a list item stays one item, and HTML/table metacharacters are
+// neutralised.
+func mdInline(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", "|", `\|`).Replace(s)
+}
+
+// mdCode escapes a value rendered inside a `code span` (resource ids, image
+// refs — already constrained charsets, but defended anyway): newlines flattened,
+// backticks dropped (they would close the span) and table pipes escaped.
+func mdCode(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "`", "'")
+	return strings.ReplaceAll(s, "|", `\|`)
+}
+
+// shortVer trims an "algo:hexdigest" reference to "algo:<12 hex>…" so a
+// digest-pinned image doesn't sprawl across the table; tags pass through.
+func shortVer(v string) string {
+	if v == "" {
+		return "∅"
+	}
+	i := strings.IndexByte(v, ':')
+	if i < 0 {
+		return v
+	}
+	if hex := v[i+1:]; len(hex) > 12 && isHex(hex) {
+		return v[:i+1] + hex[:12] + "…"
+	}
+	return v
+}
+
+func isHex(s string) bool {
+	for _, c := range s {
+		switch {
+		case c >= '0' && c <= '9', c >= 'a' && c <= 'f', c >= 'A' && c <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// reviewURLFromRequest reconstructs konflate's own public URL for a PR's review
+// from the inbound request, honouring the usual reverse-proxy headers (konflate
+// typically sits behind an ingress).
+func reviewURLFromRequest(r *http.Request, number int) string {
+	scheme := "https"
+	if p := r.Header.Get("X-Forwarded-Proto"); p != "" {
+		scheme = strings.TrimSpace(strings.Split(p, ",")[0])
+	} else if r.TLS == nil {
+		scheme = "http"
+	}
+	host := r.Header.Get("X-Forwarded-Host")
+	if host == "" {
+		host = r.Host
+	}
+	if host == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s://%s/#/pr/%d", scheme, host, number)
+}

--- a/internal/server/markdown_test.go
+++ b/internal/server/markdown_test.go
@@ -1,0 +1,109 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/home-operations/konflate/internal/api"
+)
+
+func sampleSummaryEnv() api.DiffEnvelope {
+	return api.DiffEnvelope{
+		Status: api.JobReady,
+		PR:     api.PR{Number: 142},
+		Diff: &api.DiffResult{
+			Summary:  api.DiffSummary{Added: 2, Changed: 3, Removed: 1},
+			Impact:   api.Impact{Resources: 6, Parents: 2, CRDs: 1},
+			Warnings: []api.Warning{{Level: api.LevelCaution, Rule: "replicas-zero", Resource: "Deployment web/api", Detail: "replicas set to 0"}},
+			Failures: []api.RenderFailure{{Parent: "HelmRelease media/plex", Message: "values don't meet the schema"}},
+			Images:   []api.ImageChange{{Name: "ghcr.io/rook/ceph", From: "v1.14.9", To: "v1.15.0"}},
+		},
+	}
+}
+
+func TestSummaryMarkdown_GitHubAdmonitions(t *testing.T) {
+	t.Parallel()
+	md := summaryMarkdown(sampleSummaryEnv(), "https://k.example/#/pr/142", true)
+	for _, want := range []string{
+		"<!-- konflate:pr-142 -->",
+		"### konflate — rendered diff for #142",
+		"+2 added · 3 changed · −1 removed** — 6 resources · 2 apps · 1 CRD",
+		"> [!CAUTION]",
+		"> - `Deployment web/api` — replicas set to 0",
+		"> [!WARNING]",
+		"> - `HelmRelease media/plex` — values don't meet the schema",
+		"| image | from | to |",
+		"| `ghcr.io/rook/ceph` | `v1.14.9` | `v1.15.0` |",
+		"[View the full rendered diff →](https://k.example/#/pr/142)",
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("github markdown missing %q\n---\n%s", want, md)
+		}
+	}
+}
+
+func TestSummaryMarkdown_PlainHasNoAdmonitions(t *testing.T) {
+	t.Parallel()
+	md := summaryMarkdown(sampleSummaryEnv(), "", false)
+	if strings.Contains(md, "[!CAUTION]") || strings.Contains(md, "[!WARNING]") {
+		t.Errorf("plain markdown must not use GitHub admonitions:\n%s", md)
+	}
+	for _, want := range []string{"**⚠ Cautions (1)**", "**⛔ Render failures (1)**"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("plain markdown missing %q\n---\n%s", want, md)
+		}
+	}
+	// No review URL → no link line.
+	if strings.Contains(md, "View the full rendered diff") {
+		t.Errorf("empty review URL should omit the link:\n%s", md)
+	}
+}
+
+func TestSummaryMarkdown_EscapesForgeText(t *testing.T) {
+	t.Parallel()
+	env := sampleSummaryEnv()
+	// What a malicious PR might craft into a render error: a pipe (table break),
+	// raw HTML (injection), and a newline (would split the list item).
+	env.Diff.Failures = []api.RenderFailure{{
+		Parent:  "HelmRelease ns/app",
+		Message: "boom | <script>alert(1)</script>\nsecond line",
+	}}
+	md := summaryMarkdown(env, "", true)
+	if strings.Contains(md, "<script>") {
+		t.Errorf("raw HTML must be escaped:\n%s", md)
+	}
+	if !strings.Contains(md, "&lt;script&gt;") {
+		t.Errorf("expected HTML-escaped tags:\n%s", md)
+	}
+	if !strings.Contains(md, `boom \|`) {
+		t.Errorf("expected escaped table pipe:\n%s", md)
+	}
+	if strings.Contains(md, "\nsecond line") {
+		t.Errorf("a newline in a message must collapse to a space:\n%s", md)
+	}
+}
+
+func TestSummaryMarkdown_NotReady(t *testing.T) {
+	t.Parallel()
+	md := summaryMarkdown(api.DiffEnvelope{Status: api.JobRunning, PR: api.PR{Number: 9}}, "https://k/#/pr/9", true)
+	if !strings.Contains(md, "Still rendering") {
+		t.Errorf("a running PR should say it's still rendering:\n%s", md)
+	}
+	if strings.Contains(md, "[!CAUTION]") {
+		t.Errorf("no diff yet → no caution block:\n%s", md)
+	}
+}
+
+func TestShortVer(t *testing.T) {
+	t.Parallel()
+	cases := []struct{ in, want string }{
+		{"", "∅"},
+		{"v1.15.0", "v1.15.0"},
+		{"sha256:" + strings.Repeat("a", 64), "sha256:" + strings.Repeat("a", 12) + "…"},
+	}
+	for _, c := range cases {
+		if got := shortVer(c.in); got != c.want {
+			t.Errorf("shortVer(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -215,6 +215,56 @@ func TestServer_Summary(t *testing.T) {
 	}
 }
 
+func TestServer_SummaryMarkdown(t *testing.T) {
+	t.Parallel()
+	pr := api.PR{Number: 7, Title: "feat: widget", HeadRef: "feat", BaseRef: "main", HeadSHA: "abc123"}
+	rich := &fakeEngine{fn: func(pr api.PR) (api.DiffResult, error) {
+		return api.DiffResult{
+			PRNumber: pr.Number, HeadSHA: "abc123",
+			Summary:  api.DiffSummary{Changed: 1},
+			Impact:   api.Impact{Resources: 1},
+			Warnings: []api.Warning{{Level: api.LevelCaution, Rule: "replicas-zero", Resource: "Deployment web/api", Detail: "scaled to zero"}},
+		}, nil
+	}}
+	s := newTestServer(t, ghCfg("tok"), &fakeProvider{prs: []api.PR{pr}}, rich)
+	h := s.mainHandler()
+	s.refreshList(s.runCtx)
+	waitFor(t, s, 7)
+
+	// Accept: text/markdown → a paste-ready block. The instance is GitHub, so it
+	// emits admonitions with no ?forge param, and the review URL is derived from
+	// the request host.
+	rec := do(h, "GET", "/api/prs/7/summary", nil, map[string]string{"Accept": "text/markdown"})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("summary md: got %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/markdown") {
+		t.Errorf("content-type = %q, want text/markdown", ct)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"rendered diff for #7", "> [!CAUTION]", "`Deployment web/api`", "/#/pr/7"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("markdown body missing %q\n%s", want, body)
+		}
+	}
+
+	// ?forge=gitlab forces the plain (non-admonition) flavour.
+	plain := do(h, "GET", "/api/prs/7/summary?forge=gitlab", nil, map[string]string{"Accept": "text/markdown"}).Body.String()
+	if strings.Contains(plain, "[!CAUTION]") {
+		t.Errorf("?forge=gitlab should not emit GitHub admonitions:\n%s", plain)
+	}
+	if !strings.Contains(plain, "**⚠ Cautions (1)**") {
+		t.Errorf("plain flavour missing the cautions heading:\n%s", plain)
+	}
+
+	// Default (no Accept) is JSON, unchanged, now carrying reviewUrl.
+	var env api.DiffEnvelope
+	mustJSON(t, do(h, "GET", "/api/prs/7/summary", nil, nil), &env)
+	if env.Diff == nil || !strings.HasSuffix(env.ReviewURL, "/#/pr/7") {
+		t.Errorf("json summary reviewUrl = %q (diff set: %v)", env.ReviewURL, env.Diff != nil)
+	}
+}
+
 func TestServer_AvatarProxy(t *testing.T) {
 	t.Parallel()
 	s := newTestServer(t, ghCfg("tok"), &fakeProvider{}, okEngine())


### PR DESCRIPTION
Follow-up to the lean `/api/prs/{n}/summary` endpoint: let it serve **Markdown** so a CI job can curl it and post a PR comment — no client-side polling, no write access on konflate (it stays read-only toward the forge; the workflow posts with its own token).

### Content negotiation
Same URL, the `Accept` header picks the representation:
- `Accept: text/markdown` → a paste-ready comment body
- anything else (default, incl. the SPA's `application/json`) → today's JSON, unchanged

### Forge flavour (`?forge=`)
- `?forge=github` → GitHub alert admonitions (`> [!CAUTION]` for cautions, `> [!WARNING]` for render failures)
- anything else → plain Markdown (bold headings + lists) that renders on GitLab/Forgejo/anywhere
- **default** = this instance's configured forge, so a GitHub-watching konflate emits admonitions with no param

### Also
- **`reviewUrl`** added to the envelope (the canonical `/#/pr/N` link, derived from the request honouring `X-Forwarded-*`) — used as the "view the full diff" link and available to JSON consumers too.
- A hidden `<!-- konflate:pr-N -->` marker in the body so a poster can find-and-edit one comment in place instead of spamming.
- **Escaping** on the Markdown path: forge-controlled text (resource names, render messages) has newlines collapsed, HTML neutralised, and table pipes escaped — a crafted resource name can't break the table or inject into the comment.

### What it looks like

```markdown
<!-- konflate:pr-142 -->
### konflate — rendered diff for #142

**+2 added · 3 changed · −1 removed** — 6 resources · 2 apps · 1 CRD

> [!CAUTION]
> **1 caution**
> - `Deployment web/api` — replicas set to 0

> [!WARNING]
> **1 render failure**
> - `HelmRelease media/plex` — values don't meet the schema

**Image changes**

| image | from | to |
|---|---|---|
| `ghcr.io/rook/ceph` | `v1.14.9` | `v1.15.0` |

[View the full rendered diff →](https://konflate.turbo.ac/#/pr/142)
```

### The whole CI step (no loop)

```bash
curl -fsS -H 'Accept: text/markdown' \
  "$KONFLATE_URL/api/prs/${PR}/summary" | gh pr comment "${PR}" --body-file - --edit-last
```

konflate keeps PRs rendered on its own, so the diff's normally ready when CI asks; a `202` just means "still rendering — try next push."

## Test plan
`go test ./...` green incl. new `markdown_test.go` (GitHub admonitions vs plain, HTML/pipe/newline escaping, `shortVer`, not-ready states) and `TestServer_SummaryMarkdown` (Accept → 200 + `text/markdown` + admonitions; `?forge=gitlab` → plain; default → JSON carrying `reviewUrl`). `go vet`, `golangci-lint`, `gofmt` clean. README documents the endpoint + the one-line `gh pr comment` example. No UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
