### PR TITLE
fix(ui): review header on one row + merge command on the Summary bar

### DIFF
--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -923,16 +923,19 @@ button.sum-pill:hover {
   border-bottom: 1px solid var(--border);
   background: var(--panel);
 }
+/* One row: the title grows to fill the bar and the meta chips sit at the far
+   right, so the header uses its full width and the nav buttons line up with a
+   single-height content row (no taller two-line block to float against). */
 .review-title {
   flex: 1 1 auto;
   min-width: 0;
-}
-.rt-line {
   display: flex;
-  align-items: baseline;
-  gap: 8px;
+  align-items: center;
+  gap: 12px;
 }
 .rt-name {
+  flex: 1 1 auto;
+  min-width: 0;
   font-weight: 600;
   font-size: 14px;
   overflow: hidden;
@@ -942,11 +945,11 @@ button.sum-pill:hover {
 .rt-meta {
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  flex: 0 0 auto;
   gap: 6px;
   font-size: 11px;
   color: var(--muted);
-  margin-top: 4px;
 }
 /* Each meta item (#id, author, sha, opened, refreshed, open link) reads as a
    small tag, matching the chip language of the status pills. Explicit class —
@@ -1960,6 +1963,11 @@ kbd {
   .review-title {
     order: 1;
     flex-basis: 100%;
+    /* Stack title over the (wrapping) meta chips on a phone — there's no room
+       for them side by side. */
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
   }
   /* 16px so iOS doesn't force-zoom the page when the filter gains focus. */
   .pr-search {

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -1047,15 +1047,14 @@ button.sum-pill:hover {
   font-weight: 600;
   border-bottom: 1px solid color-mix(in srgb, var(--warn) 30%, var(--border));
 }
-/* The optional "copy to merge" command: a quiet bar below the status strips
-   (it's a convenience, not a status), with the command in a monospace chip. */
+/* The optional "copy to merge" command rides on the right of the Summary
+   header (not its own strip) — a convenience, in a monospace chip. */
 .merge-cmd {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 7px 14px;
-  background: var(--panel);
-  border-bottom: 1px solid var(--border);
+  gap: 6px;
+  min-width: 0;
+  margin-left: auto;
   color: var(--muted);
 }
 .merge-cmd code {

--- a/internal/web/src/lib/Diffs.svelte
+++ b/internal/web/src/lib/Diffs.svelte
@@ -5,7 +5,8 @@
   import Diff from './Diff.svelte';
   import Overview from './Overview.svelte';
   import Icon from './Icon.svelte';
-  import { mdiChevronLeft, mdiChevronRight } from './icons';
+  import Copy from './Copy.svelte';
+  import { mdiChevronLeft, mdiChevronRight, mdiConsoleLine } from './icons';
 
   // The selection: 'summary' or a resource id. A bare #/pr/N (null) lands on
   // the Summary. Every section renders stacked in one scrolling pane — the
@@ -230,6 +231,16 @@
         <div class="res-header">
           <span class="res-status">summary</span>
           <span class="res-title res-title-quiet">Overview</span>
+          <!-- The "copy to merge" command rides on the right of the Summary's
+               header instead of its own full-width strip — one fewer bar, and it
+               fills the otherwise-empty right side. Open PRs with the feature on. -->
+          {#if store.diffMergeCommand}
+            <div class="merge-cmd">
+              <Icon path={mdiConsoleLine} size={14} />
+              <code>{store.diffMergeCommand}</code>
+              <Copy text={store.diffMergeCommand} label="Copy merge command" />
+            </div>
+          {/if}
         </div>
         <Overview />
       </section>

--- a/internal/web/src/lib/Review.svelte
+++ b/internal/web/src/lib/Review.svelte
@@ -44,9 +44,7 @@
         </button>
       </div>
       <div class="review-title">
-        <div class="rt-line">
-          <span class="rt-name"><Breakable text={pr?.title ?? ''} /></span>
-        </div>
+        <span class="rt-name"><Breakable text={pr?.title ?? ''} /></span>
         <div class="rt-meta">
           <span class="rt-tag pr-id"><Icon path={mdiSourcePull} size={13} /> #{route.pr}</span>
           {#if pr}

--- a/internal/web/src/lib/Review.svelte
+++ b/internal/web/src/lib/Review.svelte
@@ -16,7 +16,6 @@
     mdiTrayFull,
     mdiClockOutline,
     mdiRefresh,
-    mdiConsoleLine,
   } from './icons';
   import Diffs from './Diffs.svelte';
   import Copy from './Copy.svelte';
@@ -78,14 +77,6 @@
     {#if store.diffRefreshError}
       <div class="refresh-strip" title={store.diffRefreshError}>
         <Icon path={mdiRefresh} size={15} /> Couldn't refresh — showing the last successful render
-      </div>
-    {/if}
-
-    {#if store.diffMergeCommand}
-      <div class="merge-cmd">
-        <Icon path={mdiConsoleLine} size={14} />
-        <code>{store.diffMergeCommand}</code>
-        <Copy text={store.diffMergeCommand} label="Copy merge command" />
       </div>
     {/if}
 


### PR DESCRIPTION
Review-screen header polish, from the review feedback: the left nav buttons didn't align, and the header (and the merge-command strip) wasted a lot of horizontal space.

### 1. Header on one row, full width
The PR title and its meta chips were stacked in two rows, so the back / ‹ / › buttons centred against that taller block and floated, with the right ~60% empty. Now the title and chips share **one row** — the title grows, the chips sit at the far right — so the nav buttons line up with a single-height content row and the header uses its width. Mobile still stacks (title → chips below the button row).

**Before**
![before](https://raw.githubusercontent.com/home-operations/konflate/assets/review-header-align/internal/web/screenshots/review-head-before.png)

**After**
![after](https://raw.githubusercontent.com/home-operations/konflate/assets/review-header-align/internal/web/screenshots/review-head-after.png)

### 2. Merge command folded onto the Summary header
The `gh pr merge …` command was a full-width strip of its own below the header. It now rides on the **right of the Summary section's "Overview" header** — one fewer bar, and it fills that header's otherwise-empty right side. Shown for open PRs with the merge-command feature on; resource headers are unchanged.

![merge on summary bar](https://raw.githubusercontent.com/home-operations/konflate/assets/review-header-align/internal/web/screenshots/review-merge.png)

### Mobile (unchanged)
![mobile](https://raw.githubusercontent.com/home-operations/konflate/assets/review-header-align/internal/web/screenshots/review-head-mobile.png)

## Test plan
`ui-typecheck` 0 errors, `ui-build` clean, `ui-test` 58 passed (incl. the review merge-command test and the mobile review-header tests). CSS + markup only — dropped the `.rt-line` wrapper and moved the merge command from `Review.svelte` into the Summary header in `Diffs.svelte`; no JS/logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
