### PR TITLE
perf(config): scale the in-memory Helm template cache by render concurrency

### DIFF
--- a/charts/konflate/README.md
+++ b/charts/konflate/README.md
@@ -52,7 +52,7 @@ Kubernetes: `>=1.25.0-0`
 | config.diffTimeout | string | `""` | Hard cap on a single PR render end-to-end (Go duration). Empty = default (10m); "0" disables. Lower on untrusted instances. |
 | config.extraEnv | list | `[]` | Extra raw env vars merged into the container (advanced). |
 | config.helmRenderCacheMb | string | `""` | Advanced: persistent on-disk Helm render cache in MiB, reused across renders/PRs/restarts. Empty = default (1024); "0" disables. |
-| config.helmTemplateCacheMb | string | `""` | Advanced: in-memory Helm template cache in MiB (the biggest CPU saver). Empty = flate default (256); "0" disables. |
+| config.helmTemplateCacheMb | string | `""` | Advanced: in-memory Helm template cache in MiB (the biggest CPU saver). Empty = auto (256 ÷ render concurrency, so it doesn't scale with the CPU limit); "0" disables. |
 | config.logFormat | string | `"json"` | Log format: json or text. |
 | config.logLevel | string | `"info"` | Log level: debug, info, warn, or error. |
 | config.maxDiffConcurrency | int | `0` | Max concurrent diff renders; 0 = auto (from the CPU limit, capped at 4). |

--- a/charts/konflate/values.schema.json
+++ b/charts/konflate/values.schema.json
@@ -56,7 +56,7 @@
         },
         "helmTemplateCacheMb": {
           "default": "",
-          "description": "Advanced: in-memory Helm template cache in MiB (the biggest CPU saver). Empty = flate default (256); \"0\" disables.",
+          "description": "Advanced: in-memory Helm template cache in MiB (the biggest CPU saver). Empty = auto (256 ÷ render concurrency, so it doesn't scale with the CPU limit); \"0\" disables.",
           "title": "helmTemplateCacheMb",
           "type": "string"
         },

--- a/charts/konflate/values.yaml
+++ b/charts/konflate/values.yaml
@@ -89,7 +89,7 @@ config:
   # sizing that volume matters as much as these caps. Quote values; use "0" to
   # disable a cache.
 
-  # -- Advanced: in-memory Helm template cache in MiB (the biggest CPU saver). Empty = flate default (256); "0" disables.
+  # -- Advanced: in-memory Helm template cache in MiB (the biggest CPU saver). Empty = auto (256 ÷ render concurrency, so it doesn't scale with the CPU limit); "0" disables.
   helmTemplateCacheMb: ""
   # -- Advanced: persistent on-disk Helm render cache in MiB, reused across renders/PRs/restarts. Empty = default (1024); "0" disables.
   helmRenderCacheMb: ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -158,8 +158,11 @@ type Config struct {
 
 	// HelmTemplateCacheMB caps flate's in-memory Helm template-output cache —
 	// repeat HelmReleases with identical inputs skip re-templating, the single
-	// largest CPU/allocation cost of a render. 0 disables it. In MiB.
-	HelmTemplateCacheMB int `env:"KONFLATE_HELM_TEMPLATE_CACHE_MB" envDefault:"256"`
+	// largest CPU/allocation cost of a render. In MiB. 0 disables it; a negative
+	// value (the default) derives the cap from the render concurrency in Load (see
+	// defaultHelmTemplateCacheMB) so this cache tracks the memory limit, not the
+	// CPU count.
+	HelmTemplateCacheMB int `env:"KONFLATE_HELM_TEMPLATE_CACHE_MB" envDefault:"-1"`
 
 	// HelmRenderCacheMB caps flate's persistent on-disk Helm render cache (under
 	// CacheDir). It is reused across renders, PRs, and restarts: a re-render
@@ -280,6 +283,9 @@ func Load() (*Config, error) {
 	if cfg.MaxDiffConcurrency <= 0 {
 		cfg.MaxDiffConcurrency = defaultDiffConcurrency()
 	}
+	if cfg.HelmTemplateCacheMB < 0 {
+		cfg.HelmTemplateCacheMB = defaultHelmTemplateCacheMB(cfg.MaxDiffConcurrency)
+	}
 
 	return cfg, nil
 }
@@ -291,6 +297,22 @@ func Load() (*Config, error) {
 func defaultDiffConcurrency() int {
 	// clamp(GOMAXPROCS, 1, 4)
 	return max(min(runtime.GOMAXPROCS(0), 4), 1)
+}
+
+// defaultHelmTemplateCacheMB sizes flate's in-memory Helm template cache so its
+// aggregate footprint stays bounded regardless of the CPU limit. flate builds
+// one such cache per orchestrator and runs two per render (base + head), so up
+// to 2*concurrency are live at once; dividing a fixed budget by the concurrency
+// keeps the total near 2*256 MiB instead of letting it scale with GOMAXPROCS.
+// These entries are live LRU references the GC can't reclaim under GOMEMLIMIT,
+// so this is the one render pool that must track the memory limit rather than
+// the CPU count. flate's persistent on-disk render cache (HelmRenderCacheMB)
+// still carries cross-render reuse, so a smaller in-memory L1 costs little for
+// konflate's changed-only renders. concurrency<=1 keeps the original 256 MiB;
+// floored so a high operator-set concurrency can't shrink it to nothing.
+func defaultHelmTemplateCacheMB(concurrency int) int {
+	const baseMB = 256
+	return max(baseMB/max(concurrency, 1), 32)
 }
 
 // xdgCacheHome returns $XDG_CACHE_HOME if set, otherwise ~/.cache (the XDG

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -92,7 +92,8 @@ func TestLoad_DiffConcurrency(t *testing.T) {
 
 func TestLoad_FlateTuningDefaults(t *testing.T) {
 	// Unset, the flate render knobs default to flate's own CLI values so the
-	// caching applies out of the box.
+	// caching applies out of the box. (HelmTemplateCacheMB is the exception — it's
+	// concurrency-derived; see TestLoad_HelmTemplateCacheMB.)
 	t.Setenv("KONFLATE_REPO", "github://owner/repo")
 	cfg, err := Load()
 	if err != nil {
@@ -102,7 +103,6 @@ func TestLoad_FlateTuningDefaults(t *testing.T) {
 		name      string
 		got, want int
 	}{
-		{"HelmTemplateCacheMB", cfg.HelmTemplateCacheMB, 256},
 		{"HelmRenderCacheMB", cfg.HelmRenderCacheMB, 1024},
 		{"StageCacheMB", cfg.StageCacheMB, 2048},
 		{"SourceRetryAttempts", cfg.SourceRetryAttempts, 3},
@@ -118,6 +118,55 @@ func TestLoad_FlateTuningDefaults(t *testing.T) {
 	}
 	if cfg.CacheTTL != 168*time.Hour {
 		t.Errorf("CacheTTL default = %v, want 168h", cfg.CacheTTL)
+	}
+}
+
+func TestDefaultHelmTemplateCacheMB(t *testing.T) {
+	// flate builds one in-memory template cache per orchestrator and runs two per
+	// render, so the budget is divided by the render concurrency to keep the
+	// aggregate (~2*256 MiB) flat instead of scaling with the CPU limit; floored
+	// at 32 so a high operator-set concurrency can't shrink it to nothing.
+	for _, c := range []struct {
+		conc, want int
+	}{
+		{1, 256}, {2, 128}, {4, 64}, {8, 32}, {100, 32}, {0, 256},
+	} {
+		if got := defaultHelmTemplateCacheMB(c.conc); got != c.want {
+			t.Errorf("defaultHelmTemplateCacheMB(%d) = %d, want %d", c.conc, got, c.want)
+		}
+	}
+}
+
+func TestLoad_HelmTemplateCacheMB(t *testing.T) {
+	t.Setenv("KONFLATE_REPO", "github://owner/repo")
+
+	// Unset: auto — derived from the resolved render concurrency, always positive.
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if want := defaultHelmTemplateCacheMB(cfg.MaxDiffConcurrency); cfg.HelmTemplateCacheMB != want {
+		t.Errorf("auto HelmTemplateCacheMB = %d, want %d (256/concurrency)", cfg.HelmTemplateCacheMB, want)
+	}
+
+	// An explicit positive value is respected verbatim.
+	t.Setenv("KONFLATE_HELM_TEMPLATE_CACHE_MB", "128")
+	cfg, err = Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.HelmTemplateCacheMB != 128 {
+		t.Errorf("explicit HelmTemplateCacheMB = %d, want 128", cfg.HelmTemplateCacheMB)
+	}
+
+	// 0 disables the cache and is preserved (not mistaken for unset).
+	t.Setenv("KONFLATE_HELM_TEMPLATE_CACHE_MB", "0")
+	cfg, err = Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.HelmTemplateCacheMB != 0 {
+		t.Errorf("explicit 0 HelmTemplateCacheMB = %d, want 0 (disabled)", cfg.HelmTemplateCacheMB)
 	}
 }
 


### PR DESCRIPTION
## What

Scale flate's **in-memory Helm template cache** by the render concurrency, so it stops being sized by the **CPU** limit instead of the memory limit.

## Why

flate builds this cache **per orchestrator**, and every render runs **two** (base + head, concurrently). So live caches = `2 × MaxDiffConcurrency`, each capped at the **256 MiB** default — a value inherited from flate's *single-orchestrator, full-cluster* CLI. At the default concurrency (`clamp(GOMAXPROCS,1,4)`), a 4-CPU pod can hold a worst-case **~2 GiB** of template-cache LRU entries, and they're live references, so **`GOMEMLIMIT` can't reclaim them**. Against the chart's **1Gi** default memory limit, that's the one render pool sized by the CPU limit, not the memory limit.

## Fix

Default `HelmTemplateCacheMB = 256 ÷ MaxDiffConcurrency` (floored at 32), so the aggregate (`2 × concurrency × per-cache`) stays ~512 MiB flat regardless of CPU count:

| concurrency | per-cache (MiB) | aggregate |
|---|---|---|
| 1 | 256 (unchanged) | 512 |
| 2 | 128 | 512 |
| 4 | 64 | 512 |
| 8 | 32 (floor) | 512 |

flate's persistent **on-disk** render cache (`HelmRenderCacheMB`, 1 GiB) still carries cross-render reuse, so a smaller in-memory L1 costs little for konflate's *changed-only* renders (each changed HelmRelease templates once per side — low intra-render L1 hit rate anyway).

Implemented as a sentinel default (`-1` = auto) resolved in `config.Load()` from the already-resolved concurrency. An explicit `KONFLATE_HELM_TEMPLATE_CACHE_MB` is unchanged — a positive value is honored verbatim, `0` still disables. Conservative: never uses more memory than today (concurrency 1 is identical).

## Context

The rest of the resource model is already tight — Go 1.26 cgroup-aware `GOMAXPROCS`, `automemlimit` `GOMEMLIMIT`=90%, all-in-process rendering (so `GOMEMLIMIT` is authoritative), concurrency derived from the CPU limit, bounded reconcile fan-out, a 500-resource diff cap, persistent disk caches + GC sweep. This was the one pool still scaling with the CPU count.

## Verify

`go test ./...` ✅ · golangci-lint (0) ✅ · gofmt ✅ · helm lint ✅ · helm-unittest (28) ✅ · generate-check ✅ — new `config` tests cover the helper (1→256, 4→64, 8→32) and Load's auto/explicit/disable paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
