### PR TITLE
fix(server): polish the summary PR comment

### DIFF
--- a/internal/server/markdown.go
+++ b/internal/server/markdown.go
@@ -40,19 +40,26 @@ func summaryMarkdown(env api.DiffEnvelope, reviewURL string, admonitions bool) s
 	}
 
 	d := env.Diff
-	fmt.Fprintf(&b, "\n**+%d added · %d changed · −%d removed** — %d %s",
+	// Impact line — "+N added · N changed · −N removed — N resources · …". On the
+	// GitHub flavour it sits inside a [!NOTE] admonition; plain keeps it bare.
+	var impact strings.Builder
+	fmt.Fprintf(&impact, "**+%d added · %d changed · −%d removed** — %d %s",
 		d.Summary.Added, d.Summary.Changed, d.Summary.Removed,
 		d.Impact.Resources, plural(d.Impact.Resources, "resource", "resources"))
 	if d.Impact.Parents > 0 {
-		fmt.Fprintf(&b, " · %d %s", d.Impact.Parents, plural(d.Impact.Parents, "app", "apps"))
+		fmt.Fprintf(&impact, " · %d %s", d.Impact.Parents, plural(d.Impact.Parents, "app", "apps"))
 	}
 	if d.Impact.CRDs > 0 {
-		fmt.Fprintf(&b, " · %d %s", d.Impact.CRDs, plural(d.Impact.CRDs, "CRD", "CRDs"))
+		fmt.Fprintf(&impact, " · %d %s", d.Impact.CRDs, plural(d.Impact.CRDs, "CRD", "CRDs"))
 	}
 	if d.Truncated > 0 {
-		fmt.Fprintf(&b, " · %d not shown", d.Truncated)
+		fmt.Fprintf(&impact, " · %d not shown", d.Truncated)
 	}
-	b.WriteString("\n")
+	if admonitions {
+		fmt.Fprintf(&b, "\n> [!NOTE]\n> %s\n", impact.String())
+	} else {
+		fmt.Fprintf(&b, "\n%s\n", impact.String())
+	}
 
 	if len(d.Warnings) > 0 {
 		label := plural(len(d.Warnings), "Caution", "Cautions")

--- a/internal/server/markdown.go
+++ b/internal/server/markdown.go
@@ -102,14 +102,14 @@ func summaryMarkdown(env api.DiffEnvelope, reviewURL string, admonitions bool) s
 	writeRefreshNote()
 
 	if len(d.Warnings) > 0 {
-		label := plural(len(d.Warnings), "Caution", "Cautions")
 		if admonitions {
-			fmt.Fprintf(&b, "\n> [!CAUTION]\n> **%s**\n", label)
+			// [!CAUTION] renders its own "Caution" heading — no redundant title line.
+			b.WriteString("\n> [!CAUTION]\n")
 			for _, wn := range d.Warnings {
 				fmt.Fprintf(&b, "> - `%s` — %s\n", mdCode(wn.Resource), mdInline(wn.Detail))
 			}
 		} else {
-			fmt.Fprintf(&b, "\n**⚠ %s**\n", label)
+			fmt.Fprintf(&b, "\n**⚠ %s**\n", plural(len(d.Warnings), "Caution", "Cautions"))
 			for _, wn := range d.Warnings {
 				fmt.Fprintf(&b, "- `%s` — %s\n", mdCode(wn.Resource), mdInline(wn.Detail))
 			}

--- a/internal/server/markdown.go
+++ b/internal/server/markdown.go
@@ -40,6 +40,45 @@ func summaryMarkdown(env api.DiffEnvelope, reviewURL string, admonitions bool) s
 	}
 
 	d := env.Diff
+
+	// writeFooter closes the comment: the review link, then a subtle provenance
+	// line naming the commit this summary reflects. The comment is edited in place
+	// across pushes, so the rendered SHA is the only cue to which one it shows.
+	writeFooter := func() {
+		writeLink()
+		if sha := shortSHA(d.HeadSHA); sha != "" {
+			fmt.Fprintf(&b, "\n<sub>konflate · rendered `%s` · advisory, not a gate</sub>\n", sha)
+		} else {
+			b.WriteString("\n<sub>konflate · advisory, not a gate</sub>\n")
+		}
+	}
+	// writeRefreshNote flags that the most recent re-render failed and we're showing
+	// the last good diff, so a reviewer doesn't act on a stale render unaware.
+	writeRefreshNote := func() {
+		if env.RefreshError == "" {
+			return
+		}
+		if admonitions {
+			b.WriteString("\n> [!WARNING]\n> Couldn't refresh against the latest push — showing the last good render.\n")
+		} else {
+			b.WriteString("\n**⚠ Stale render** — couldn't refresh against the latest push; showing the last good render.\n")
+		}
+	}
+
+	// Nothing rendered-changed (a docs/CI-only PR, or a Flux edit that nets to
+	// nothing): say so plainly instead of a "+0 · 0 · −0 — 0 resources" line. Any
+	// warning, failure, or image change means there's something worth showing.
+	if d.Summary.Added == 0 && d.Summary.Changed == 0 && d.Summary.Removed == 0 &&
+		len(d.Warnings) == 0 && len(d.Failures) == 0 && len(d.Images) == 0 {
+		if admonitions {
+			b.WriteString("\n> [!NOTE]\n> ✅ No rendered changes.\n")
+		} else {
+			b.WriteString("\n✅ No rendered changes.\n")
+		}
+		writeRefreshNote()
+		writeFooter()
+		return b.String()
+	}
 	// Impact line — "+N added · N changed · −N removed — N resources · …". On the
 	// GitHub flavour it sits inside a [!NOTE] admonition; plain keeps it bare.
 	var impact strings.Builder
@@ -60,6 +99,7 @@ func summaryMarkdown(env api.DiffEnvelope, reviewURL string, admonitions bool) s
 	} else {
 		fmt.Fprintf(&b, "\n%s\n", impact.String())
 	}
+	writeRefreshNote()
 
 	if len(d.Warnings) > 0 {
 		label := plural(len(d.Warnings), "Caution", "Cautions")
@@ -99,8 +139,7 @@ func summaryMarkdown(env api.DiffEnvelope, reviewURL string, admonitions bool) s
 		}
 	}
 
-	writeLink()
-	b.WriteString("\n<sub>konflate · advisory, not a gate</sub>\n")
+	writeFooter()
 	return b.String()
 }
 
@@ -109,6 +148,15 @@ func plural(n int, one, many string) string {
 		return one
 	}
 	return many
+}
+
+// shortSHA trims a git commit SHA to its 7-character display prefix; shorter or
+// empty input is returned unchanged.
+func shortSHA(s string) string {
+	if len(s) > 7 {
+		return s[:7]
+	}
+	return s
 }
 
 // mdInline escapes free text (warning details, render messages — possibly

--- a/internal/server/markdown_test.go
+++ b/internal/server/markdown_test.go
@@ -43,6 +43,10 @@ func TestSummaryMarkdown_GitHubAdmonitions(t *testing.T) {
 			t.Errorf("github markdown missing %q\n---\n%s", want, md)
 		}
 	}
+	// The [!CAUTION] block is its own heading; don't repeat the word in a title line.
+	if strings.Contains(md, "> **Caution") {
+		t.Errorf("caution admonition should not carry a redundant title:\n%s", md)
+	}
 }
 
 func TestSummaryMarkdown_PlainHasNoAdmonitions(t *testing.T) {

--- a/internal/server/markdown_test.go
+++ b/internal/server/markdown_test.go
@@ -12,6 +12,7 @@ func sampleSummaryEnv() api.DiffEnvelope {
 		Status: api.JobReady,
 		PR:     api.PR{Number: 142},
 		Diff: &api.DiffResult{
+			HeadSHA:  "1a2b3c4d5e6f78901234567890abcdef12345678",
 			Summary:  api.DiffSummary{Added: 2, Changed: 3, Removed: 1},
 			Impact:   api.Impact{Resources: 6, Parents: 2, CRDs: 1},
 			Warnings: []api.Warning{{Level: api.LevelCaution, Rule: "replicas-zero", Resource: "Deployment web/api", Detail: "replicas set to 0"}},
@@ -36,6 +37,7 @@ func TestSummaryMarkdown_GitHubAdmonitions(t *testing.T) {
 		"| image | from | to |",
 		"| `ghcr.io/rook/ceph` | `v1.14.9` | `v1.15.0` |",
 		"[View the full rendered diff →](https://k.example/#/pr/142)",
+		"konflate · rendered `1a2b3c4` · advisory, not a gate",
 	} {
 		if !strings.Contains(md, want) {
 			t.Errorf("github markdown missing %q\n---\n%s", want, md)
@@ -92,6 +94,41 @@ func TestSummaryMarkdown_NotReady(t *testing.T) {
 	}
 	if strings.Contains(md, "[!CAUTION]") {
 		t.Errorf("no diff yet → no caution block:\n%s", md)
+	}
+}
+
+func TestSummaryMarkdown_NoChanges(t *testing.T) {
+	t.Parallel()
+	env := api.DiffEnvelope{
+		Status: api.JobReady,
+		PR:     api.PR{Number: 5},
+		Diff:   &api.DiffResult{HeadSHA: "deadbeefcafef00d"},
+	}
+	for _, admonitions := range []bool{true, false} {
+		md := summaryMarkdown(env, "", admonitions)
+		if !strings.Contains(md, "No rendered changes") {
+			t.Errorf("admonitions=%v: expected a no-changes message:\n%s", admonitions, md)
+		}
+		if strings.Contains(md, "added ·") {
+			t.Errorf("admonitions=%v: no-op summary must omit the impact line:\n%s", admonitions, md)
+		}
+		if !strings.Contains(md, "rendered `deadbee`") {
+			t.Errorf("admonitions=%v: no-op summary should still carry provenance:\n%s", admonitions, md)
+		}
+	}
+}
+
+func TestSummaryMarkdown_RefreshError(t *testing.T) {
+	t.Parallel()
+	env := sampleSummaryEnv()
+	env.RefreshError = "forge timeout"
+	md := summaryMarkdown(env, "", true)
+	if !strings.Contains(md, "showing the last good render") {
+		t.Errorf("a refresh failure should be flagged:\n%s", md)
+	}
+	// The last-good diff is still rendered alongside the stale note.
+	if !strings.Contains(md, "Deployment web/api") {
+		t.Errorf("last-good diff content should still render:\n%s", md)
 	}
 }
 

--- a/internal/server/markdown_test.go
+++ b/internal/server/markdown_test.go
@@ -27,6 +27,7 @@ func TestSummaryMarkdown_GitHubAdmonitions(t *testing.T) {
 	for _, want := range []string{
 		"<!-- konflate:pr-142 -->",
 		"### konflate — summary",
+		"> [!NOTE]",
 		"+2 added · 3 changed · −1 removed** — 6 resources · 2 apps · 1 CRD",
 		"> [!CAUTION]",
 		"> - `Deployment web/api` — replicas set to 0",
@@ -45,7 +46,7 @@ func TestSummaryMarkdown_GitHubAdmonitions(t *testing.T) {
 func TestSummaryMarkdown_PlainHasNoAdmonitions(t *testing.T) {
 	t.Parallel()
 	md := summaryMarkdown(sampleSummaryEnv(), "", false)
-	if strings.Contains(md, "[!CAUTION]") || strings.Contains(md, "[!WARNING]") {
+	if strings.Contains(md, "[!NOTE]") || strings.Contains(md, "[!CAUTION]") || strings.Contains(md, "[!WARNING]") {
 		t.Errorf("plain markdown must not use GitHub admonitions:\n%s", md)
 	}
 	for _, want := range []string{"**⚠ Caution**", "**⛔ Render failures (1)**"} {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -276,7 +276,7 @@ func TestServer_SummaryMarkdown(t *testing.T) {
 		t.Errorf("content-type = %q, want text/markdown", ct)
 	}
 	body := rec.Body.String()
-	for _, want := range []string{"konflate — summary", "> [!CAUTION]", "`Deployment web/api`", "/#/pr/7"} {
+	for _, want := range []string{"konflate — summary", "> [!NOTE]", "> [!CAUTION]", "`Deployment web/api`", "/#/pr/7"} {
 		if !strings.Contains(body, want) {
 			t.Errorf("markdown body missing %q\n%s", want, body)
 		}


### PR DESCRIPTION
## What

Refinements to the Markdown summary comment konflate renders for a PR (`GET /api/prs/{n}/summary`, `Accept: text/markdown`).

1. **Impact line → `[!NOTE]` (GitHub).** The overview line sits in a `> [!NOTE]` block, parallel to the `[!CAUTION]` / `[!WARNING]` sections. Plain flavour keeps it bare.
2. **No rendered changes.** A PR that changes no rendered output (docs/CI-only, or a Flux edit that nets to nothing) renders **✅ No rendered changes.** instead of a `+0 · 0 · −0 — 0 resources` line.
3. **Rendered-commit provenance.** The footer names the commit the summary reflects (short `d.HeadSHA`) — the comment is edited in place across pushes, so the SHA is the only cue to *which* one it shows.
4. **Stale-render note.** When the latest re-render failed and the last good diff is shown (`env.RefreshError` set), a `[!WARNING]` says so. Previously silent.
5. **No redundant caution title.** `[!CAUTION]` already renders its own "Caution" heading, so the `> **Caution**` line under it was dropped (GitHub flavour). Plain keeps `**⚠ Caution**`.

### Rendered (GitHub)

```
### konflate — summary

> [!NOTE]
> **+2 added · 3 changed · −1 removed** — 6 resources · 2 apps · 1 CRD

> [!CAUTION]
> - `Deployment web/api` — replicas set to 0

> [!WARNING]
> **1 render failure**
> - `HelmRelease media/plex` — values don't meet the schema

[View the full rendered diff →](…)

konflate · rendered `1a2b3c4` · advisory, not a gate
```

## Verify

`go test ./...` ✅ · golangci-lint (0) ✅ · gofmt ✅ — `markdown_test.go` covers the NOTE block, no-op (both flavours), provenance, stale-render note, and asserts the caution admonition carries no redundant title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
