### PR TITLE
feat(server): X-Konflate-Render-Status header on the summary endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,16 +185,16 @@ re-renders](#triggering-re-renders)).
 
 Main server (`KONFLATE_PORT`):
 
-| Method & path                 | Purpose                                                                                                                                                                                                                                                                                                                                                                             |
-| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `GET /`                       | The web UI.                                                                                                                                                                                                                                                                                                                                                                         |
-| `GET /api/prs`                | Tracked PRs and each one's diff-job status.                                                                                                                                                                                                                                                                                                                                         |
-| `GET /api/prs/{n}/diff`       | A PR's rendered diff (`200` ready/error, `202` still rendering).                                                                                                                                                                                                                                                                                                                    |
-| `GET /api/prs/{n}/summary`    | The diff's headline facts only — impact, cautions, image bumps, failures — without the per-resource render. JSON by default; `Accept: text/markdown` returns a paste-ready comment body (`?forge=github` for `[!CAUTION]` admonitions, else plain). Ready ⇒ `200`; while rendering, JSON returns `202` and Markdown returns `503` + `Retry-After` (so `curl --retry` waits it out). |
-| `POST /api/prs/{n}/refresh`   | **Auth** (bearer `KONFLATE_PUSH_TOKEN`) — re-render one PR. `501` unless the token is set.                                                                                                                                                                                                                                                                                          |
-| `POST /hooks`                 | Verified forge webhook — re-renders the affected PR. `501` unless the secret is set.                                                                                                                                                                                                                                                                                                |
-| `GET /ws`                     | Websocket stream of diff-job status events.                                                                                                                                                                                                                                                                                                                                         |
-| `GET /healthz`, `GET /readyz` | Liveness / readiness.                                                                                                                                                                                                                                                                                                                                                               |
+| Method & path                 | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /`                       | The web UI.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `GET /api/prs`                | Tracked PRs and each one's diff-job status.                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `GET /api/prs/{n}/diff`       | A PR's rendered diff (`200` ready/error, `202` still rendering).                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `GET /api/prs/{n}/summary`    | The diff's headline facts only — impact, cautions, image bumps, failures — without the per-resource render. JSON by default; `Accept: text/markdown` returns a paste-ready comment body (`?forge=github` for `[!CAUTION]` admonitions, else plain). Ready ⇒ `200`; while rendering, JSON returns `202` and Markdown returns `503` + `Retry-After` (so `curl --retry` waits it out). Every response carries an `X-Konflate-Render-Status` header (`ok`/`failures`/`error`/`pending`) for CI gating — see below. |
+| `POST /api/prs/{n}/refresh`   | **Auth** (bearer `KONFLATE_PUSH_TOKEN`) — re-render one PR. `501` unless the token is set.                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `POST /hooks`                 | Verified forge webhook — re-renders the affected PR. `501` unless the secret is set.                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `GET /ws`                     | Websocket stream of diff-job status events.                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `GET /healthz`, `GET /readyz` | Liveness / readiness.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 
 Operational server (`KONFLATE_METRICS_ADDR`): `GET /metrics`.
 
@@ -212,6 +212,30 @@ curl -fsS --retry 10 --retry-delay 3 -H 'Accept: text/markdown' \
 The comment carries a `<!-- konflate:pr-N -->` marker so a poster can find and
 update its own comment. konflate keeps PRs rendered on its own (webhook /
 interval), so the diff is normally ready by the time CI asks anyway.
+
+**Gating the workflow on the render.** Every summary response (Markdown or JSON)
+carries an `X-Konflate-Render-Status` header, so the same request that fetches
+the comment also tells CI whether to pass:
+
+| Value      | Meaning                                                                                                 |
+| ---------- | ------------------------------------------------------------------------------------------------------- |
+| `ok`       | Rendered cleanly.                                                                                       |
+| `failures` | Rendered, but one or more resources failed to render (the diff is shown, minus those).                  |
+| `error`    | The render itself errored — no diff produced.                                                           |
+| `pending`  | Still rendering. The Markdown path `503`s until a terminal verdict, so `--retry` never leaves you here. |
+
+```bash
+status=$(curl -fsS --retry 10 --retry-delay 3 -H 'Accept: text/markdown' \
+  -o body.md -w '%header{x-konflate-render-status}' \
+  "https://konflate.example.com/api/prs/${PR_NUMBER}/summary")
+gh pr comment "${PR_NUMBER}" --body-file body.md --edit-last   # always post what rendered
+[ "$status" = ok ] || { echo "::error::konflate render: ${status}"; exit 1; }
+```
+
+The check above blocks on both `error` and `failures`; relax it to
+`case "$status" in ok | failures) ;; *) exit 1 ;; esac` if a partial render
+shouldn't fail the PR. (`%header{}` needs curl ≥ 8.3; older curl can `-D -` and
+grep the header instead.)
 
 ## Triggering re-renders
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -136,6 +136,10 @@ func (s *Server) handleSummary(w http.ResponseWriter, r *http.Request) {
 		env.Diff = &lite
 	}
 	rendering := env.Status == api.JobPending || env.Status == api.JobRunning
+	// A render-status header (ok / failures / error / pending) lets a CI gate
+	// decide pass/fail from the very request it fetches the comment body with — no
+	// second JSON call. Set before either branch writes its status line.
+	w.Header().Set(renderStatusHeader, renderStatus(env))
 	// Content negotiation: a caller asking for Markdown gets a paste-ready block
 	// (forge flavour from ?forge=, defaulting to this instance's forge — so a
 	// GitHub-watching konflate emits [!CAUTION] admonitions with no param). Every
@@ -169,6 +173,35 @@ func (s *Server) handleSummary(w http.ResponseWriter, r *http.Request) {
 // summaryRetryAfterSeconds is the Retry-After hint on a still-rendering Markdown
 // summary response, so a `curl --retry` consumer backs off a beat between tries.
 const summaryRetryAfterSeconds = 3
+
+// renderStatusHeader names the response header carrying the render verdict on
+// the summary endpoint, so a CI gate can pass/fail off one request. Values are
+// from [renderStatus].
+const renderStatusHeader = "X-Konflate-Render-Status"
+
+// renderStatus reduces a PR's envelope to the verdict a CI gate cares about:
+//
+//	ok       — rendered cleanly, no resource failed
+//	failures — rendered, but flate could not render one or more resources
+//	error    — the render itself errored (Error is set, no diff)
+//	pending  — still queued/rendering (the Markdown path 503s here, so a
+//	           `curl --retry` consumer only observes a terminal value)
+//
+// "failures" and "error" are the fail-the-PR cases; a transient RefreshError
+// (last-good diff still shown) is deliberately reported as "ok".
+func renderStatus(env api.DiffEnvelope) string {
+	switch env.Status {
+	case api.JobError:
+		return "error"
+	case api.JobReady:
+		if env.Diff != nil && len(env.Diff.Failures) > 0 {
+			return "failures"
+		}
+		return "ok"
+	default: // pending, running
+		return "pending"
+	}
+}
 
 // avatarClient fetches author avatars with a tight timeout; responses are
 // size-capped and must be images (see handleAvatar).

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -327,6 +327,47 @@ func TestServer_SummaryMarkdownRetryAfter(t *testing.T) {
 	}
 }
 
+func TestServer_RenderStatusHeader(t *testing.T) {
+	t.Parallel()
+	eng := &fakeEngine{fn: func(pr api.PR) (api.DiffResult, error) {
+		switch pr.Number {
+		case 2: // rendered, but a resource failed
+			return api.DiffResult{PRNumber: 2, HeadSHA: pr.HeadSHA,
+				Failures: []api.RenderFailure{{Parent: "HelmRelease media/plex", Message: "values schema"}}}, nil
+		case 3: // the render itself errored
+			return api.DiffResult{}, fmt.Errorf("clone failed")
+		default: // clean
+			return api.DiffResult{PRNumber: pr.Number, HeadSHA: pr.HeadSHA}, nil
+		}
+	}}
+	prs := []api.PR{
+		{Number: 1, HeadRef: "a", BaseRef: "main", HeadSHA: "s1", Open: true},
+		{Number: 2, HeadRef: "b", BaseRef: "main", HeadSHA: "s2", Open: true},
+		{Number: 3, HeadRef: "c", BaseRef: "main", HeadSHA: "s3", Open: true},
+	}
+	s := newTestServer(t, ghCfg("tok"), &fakeProvider{prs: prs}, eng)
+	h := s.mainHandler()
+	s.refreshList(s.runCtx)
+	waitFor(t, s, 1)
+	waitFor(t, s, 2)
+	waitFor(t, s, 3)
+	// #4 is recorded but never rendered → still pending.
+	s.store.upsertPR(api.PR{Number: 4, HeadRef: "d", BaseRef: "main", HeadSHA: "s4", Open: true})
+
+	// The verdict header lets a CI gate pass/fail off the same request it fetches
+	// the comment with — no second JSON call.
+	for n, want := range map[int]string{1: "ok", 2: "failures", 3: "error", 4: "pending"} {
+		rec := do(h, "GET", fmt.Sprintf("/api/prs/%d/summary", n), nil, map[string]string{"Accept": "text/markdown"})
+		if got := rec.Header().Get(renderStatusHeader); got != want {
+			t.Errorf("PR #%d: %s = %q, want %q", n, renderStatusHeader, got, want)
+		}
+	}
+	// Present on the JSON path too (not just Markdown).
+	if got := do(h, "GET", "/api/prs/2/summary", nil, nil).Header().Get(renderStatusHeader); got != "failures" {
+		t.Errorf("JSON path: %s = %q, want failures", renderStatusHeader, got)
+	}
+}
+
 func TestServer_AvatarProxy(t *testing.T) {
 	t.Parallel()
 	s := newTestServer(t, ghCfg("tok"), &fakeProvider{}, okEngine())


### PR DESCRIPTION
## What

Adds an `X-Konflate-Render-Status` response header to `GET /api/prs/{n}/summary`. It lets a CI gate decide pass/fail from the **same request** it fetches the PR-comment body with — no second JSON call, no envelope parsing.

| Value      | Meaning                                                                                |
| ---------- | -------------------------------------------------------------------------------------- |
| `ok`       | Rendered cleanly.                                                                      |
| `failures` | Rendered, but one or more resources failed to render (the diff is shown, minus those). |
| `error`    | The render itself errored — no diff produced.                                          |
| `pending`  | Still queued/rendering.                                                                |

The Markdown path already answers `503` + `Retry-After` while a render is in flight, so a `curl --retry` consumer only ever observes a **terminal** verdict — never `pending`. A transient refresh error (last-good diff still shown) is deliberately reported as `ok`.

## Why

The summary endpoint already doubles as a CI PR-comment source. The missing piece was a machine-readable verdict so one workflow step can post the comment **and** fail the job on a bad render:

```bash
status=$(curl -fsS --retry 10 --retry-delay 3 -H 'Accept: text/markdown' \
  -o body.md -w '%header{x-konflate-render-status}' \
  "https://konflate.example.com/api/prs/${PR_NUMBER}/summary")
gh pr comment "${PR_NUMBER}" --body-file body.md --edit-last   # always post what rendered
[ "$status" = ok ] || { echo "::error::konflate render: ${status}"; exit 1; }
```

## Layout

- `internal/server/handlers.go` — `renderStatus(env)` helper + `renderStatusHeader` const; the header is set in `handleSummary` **before** content negotiation, so it's present on both the Markdown and JSON paths (and on the in-flight `503`/`202` responses).
- `internal/server/server_test.go` — `TestServer_RenderStatusHeader`: `ok`/`failures`/`error`/`pending` across four PRs, plus the JSON path.
- `README.md` — documents the header + a one-request CI-gate snippet.

## Verify

`go test ./...` ✅ · golangci-lint (0) ✅ · gofmt ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
