### PR TITLE
feat(api): 503 + Retry-After for still-rendering Markdown summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,32 +160,33 @@ re-renders](#triggering-re-renders)).
 
 Main server (`KONFLATE_PORT`):
 
-| Method & path                 | Purpose                                                                                                                                                                                                                                                                     |
-| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `GET /`                       | The web UI.                                                                                                                                                                                                                                                                 |
-| `GET /api/prs`                | Tracked PRs and each one's diff-job status.                                                                                                                                                                                                                                 |
-| `GET /api/prs/{n}/diff`       | A PR's rendered diff (`200` ready/error, `202` still rendering).                                                                                                                                                                                                            |
-| `GET /api/prs/{n}/summary`    | The diff's headline facts only — impact, cautions, image bumps, failures — without the per-resource render. JSON by default; `Accept: text/markdown` returns a paste-ready comment body (`?forge=github` for `[!CAUTION]` admonitions, else plain). `200`/`202` as `/diff`. |
-| `POST /api/prs/{n}/refresh`   | **Auth** (bearer `KONFLATE_PUSH_TOKEN`) — re-render one PR. `501` unless the token is set.                                                                                                                                                                                  |
-| `POST /hooks`                 | Verified forge webhook — re-renders the affected PR. `501` unless the secret is set.                                                                                                                                                                                        |
-| `GET /ws`                     | Websocket stream of diff-job status events.                                                                                                                                                                                                                                 |
-| `GET /healthz`, `GET /readyz` | Liveness / readiness.                                                                                                                                                                                                                                                       |
+| Method & path                 | Purpose                                                                                                                                                                                                                                                                                                                                                                             |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /`                       | The web UI.                                                                                                                                                                                                                                                                                                                                                                         |
+| `GET /api/prs`                | Tracked PRs and each one's diff-job status.                                                                                                                                                                                                                                                                                                                                         |
+| `GET /api/prs/{n}/diff`       | A PR's rendered diff (`200` ready/error, `202` still rendering).                                                                                                                                                                                                                                                                                                                    |
+| `GET /api/prs/{n}/summary`    | The diff's headline facts only — impact, cautions, image bumps, failures — without the per-resource render. JSON by default; `Accept: text/markdown` returns a paste-ready comment body (`?forge=github` for `[!CAUTION]` admonitions, else plain). Ready ⇒ `200`; while rendering, JSON returns `202` and Markdown returns `503` + `Retry-After` (so `curl --retry` waits it out). |
+| `POST /api/prs/{n}/refresh`   | **Auth** (bearer `KONFLATE_PUSH_TOKEN`) — re-render one PR. `501` unless the token is set.                                                                                                                                                                                                                                                                                          |
+| `POST /hooks`                 | Verified forge webhook — re-renders the affected PR. `501` unless the secret is set.                                                                                                                                                                                                                                                                                                |
+| `GET /ws`                     | Websocket stream of diff-job status events.                                                                                                                                                                                                                                                                                                                                         |
+| `GET /healthz`, `GET /readyz` | Liveness / readiness.                                                                                                                                                                                                                                                                                                                                                               |
 
 Operational server (`KONFLATE_METRICS_ADDR`): `GET /metrics`.
 
 The summary endpoint doubles as a PR-comment source for CI — ask for Markdown
-and post it straight back (one comment, edited in place on each push):
+and post it straight back (one comment, edited in place on each push). While a
+render is in flight it answers `503` + `Retry-After`, so `curl --retry` waits it
+out with no polling loop of your own:
 
 ```bash
-curl -fsS -H 'Accept: text/markdown' \
+curl -fsS --retry 10 --retry-delay 3 -H 'Accept: text/markdown' \
   "https://konflate.example.com/api/prs/${PR_NUMBER}/summary" \
   | gh pr comment "${PR_NUMBER}" --body-file - --edit-last
 ```
 
-konflate keeps PRs rendered on its own (webhook/interval), so the diff is
-normally ready when CI asks; a `202` just means "still rendering — try again on
-the next push". The comment carries a `<!-- konflate:pr-N -->` marker so a poster
-can find and update its own comment.
+The comment carries a `<!-- konflate:pr-N -->` marker so a poster can find and
+update its own comment. konflate keeps PRs rendered on its own (webhook /
+interval), so the diff is normally ready by the time CI asks anyway.
 
 ## Triggering re-renders
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -135,10 +135,7 @@ func (s *Server) handleSummary(w http.ResponseWriter, r *http.Request) {
 		lite.ChromaCSS = ""
 		env.Diff = &lite
 	}
-	code := http.StatusOK
-	if env.Status == api.JobPending || env.Status == api.JobRunning {
-		code = http.StatusAccepted
-	}
+	rendering := env.Status == api.JobPending || env.Status == api.JobRunning
 	// Content negotiation: a caller asking for Markdown gets a paste-ready block
 	// (forge flavour from ?forge=, defaulting to this instance's forge — so a
 	// GitHub-watching konflate emits [!CAUTION] admonitions with no param). Every
@@ -149,12 +146,29 @@ func (s *Server) handleSummary(w http.ResponseWriter, r *http.Request) {
 			flavor = string(s.cfg.Forge.Kind)
 		}
 		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
-		w.WriteHeader(code)
+		// A Markdown consumer (a CI comment poster) waits with `curl --retry`. While
+		// the render is in flight, answer 503 + Retry-After so the retry kicks in —
+		// 202 is a success curl wouldn't retry. The JSON path keeps 202 (the SPA
+		// treats it as "still loading", not an error).
+		if rendering {
+			w.Header().Set("Retry-After", strconv.Itoa(summaryRetryAfterSeconds))
+			w.WriteHeader(http.StatusServiceUnavailable)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
 		_, _ = io.WriteString(w, summaryMarkdown(env, env.ReviewURL, flavor == "github"))
 		return
 	}
+	code := http.StatusOK
+	if rendering {
+		code = http.StatusAccepted
+	}
 	writeJSON(w, code, env)
 }
+
+// summaryRetryAfterSeconds is the Retry-After hint on a still-rendering Markdown
+// summary response, so a `curl --retry` consumer backs off a beat between tries.
+const summaryRetryAfterSeconds = 3
 
 // avatarClient fetches author avatars with a tight timeout; responses are
 // size-capped and must be images (see handleAvatar).

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -265,6 +265,34 @@ func TestServer_SummaryMarkdown(t *testing.T) {
 	}
 }
 
+func TestServer_SummaryMarkdownRetryAfter(t *testing.T) {
+	t.Parallel()
+	pr := api.PR{Number: 9, Title: "wip", HeadRef: "wip", BaseRef: "main", HeadSHA: "deadbeef"}
+	s := newTestServer(t, ghCfg("tok"), &fakeProvider{prs: []api.PR{pr}}, okEngine())
+	h := s.mainHandler()
+	// Record the PR without rendering it → status pending (upsertPR doesn't enqueue).
+	s.store.upsertPR(pr)
+
+	// Markdown while still rendering → 503 + Retry-After, so `curl --retry` retries
+	// (a 202 is a success curl wouldn't retry).
+	rec := do(h, "GET", "/api/prs/9/summary", nil, map[string]string{"Accept": "text/markdown"})
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("markdown while rendering: got %d, want 503", rec.Code)
+	}
+	if rec.Header().Get("Retry-After") == "" {
+		t.Error("a still-rendering 503 must carry a Retry-After header")
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/markdown") {
+		t.Errorf("content-type = %q, want text/markdown", ct)
+	}
+
+	// JSON while rendering stays 202 — the SPA reads it as "still loading", not an error.
+	rec = do(h, "GET", "/api/prs/9/summary", nil, nil)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("json while rendering: got %d, want 202", rec.Code)
+	}
+}
+
 func TestServer_AvatarProxy(t *testing.T) {
 	t.Parallel()
 	s := newTestServer(t, ghCfg("tok"), &fakeProvider{}, okEngine())


### PR DESCRIPTION
Follow-up to #85. Lets a CI comment-poster wait out an in-flight render with **`curl --retry`** — no client-side loop, and konflate holds no connection open.

When a caller asks for the summary as Markdown and the render is still running:

- **`Accept: text/markdown` + rendering → `503` + `Retry-After: 3`** (was `202`). `curl --retry` treats `503` as transient and honours `Retry-After`, so it backs off and retries on its own; `202` is a *success* curl wouldn't retry.
- **Ready → `200`** + the Markdown body, unchanged.
- **JSON path → still `202` while rendering** — the SPA reads that as "still loading", not an error, so it's untouched.

This is the loop-free, stateless-server shape: the client makes repeated short requests managed by curl's own `--retry` (one flag), and konflate answers instantly each time rather than parking a long-poll connection.

```bash
curl -fsS --retry 10 --retry-delay 3 -H 'Accept: text/markdown' \
  "$KONFLATE_URL/api/prs/$PR/summary" -o summary.md
# → then post summary.md as a PR comment (gh / github-script marker upsert)
```

## Test plan
`go test ./...` green incl. new `TestServer_SummaryMarkdownRetryAfter` (markdown while rendering → `503` + `Retry-After` + `text/markdown`; JSON while rendering → `202`) and the existing ready-path assertions (`200` + admonitions, `?forge=` flavour, JSON `reviewUrl`). `go vet`, `golangci-lint`, `gofmt` clean. README updated (endpoint row + `curl --retry` example). No UI changes.

> Note: a `503` for "still rendering" will show in 5xx-rate dashboards as a non-error — the conventional cost of a curl-retryable "come back later". Health checks hit `/healthz`, not `/summary`, so this doesn't affect readiness/liveness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
