### PR TITLE
fix(ui): mobile diff-header overflow + unified click-to-copy merge command

### DIFF
--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -1067,10 +1067,14 @@ button.sum-pill:hover {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
 }
-/* Flag tokens (`--repo`, …) in a rendered merge command — dimmed so they read as
-   a separate token from the value before them (see MergeCommand.svelte). */
+/* Flag tokens (`--repo`, …) in a rendered merge command. Two cues so the flag
+   reads as its own token (a short mid-height `--` otherwise optically attaches to
+   the value before it — `142 --repo` looks like `142--repo`): dim it, and nudge
+   it right by half a character. The margin only widens the gap *before a flag*,
+   leaving the rest of the command on the pure mono grid. See MergeCommand.svelte. */
 .cmd-flag {
   color: var(--muted);
+  margin-left: 0.5ch;
 }
 .review-body {
   flex: 1 1 auto;

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -611,24 +611,6 @@ a.repo:focus-visible .repo-ext {
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
-/* The copy-merge row: the command in a mono chip plus the copy button. */
-.pv-cmd-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-.pv-cmd {
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow-x: auto;
-  white-space: nowrap;
-  font-family: var(--font-mono);
-  font-size: 12px;
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 3px 8px;
-}
 .pv-msg {
   display: flex;
   align-items: center;
@@ -1047,32 +1029,46 @@ button.sum-pill:hover {
   font-weight: 600;
   border-bottom: 1px solid color-mix(in srgb, var(--warn) 30%, var(--border));
 }
-/* The optional "copy to merge" command rides on the right of the Summary
-   header (not its own strip) — a convenience, in a monospace chip. */
+/* The "copy to merge" command (MergeCommand.svelte): a terminal icon, the
+   command in a mono chip, and a copy button — shown identically on the right of
+   the Summary header and in the PR-list folded preview. A flex row, so it sizes
+   to content in the header (pushed right by .res-title's flex) and stretches to
+   fill in the preview's flex column; no margin needed. */
 .merge-cmd {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 6px;
   min-width: 0;
-  margin-left: auto;
-  color: var(--muted);
+  color: var(--muted); /* the terminal icon */
 }
-.merge-cmd code {
-  flex: 0 1 auto;
+/* The chip is a button — clicking the command copies it (so does the adjacent
+   copy button). Recessed (--bg) so it reads the same on the panel header and the
+   panel-alt preview. */
+.merge-cmd-text {
+  flex: 1 1 auto;
   min-width: 0;
   overflow-x: auto;
   white-space: nowrap;
   font-family: var(--font-mono);
   font-size: 12.5px;
   color: var(--text);
-  background: var(--panel-alt);
+  background: var(--bg);
   border: 1px solid var(--border);
   border-radius: 6px;
   padding: 3px 9px;
+  text-align: left;
+  cursor: pointer;
+  appearance: none;
+}
+.merge-cmd-text:hover {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--border));
+}
+.merge-cmd-text:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
 }
 /* Flag tokens (`--repo`, …) in a rendered merge command — dimmed so they read as
-   a separate token from the value before them (see MergeCommand.svelte). Shared
-   by the diff-overview chip and the list-row preview chip (.pv-cmd). */
+   a separate token from the value before them (see MergeCommand.svelte). */
 .cmd-flag {
   color: var(--muted);
 }

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -1070,6 +1070,12 @@ button.sum-pill:hover {
   border-radius: 6px;
   padding: 3px 9px;
 }
+/* Flag tokens (`--repo`, …) in a rendered merge command — dimmed so they read as
+   a separate token from the value before them (see MergeCommand.svelte). Shared
+   by the diff-overview chip and the list-row preview chip (.pv-cmd). */
+.cmd-flag {
+  color: var(--muted);
+}
 .review-body {
   flex: 1 1 auto;
   min-height: 0;

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -1277,6 +1277,13 @@ button.sum-pill:hover {
   display: flex;
   flex-direction: column;
   min-height: 0;
+  /* A wide diff line's min-content width must NOT size the column. Diff cells
+     wrap (white-space: pre-wrap), but word-break: break-word doesn't shrink
+     their *min-content*, so without this a long token floors this grid item at
+     the line's full width — blowing the whole pane (and the sticky .res-header /
+     mobile switcher, badges and all) out past the viewport. min-width: 0 lets
+     the item shrink to its column so the line wraps instead. See .diffs. */
+  min-width: 0;
   overflow: hidden;
   background: var(--panel);
 }
@@ -1284,6 +1291,7 @@ button.sum-pill:hover {
   flex: 1 1 auto;
   overflow: auto;
   min-height: 0;
+  min-width: 0; /* same min-content blowout as .diff-main: shrink to the column, don't size to the diff */
 }
 /* All sections (Summary + every resource diff) stack in one scrolling pane —
    review by scrolling, not by clicking each resource. The sticky .res-header
@@ -1889,7 +1897,12 @@ kbd {
 /* ---- mobile ---------------------------------------------------------- */
 @media (max-width: 900px) {
   .diffs {
-    grid-template-columns: 1fr;
+    /* minmax(0, 1fr), not 1fr: a bare 1fr track floors at its content's
+       min-content width, so a wide diff line would stretch the single column
+       past the viewport (clipping the diff header's filename + badges). Capping
+       the track minimum at 0 keeps it at the viewport width so the line wraps to
+       fit instead. Pairs with min-width: 0 on .diff-main / .diff-pane. */
+    grid-template-columns: minmax(0, 1fr);
     height: auto; /* page-scroll: size to content; .review owns the scroll */
   }
   .rail {

--- a/internal/web/src/lib/Diffs.svelte
+++ b/internal/web/src/lib/Diffs.svelte
@@ -5,9 +5,8 @@
   import Diff from './Diff.svelte';
   import Overview from './Overview.svelte';
   import Icon from './Icon.svelte';
-  import Copy from './Copy.svelte';
   import MergeCommand from './MergeCommand.svelte';
-  import { mdiChevronLeft, mdiChevronRight, mdiConsoleLine } from './icons';
+  import { mdiChevronLeft, mdiChevronRight } from './icons';
 
   // The selection: 'summary' or a resource id. A bare #/pr/N (null) lands on
   // the Summary. Every section renders stacked in one scrolling pane — the
@@ -236,11 +235,7 @@
                header instead of its own full-width strip — one fewer bar, and it
                fills the otherwise-empty right side. Open PRs with the feature on. -->
           {#if store.diffMergeCommand}
-            <div class="merge-cmd">
-              <Icon path={mdiConsoleLine} size={14} />
-              <code><MergeCommand command={store.diffMergeCommand} /></code>
-              <Copy text={store.diffMergeCommand} label="Copy merge command" />
-            </div>
+            <MergeCommand command={store.diffMergeCommand} />
           {/if}
         </div>
         <Overview />

--- a/internal/web/src/lib/Diffs.svelte
+++ b/internal/web/src/lib/Diffs.svelte
@@ -6,6 +6,7 @@
   import Overview from './Overview.svelte';
   import Icon from './Icon.svelte';
   import Copy from './Copy.svelte';
+  import MergeCommand from './MergeCommand.svelte';
   import { mdiChevronLeft, mdiChevronRight, mdiConsoleLine } from './icons';
 
   // The selection: 'summary' or a resource id. A bare #/pr/N (null) lands on
@@ -237,7 +238,7 @@
           {#if store.diffMergeCommand}
             <div class="merge-cmd">
               <Icon path={mdiConsoleLine} size={14} />
-              <code>{store.diffMergeCommand}</code>
+              <code><MergeCommand command={store.diffMergeCommand} /></code>
               <Copy text={store.diffMergeCommand} label="Copy merge command" />
             </div>
           {/if}

--- a/internal/web/src/lib/List.svelte
+++ b/internal/web/src/lib/List.svelte
@@ -9,6 +9,7 @@
   import Copy from './Copy.svelte';
   import Footer from './Footer.svelte';
   import Breakable from './Breakable.svelte';
+  import MergeCommand from './MergeCommand.svelte';
   import {
     mdiAlert,
     mdiPackageVariantClosed,
@@ -172,7 +173,7 @@
     <div class="pv-group">
       <span class="pv-label">Copy</span>
       <div class="pv-cmd-row">
-        <code class="pv-cmd">{pr.mergeCommand}</code>
+        <code class="pv-cmd"><MergeCommand command={pr.mergeCommand} /></code>
         <Copy text={pr.mergeCommand} label="Copy merge command" icon={mdiConsoleLine} />
       </div>
     </div>

--- a/internal/web/src/lib/List.svelte
+++ b/internal/web/src/lib/List.svelte
@@ -6,7 +6,6 @@
   import Icon from './Icon.svelte';
   import Spinner from './Spinner.svelte';
   import Avatar from './Avatar.svelte';
-  import Copy from './Copy.svelte';
   import Footer from './Footer.svelte';
   import Breakable from './Breakable.svelte';
   import MergeCommand from './MergeCommand.svelte';
@@ -33,7 +32,6 @@
     mdiUnfoldMoreHorizontal,
     mdiUnfoldLessHorizontal,
     mdiArrowUp,
-    mdiConsoleLine,
   } from './icons';
 
   // Two filter stages: the text query narrows `prs` (which the summary pills
@@ -170,13 +168,7 @@
 {#snippet previewBody(pr: PRStatus)}
   {@const pv = store.previews[pr.number]}
   {#if pr.mergeCommand}
-    <div class="pv-group">
-      <span class="pv-label">Copy</span>
-      <div class="pv-cmd-row">
-        <code class="pv-cmd"><MergeCommand command={pr.mergeCommand} /></code>
-        <Copy text={pr.mergeCommand} label="Copy merge command" icon={mdiConsoleLine} />
-      </div>
-    </div>
+    <MergeCommand command={pr.mergeCommand} />
   {/if}
 
   {#if !pv || pv.state === 'loading'}

--- a/internal/web/src/lib/List.svelte
+++ b/internal/web/src/lib/List.svelte
@@ -98,6 +98,15 @@
     expanded[n] = !expanded[n];
     if (expanded[n]) ensurePreview(n, headSha);
   }
+  // The summary loads async, so on the FIRST open the panel would slide to its
+  // loading height and then jump as the fetched sections arrive. Hold the slide
+  // until the summary has resolved (a reopen is smooth precisely because the data
+  // is already cached), so it animates once, straight to the final height; the
+  // chevron spins meanwhile.
+  const previewReady = (n: number): boolean => {
+    const p = store.previews[n];
+    return !!p && p.state !== 'loading';
+  };
 
   // The visible rows that have a summary to toggle — open cards plus the merged
   // shelf when it's showing. Drives the expand/collapse-all control.
@@ -171,13 +180,14 @@
     <MergeCommand command={pr.mergeCommand} />
   {/if}
 
-  {#if !pv || pv.state === 'loading'}
-    <div class="pv-msg"><Spinner size={13} /> Loading summary…</div>
-  {:else if pv.state === 'pending'}
+  <!-- The sliding panel only mounts once the summary has loaded (see
+       previewReady), so there's no in-panel "loading…" height for the slide to
+       animate through and then jump past — the chevron carries the spinner. -->
+  {#if pv && pv.state === 'pending'}
     <div class="pv-msg"><Icon path={mdiTrayFull} size={14} /> Still rendering — open the PR to watch.</div>
-  {:else if pv.state === 'error'}
+  {:else if pv && pv.state === 'error'}
     <div class="pv-msg pv-error"><Icon path={mdiAlertCircleOutline} size={14} /> {pv.error}</div>
-  {:else}
+  {:else if pv}
     <div class="pv-group">
       <span class="pv-label">Resource diffs</span>
       <div class="pv-impact">
@@ -236,7 +246,10 @@
 {/snippet}
 
 {#snippet prCard(pr: PRStatus)}
-  <li class="card-li" class:expanded={isExpanded(pr.number)}>
+  <!-- The squared-bottom "expanded" look is tied to the panel actually being
+       shown (not just the toggle), so a card never flattens its corners while the
+       summary is still loading and no panel hangs below it yet. -->
+  <li class="card-li" class:expanded={isExpanded(pr.number) && previewReady(pr.number)}>
     <div
       class="card-shell"
       class:merged={!pr.open}
@@ -305,11 +318,15 @@
           aria-label={isExpanded(pr.number) ? `Hide summary for #${pr.number}` : `Show summary for #${pr.number}`}
           onclick={() => toggleExpand(pr.number, pr.headSha)}
         >
-          <Icon path={isExpanded(pr.number) ? mdiChevronUp : mdiChevronDown} size={18} />
+          {#if isExpanded(pr.number) && !previewReady(pr.number)}
+            <Spinner size={16} />
+          {:else}
+            <Icon path={isExpanded(pr.number) ? mdiChevronUp : mdiChevronDown} size={18} />
+          {/if}
         </button>
       {/if}
     </div>
-    {#if isExpanded(pr.number)}
+    {#if isExpanded(pr.number) && previewReady(pr.number)}
       <div class="card-preview" transition:slide={{ duration: 120 }}>
         {@render previewBody(pr)}
       </div>

--- a/internal/web/src/lib/MergeCommand.svelte
+++ b/internal/web/src/lib/MergeCommand.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  // Render a CLI command with its flags (`--repo`, …) dimmed so the tokens read
+  // as distinct in a cramped mono chip. Every space is full-width already, but a
+  // short mid-height `--` optically attaches to the token before it, so
+  // `merge 142 --repo x` reads as `142--repo`; colouring the flag makes the
+  // boundary obvious without loosening the mono spacing.
+  //
+  // Split keeps the whitespace runs (the captured group) so spacing is intact.
+  // Tokens render as plain text — auto-escaped, never {@html} — so a
+  // forge-derived repo name can't inject markup.
+  let { command }: { command: string } = $props();
+  const tokens = $derived(command.split(/(\s+)/));
+</script>
+
+{#each tokens as t}{#if t.startsWith('-')}<span class="cmd-flag">{t}</span>{:else}{t}{/if}{/each}

--- a/internal/web/src/lib/MergeCommand.svelte
+++ b/internal/web/src/lib/MergeCommand.svelte
@@ -1,15 +1,51 @@
 <script lang="ts">
-  // Render a CLI command with its flags (`--repo`, …) dimmed so the tokens read
-  // as distinct in a cramped mono chip. Every space is full-width already, but a
-  // short mid-height `--` optically attaches to the token before it, so
-  // `merge 142 --repo x` reads as `142--repo`; colouring the flag makes the
-  // boundary obvious without loosening the mono spacing.
+  // The "copy to merge" command, shown identically in the diff overview header
+  // and the PR-list folded preview: a terminal icon, the command in a mono chip,
+  // and a copy button. The chip itself is also a copy button — clicking anywhere
+  // on the command copies it.
   //
-  // Split keeps the whitespace runs (the captured group) so spacing is intact.
-  // Tokens render as plain text — auto-escaped, never {@html} — so a
-  // forge-derived repo name can't inject markup.
+  // Flags (`--repo`, …) render dimmed so the tokens read as distinct in the
+  // cramped chip (a short mid-height `--` otherwise optically attaches to the
+  // token before it: `merge 142 --repo` looks like `142--repo`). Tokens render
+  // as plain text — auto-escaped, never {@html} — so a forge-derived repo name
+  // can't inject markup. The split keeps the whitespace runs so spacing is intact.
+  import { onDestroy } from 'svelte';
+  import Icon from './Icon.svelte';
+  import { mdiConsoleLine, mdiContentCopy, mdiCheck } from './icons';
+
   let { command }: { command: string } = $props();
   const tokens = $derived(command.split(/(\s+)/));
+
+  // Mirrors Copy.svelte: write to the clipboard, then flip to a check for a beat.
+  let copied = $state(false);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  onDestroy(() => clearTimeout(timer));
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(command);
+    } catch {
+      return; // clipboard unavailable (insecure context); fail quietly
+    }
+    copied = true;
+    clearTimeout(timer);
+    timer = setTimeout(() => (copied = false), 1200);
+  }
 </script>
 
-{#each tokens as t}{#if t.startsWith('-')}<span class="cmd-flag">{t}</span>{:else}{t}{/if}{/each}
+<div class="merge-cmd">
+  <Icon path={mdiConsoleLine} size={14} />
+  <!-- The chip is a button: its accessible name is the command text it holds. -->
+  <button type="button" class="merge-cmd-text" onclick={copy} title={copied ? 'Copied!' : 'Click to copy'}
+    >{#each tokens as t}{#if t.startsWith('-')}<span class="cmd-flag">{t}</span>{:else}{t}{/if}{/each}</button
+  >
+  <button
+    type="button"
+    class="copy-btn"
+    class:copied
+    onclick={copy}
+    title={copied ? 'Copied!' : 'Copy merge command'}
+    aria-label="Copy merge command"
+  >
+    <Icon path={copied ? mdiCheck : mdiContentCopy} size={13} />
+  </button>
+</div>

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -649,11 +649,14 @@ test('merge command is copyable in the review header (not on list cards)', async
   // recorder before navigating away — a full document load resets it.)
   await page.goto('/#/pr/142');
   const bar = page.locator('.merge-cmd');
-  await expect(bar.locator('code')).toHaveText('gh pr merge 142 --repo acme/home-ops');
+  await expect(bar.locator('.merge-cmd-text')).toHaveText('gh pr merge 142 --repo acme/home-ops');
   // Flag tokens render dimmed/distinct, but the command text — and what copies —
   // is the verbatim command (the flag span only colours, never alters it).
-  await expect(bar.locator('code .cmd-flag')).toHaveText('--repo');
+  await expect(bar.locator('.merge-cmd-text .cmd-flag')).toHaveText('--repo');
+  // Both the copy button and the chip itself copy the verbatim command.
   await bar.locator('.copy-btn').click();
+  expect(await clipboard()).toContain('gh pr merge 142 --repo acme/home-ops');
+  await bar.locator('.merge-cmd-text').click();
   expect(await clipboard()).toContain('gh pr merge 142 --repo acme/home-ops');
 
   // The PR list no longer carries a copy-merge affordance — it lives only in
@@ -675,11 +678,12 @@ test('a list row expands to a brief diff summary; the row still opens the PR', a
   const preview = card.locator('.card-preview');
   await expect(preview).toBeVisible();
 
-  // Ordered sections: copy (the merge command, from the list data), resource
-  // diffs, cautions & warnings, image changes.
-  await expect(preview.locator('.pv-cmd')).toHaveText('gh pr merge 142 --repo acme/home-ops');
+  // Ordered sections: copy (the merge command, from the list data — same
+  // MergeCommand chip as the diff overview), resource diffs, cautions & warnings,
+  // image changes.
+  await expect(preview.locator('.merge-cmd-text')).toHaveText('gh pr merge 142 --repo acme/home-ops');
   // Flags render as distinct (dimmed) tokens so `142 --repo` doesn't read joined.
-  await expect(preview.locator('.pv-cmd .cmd-flag')).toHaveText('--repo');
+  await expect(preview.locator('.merge-cmd-text .cmd-flag')).toHaveText('--repo');
   await expect(preview).toContainText('Resource diffs');
   await expect(preview).toContainText('Cautions');
   await expect(preview).toContainText('Render failures');

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -650,6 +650,9 @@ test('merge command is copyable in the review header (not on list cards)', async
   await page.goto('/#/pr/142');
   const bar = page.locator('.merge-cmd');
   await expect(bar.locator('code')).toHaveText('gh pr merge 142 --repo acme/home-ops');
+  // Flag tokens render dimmed/distinct, but the command text — and what copies —
+  // is the verbatim command (the flag span only colours, never alters it).
+  await expect(bar.locator('code .cmd-flag')).toHaveText('--repo');
   await bar.locator('.copy-btn').click();
   expect(await clipboard()).toContain('gh pr merge 142 --repo acme/home-ops');
 
@@ -675,6 +678,8 @@ test('a list row expands to a brief diff summary; the row still opens the PR', a
   // Ordered sections: copy (the merge command, from the list data), resource
   // diffs, cautions & warnings, image changes.
   await expect(preview.locator('.pv-cmd')).toHaveText('gh pr merge 142 --repo acme/home-ops');
+  // Flags render as distinct (dimmed) tokens so `142 --repo` doesn't read joined.
+  await expect(preview.locator('.pv-cmd .cmd-flag')).toHaveText('--repo');
   await expect(preview).toContainText('Resource diffs');
   await expect(preview).toContainText('Cautions');
   await expect(preview).toContainText('Render failures');

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -491,6 +491,42 @@ test('mobile: diff header title is not crushed to one char per line (regression)
   expect(box?.width ?? 0).toBeGreaterThan(150);
 });
 
+test('mobile: a wide diff line keeps the diff header within the viewport (regression)', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await stubApi(page);
+  // A long, unbreakable line: diff cells wrap (white-space: pre-wrap), but
+  // word-break: break-word doesn't shrink their *min-content*, so without
+  // min-width: 0 up the flex/grid chain this floored the whole column at the
+  // line's full width — pushing the diff header (filename + caution badge) and
+  // the mobile switcher off the right edge.
+  const wide = structuredClone(diffEnvelope);
+  wide.diff.resources[0].unified.push({
+    kind: 'add',
+    newNo: 99,
+    html: 'image: ghcr.io/org/some/really/long/registry/path/that/keeps/going:v1.2.3-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  });
+  await page.route('**/api/prs/142/diff', (route) => route.fulfill({ json: wide }));
+  // r2 = StatefulSet default/postgres — the removed resource whose caution badge
+  // sat on the header's right edge (the part that got clipped).
+  await page.goto('/#/pr/142/r2');
+  const header = page.locator('[data-sel="r2"] .res-header');
+  await header.waitFor();
+
+  // The header fills the viewport but never exceeds it (was ~448 on a 390 screen).
+  const box = await header.boundingBox();
+  expect(box?.width ?? 999).toBeLessThanOrEqual(391);
+  // The caution badge stays fully inside the viewport — its right edge no longer
+  // pushed off-screen.
+  const badge = await page.locator('[data-sel="r2"] .res-header .badge.caution').boundingBox();
+  expect((badge?.x ?? 0) + (badge?.width ?? 0)).toBeLessThanOrEqual(390);
+  // And the page never scrolls sideways.
+  const review = await page.evaluate(() => {
+    const el = document.querySelector('.review') as HTMLElement;
+    return { client: el.clientWidth, scroll: el.scrollWidth };
+  });
+  expect(review.scroll).toBeLessThanOrEqual(review.client + 1);
+});
+
 test('mobile: a long PR title wraps to two lines instead of truncating', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await stubApi(page);

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -702,6 +702,33 @@ test('a list row expands to a brief diff summary; the row still opens the PR', a
   await expect(page).toHaveURL(/#\/pr\/142$/);
 });
 
+test('the row summary waits for its fetch before sliding open (no first-open jump)', async ({ page }) => {
+  await stubApi(page);
+  // Hold the summary response so we can observe the pre-load state. (Registered
+  // after stubApi, so this handler wins for the summary route.)
+  let release: () => void = () => {};
+  const gate = new Promise<void>((r) => (release = r));
+  await page.route('**/api/prs/142/summary', async (route) => {
+    await gate;
+    await route.fulfill({ json: diffEnvelope });
+  });
+  await page.goto('/');
+  const card = page.locator('.card-li', { hasText: '#142' });
+
+  await card.locator('.card-expand').click();
+  // Toggled open, but the panel is deferred until the summary lands: the chevron
+  // shows a spinner and no panel (which would otherwise slide to a loading height
+  // and then jump) has mounted yet.
+  await expect(card.locator('.card-expand')).toHaveAttribute('aria-expanded', 'true');
+  await expect(card.locator('.card-expand .kspin')).toBeVisible();
+  await expect(card.locator('.card-preview')).toHaveCount(0);
+
+  // Summary lands → the panel mounts once, with its full content.
+  release();
+  await expect(card.locator('.card-preview')).toBeVisible();
+  await expect(card.locator('.card-preview')).toContainText('StatefulSet default/postgres');
+});
+
 test('the expand-all control toggles every row summary at once', async ({ page }) => {
   await stubApi(page);
   await page.goto('/');


### PR DESCRIPTION
Several small fixes to the diff / PR-list UI.

## 1. Mobile diff header cut off on a wide line

On a phone, scrolling a diff with a long line cut off the file header — the resource filename and its caution badge ran off the right edge, and the sticky resource-switcher bar drifted off-screen with the table.

**Cause:** a long, unbreakable diff line sized the *whole review column* to its min-content width. Diff cells wrap (`white-space: pre-wrap`), but `word-break: break-word` doesn't shrink a cell's *min-content*, so the line's full width propagated up the bare `1fr` grid track and the `min-width: auto` flex/grid items — stretching the column past the viewport before wrapping could apply.

**Fix:** `grid-template-columns: minmax(0, 1fr)` on the mobile `.diffs` grid + `min-width: 0` on `.diff-main` / `.diff-pane`, so the column clamps to the viewport and the line wraps to fit.

## 2. Merge command: readable, consistent, click-to-copy

The `gh pr merge 142 --repo …` chip read as `142--repo` — not a missing space (every space is full-width; verified identical advances), but the short mid-height `--` optically attaches to the PR number.

- Flag tokens (`--…`) render **dimmed** *and* nudged right by half a character, so the boundary is unmistakable while the rest of the command stays on the mono grid.
- The diff-overview and PR-list-preview chips now share one **`MergeCommand`** component → identical layout: terminal icon left, command chip, copy button right (the preview's redundant "Copy" label is gone).
- The chip is itself a **button** — clicking anywhere on the command copies it (the copy button still works too).

Displayed text and what's copied are byte-for-byte the verbatim command; the spans only colour/space.

## 3. Row summary no longer jumps on first open

The folded PR-list summary loads async, so the first open slid the panel to its "loading…" height and then jumped as the fetched sections arrived (a reopen was smooth only because the data was cached). Now the sliding panel waits until the summary resolves — so it animates once, straight to the final height — and the chevron spins meanwhile.

## Verify

- `ui-typecheck` ✅ · `ui-test` (60 passed) ✅ · `ui-build` ✅
- Regression tests: 390px wide-line (header ≤ viewport, badge on-screen, no page h-scroll); flag-token + click-to-copy on both chips; the row panel stays unmounted until its (gated) fetch lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)