### PR TITLE
fix(server): simplify the PR-comment summary heading and caution header

### DIFF
--- a/internal/server/markdown.go
+++ b/internal/server/markdown.go
@@ -20,7 +20,7 @@ func summaryMarkdown(env api.DiffEnvelope, reviewURL string, admonitions bool) s
 	// A stable marker so a poster can find-and-edit its own comment in place
 	// instead of adding a new one on every render.
 	fmt.Fprintf(&b, "<!-- konflate:pr-%d -->\n", n)
-	fmt.Fprintf(&b, "### konflate — rendered diff for #%d\n", n)
+	b.WriteString("### konflate — summary\n")
 
 	writeLink := func() {
 		if reviewURL != "" {
@@ -55,14 +55,14 @@ func summaryMarkdown(env api.DiffEnvelope, reviewURL string, admonitions bool) s
 	b.WriteString("\n")
 
 	if len(d.Warnings) > 0 {
-		title := fmt.Sprintf("%d %s", len(d.Warnings), plural(len(d.Warnings), "caution", "cautions"))
+		label := plural(len(d.Warnings), "Caution", "Cautions")
 		if admonitions {
-			fmt.Fprintf(&b, "\n> [!CAUTION]\n> **%s**\n", title)
+			fmt.Fprintf(&b, "\n> [!CAUTION]\n> **%s**\n", label)
 			for _, wn := range d.Warnings {
 				fmt.Fprintf(&b, "> - `%s` — %s\n", mdCode(wn.Resource), mdInline(wn.Detail))
 			}
 		} else {
-			fmt.Fprintf(&b, "\n**⚠ Cautions (%d)**\n", len(d.Warnings))
+			fmt.Fprintf(&b, "\n**⚠ %s**\n", label)
 			for _, wn := range d.Warnings {
 				fmt.Fprintf(&b, "- `%s` — %s\n", mdCode(wn.Resource), mdInline(wn.Detail))
 			}

--- a/internal/server/markdown_test.go
+++ b/internal/server/markdown_test.go
@@ -26,7 +26,7 @@ func TestSummaryMarkdown_GitHubAdmonitions(t *testing.T) {
 	md := summaryMarkdown(sampleSummaryEnv(), "https://k.example/#/pr/142", true)
 	for _, want := range []string{
 		"<!-- konflate:pr-142 -->",
-		"### konflate — rendered diff for #142",
+		"### konflate — summary",
 		"+2 added · 3 changed · −1 removed** — 6 resources · 2 apps · 1 CRD",
 		"> [!CAUTION]",
 		"> - `Deployment web/api` — replicas set to 0",
@@ -48,7 +48,7 @@ func TestSummaryMarkdown_PlainHasNoAdmonitions(t *testing.T) {
 	if strings.Contains(md, "[!CAUTION]") || strings.Contains(md, "[!WARNING]") {
 		t.Errorf("plain markdown must not use GitHub admonitions:\n%s", md)
 	}
-	for _, want := range []string{"**⚠ Cautions (1)**", "**⛔ Render failures (1)**"} {
+	for _, want := range []string{"**⚠ Caution**", "**⛔ Render failures (1)**"} {
 		if !strings.Contains(md, want) {
 			t.Errorf("plain markdown missing %q\n---\n%s", want, md)
 		}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -276,7 +276,7 @@ func TestServer_SummaryMarkdown(t *testing.T) {
 		t.Errorf("content-type = %q, want text/markdown", ct)
 	}
 	body := rec.Body.String()
-	for _, want := range []string{"rendered diff for #7", "> [!CAUTION]", "`Deployment web/api`", "/#/pr/7"} {
+	for _, want := range []string{"konflate — summary", "> [!CAUTION]", "`Deployment web/api`", "/#/pr/7"} {
 		if !strings.Contains(body, want) {
 			t.Errorf("markdown body missing %q\n%s", want, body)
 		}
@@ -287,7 +287,7 @@ func TestServer_SummaryMarkdown(t *testing.T) {
 	if strings.Contains(plain, "[!CAUTION]") {
 		t.Errorf("?forge=gitlab should not emit GitHub admonitions:\n%s", plain)
 	}
-	if !strings.Contains(plain, "**⚠ Cautions (1)**") {
+	if !strings.Contains(plain, "**⚠ Caution**") {
 		t.Errorf("plain flavour missing the cautions heading:\n%s", plain)
 	}
 


### PR DESCRIPTION
## What

Two wording tweaks to the Markdown summary comment (`GET /api/prs/{n}/summary` with `Accept: text/markdown`) that CI posts onto a PR.

### Heading

The PR number is redundant — the comment already lives on the PR.

```diff
- ### konflate — rendered diff for #10973
+ ### konflate — summary
```

### Caution header

Drop the count above the caution list; it just restated what the bullets right below it already show. (Render-failure counts are left as-is.)

GitHub admonition flavour:

```diff
  > [!CAUTION]
- > **3 cautions**
+ > **Cautions**
```

Plain flavour:

```diff
- **⚠ Cautions (3)**
+ **⚠ Cautions**
```

The label pluralizes, so a single caution renders as **Caution**.

## Verify

`go test ./...` ✅ · golangci-lint (0) ✅ · gofmt ✅ — `markdown_test.go` + `server_test.go` assertions updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
