### PR TITLE
feat(ui): forge PR link (with the PR number) + icon-only render state

### DIFF
--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -188,7 +188,7 @@ a.repo:focus-visible .repo-ext {
 }
 /* One focus ring for every interactive element, matching .copy-btn's accent
    treatment. Inset so it never clips inside scroll containers. */
-:is(.btn, .card, .card-expand, .expand-all, .scroll-top, .tree-item, .tree-summary, .group-head, .expand-btn, .view-toggle button, .warning-link, .sum-pill):focus-visible {
+:is(.btn, .card, .card-expand, .forge-link, .expand-all, .scroll-top, .tree-item, .tree-summary, .group-head, .expand-btn, .view-toggle button, .warning-link, .sum-pill):focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }
@@ -569,6 +569,11 @@ a.repo:focus-visible .repo-ext {
   color: var(--text);
   background: var(--panel-alt);
   border-radius: 0 7px 7px 0;
+}
+/* Empty stand-in for the disclosure column on rows without a summary yet, so the
+   forge link to its left stays in a consistent column across rows. */
+.card-expand-spacer {
+  flex: 0 0 38px;
 }
 .card-li {
   position: relative;
@@ -991,15 +996,25 @@ button.sum-pill:hover {
   opacity: 1;
   color: var(--ok);
 }
-.ext {
+/* PR-icon link out to the change on its forge. Quiet (muted) by default; the
+   tooltip names the forge. Shared by the list rows (right of the resource count)
+   and the review title. align-self:center keeps a list-row instance a compact
+   target instead of a full-height column. */
+.forge-link {
   display: inline-flex;
   align-items: center;
-  gap: 3px;
-  color: var(--accent);
+  justify-content: center;
+  align-self: center;
+  flex: 0 0 auto;
+  padding: 6px;
+  border-radius: 6px;
+  color: var(--muted);
+  cursor: pointer;
   text-decoration: none;
 }
-.ext:hover {
-  text-decoration: underline;
+.forge-link:hover {
+  color: var(--accent);
+  background: var(--panel-alt);
 }
 .review-nav {
   display: flex;

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -269,12 +269,6 @@ a.repo:focus-visible .repo-ext {
 /* The PR number, shown first in the meta row (list + review) behind a
    pull-request glyph. Styled like its siblings (author, sha, opened, refreshed)
    — muted and normal weight — so the whole meta row reads uniformly. */
-.pr-id {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-  flex: 0 0 auto;
-}
 .tag {
   display: inline-flex;
   align-items: center;
@@ -574,6 +568,20 @@ a.repo:focus-visible .repo-ext {
    forge link to its left stays in a consistent column across rows. */
 .card-expand-spacer {
   flex: 0 0 38px;
+}
+/* Non-interactive state indicator filling the disclosure column for a PR that
+   hasn't rendered a summary yet: a spinner while queued/rendering, a failed icon
+   on error. The icon (+ its tooltip) carries the state — no row text. */
+.card-state {
+  flex: 0 0 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-left: 1px solid var(--border);
+  color: var(--muted);
+}
+.card-state.error {
+  color: var(--danger);
 }
 .card-li {
   position: relative;
@@ -878,22 +886,6 @@ button.sum-pill:hover {
   color: var(--muted);
   font-weight: 400;
 }
-.card-status {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  color: var(--muted);
-  white-space: nowrap;
-}
-.card-status.running {
-  color: var(--accent);
-}
-.card-status.s-error {
-  color: var(--danger);
-}
-.card-status.s-ready {
-  color: var(--ok);
-}
 
 /* ---- review shell ---------------------------------------------------- */
 .review {
@@ -1005,10 +997,12 @@ button.sum-pill:hover {
   align-items: center;
   justify-content: center;
   align-self: center;
+  gap: 3px;
   flex: 0 0 auto;
-  padding: 6px;
+  padding: 4px 6px;
   border-radius: 6px;
   color: var(--muted);
+  font-size: 12px;
   cursor: pointer;
   text-decoration: none;
 }

--- a/internal/web/src/lib/ForgeLink.svelte
+++ b/internal/web/src/lib/ForgeLink.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  // A quiet link out to the pull request on its forge, drawn with a
+  // pull-request glyph. The tooltip names the forge (GitHub / GitLab / Forgejo)
+  // from the instance meta. Shared by the PR list rows and the review title.
+  import Icon from './Icon.svelte';
+  import { store } from './store.svelte';
+  import { mdiSourcePull, forgeIcon } from './icons';
+
+  interface Props {
+    url: string;
+    size?: number;
+  }
+  let { url, size = 15 }: Props = $props();
+
+  // Only render an absolute http(s) link; a missing/relative url is dropped
+  // rather than emitting a dead anchor.
+  const valid = $derived(/^https?:\/\//i.test(url));
+  // The forge's display name ("GitHub"/"GitLab"/"Forgejo") from the brand-icon
+  // registry, falling back to a neutral noun if meta hasn't loaded.
+  const forgeName = $derived(forgeIcon[store.meta?.forge ?? '']?.title ?? 'the forge');
+</script>
+
+{#if valid}
+  <a
+    class="forge-link"
+    href={url}
+    target="_blank"
+    rel="noopener noreferrer"
+    title={`Open PR on ${forgeName}`}
+    aria-label={`Open PR on ${forgeName}`}
+  >
+    <Icon path={mdiSourcePull} {size} />
+  </a>
+{/if}

--- a/internal/web/src/lib/ForgeLink.svelte
+++ b/internal/web/src/lib/ForgeLink.svelte
@@ -1,19 +1,20 @@
 <script lang="ts">
-  // A quiet link out to the pull request on its forge, drawn with a
+  // The PR's number as a link out to the change on its forge, drawn with a
   // pull-request glyph. The tooltip names the forge (GitHub / GitLab / Forgejo)
-  // from the instance meta. Shared by the PR list rows and the review title.
+  // from the instance meta. This is the one place the PR number is shown — both
+  // the list rows and the review title render it here, right of the signals.
   import Icon from './Icon.svelte';
   import { store } from './store.svelte';
   import { mdiSourcePull, forgeIcon } from './icons';
 
   interface Props {
     url: string;
+    number: number;
     size?: number;
   }
-  let { url, size = 15 }: Props = $props();
+  let { url, number, size = 14 }: Props = $props();
 
-  // Only render an absolute http(s) link; a missing/relative url is dropped
-  // rather than emitting a dead anchor.
+  // Only link an absolute http(s) url; otherwise still show the number, unlinked.
   const valid = $derived(/^https?:\/\//i.test(url));
   // The forge's display name ("GitHub"/"GitLab"/"Forgejo") from the brand-icon
   // registry, falling back to a neutral noun if meta hasn't loaded.
@@ -26,9 +27,11 @@
     href={url}
     target="_blank"
     rel="noopener noreferrer"
-    title={`Open PR on ${forgeName}`}
-    aria-label={`Open PR on ${forgeName}`}
+    title={`Open PR #${number} on ${forgeName}`}
+    aria-label={`Open PR #${number} on ${forgeName}`}
   >
-    <Icon path={mdiSourcePull} {size} />
+    <Icon path={mdiSourcePull} {size} /> #{number}
   </a>
+{:else}
+  <span class="forge-link forge-link-static"><Icon path={mdiSourcePull} {size} /> #{number}</span>
 {/if}

--- a/internal/web/src/lib/List.svelte
+++ b/internal/web/src/lib/List.svelte
@@ -9,6 +9,7 @@
   import Footer from './Footer.svelte';
   import Breakable from './Breakable.svelte';
   import MergeCommand from './MergeCommand.svelte';
+  import ForgeLink from './ForgeLink.svelte';
   import {
     mdiAlert,
     mdiPackageVariantClosed,
@@ -291,12 +292,12 @@
               <span class="badge caution" title="cautions"><Icon path={mdiAlert} size={13} /> {pr.signals.caution}</span>
             {/if}
             {#if pr.signals.images}
-              <span class="badge" title="image changes"><Icon path={mdiPackageVariantClosed} size={13} /> {pr.signals.images}</span>
+              <span class="badge" title={`${pr.signals.images} image change${pr.signals.images === 1 ? '' : 's'}`}><Icon path={mdiPackageVariantClosed} size={13} /> {pr.signals.images}</span>
             {/if}
             {#if pr.signals.failures}
               <span class="badge danger" title="render failures"><Icon path={mdiAlertCircleOutline} size={13} /> {pr.signals.failures}</span>
             {/if}
-            <span class="badge muted" title="changed resources">
+            <span class="badge muted" title={`${pr.signals.resources} resource change${pr.signals.resources === 1 ? '' : 's'}`}>
               <Icon path={mdiFileDocumentOutline} size={13} /> {pr.signals.resources}
             </span>
           </span>
@@ -309,6 +310,9 @@
         {/if}
       </div>
       </button>
+      <!-- Link out to the PR on its forge. Sibling of the card <button> (it can't
+           nest an anchor), so it sits just right of the resource count. -->
+      <ForgeLink url={pr.url} />
       <!-- Disclosure for the inline summary. Sibling of the card <button> (a
            button can't nest), only shown once the PR has rendered signals. -->
       {#if pr.signals}
@@ -324,6 +328,10 @@
             <Icon path={isExpanded(pr.number) ? mdiChevronUp : mdiChevronDown} size={18} />
           {/if}
         </button>
+      {:else}
+        <!-- Reserve the disclosure column's width so the forge link aligns into a
+             column across rows whether or not a PR has rendered a summary yet. -->
+        <span class="card-expand-spacer" aria-hidden="true"></span>
       {/if}
     </div>
     {#if isExpanded(pr.number) && previewReady(pr.number)}

--- a/internal/web/src/lib/List.svelte
+++ b/internal/web/src/lib/List.svelte
@@ -19,7 +19,6 @@
     mdiRefresh,
     mdiTagOutline,
     mdiSourceBranch,
-    mdiSourcePull,
     mdiClose,
     mdiFilterOutline,
     mdiSortVariant,
@@ -142,10 +141,6 @@
     return /^[0-9a-f]+$/i.test(hex) && hex.length > 12 ? `${v.slice(0, i + 1)}${hex.slice(0, 12)}…` : v;
   }
 
-  // pending/running render as icons below and ready carries signal badges, so
-  // this fallback only labels the terminal error state.
-  const statusLabel: Record<string, string> = { error: 'failed' };
-
   // A '#'-prefixed color for a label dot, or '' when the forge gave no usable
   // hex (e.g. GitLab) — validated so a stray value can't reach the style binding.
   const labelColor = (l: { color?: string }) =>
@@ -262,7 +257,6 @@
         <span class="card-title"><Breakable text={pr.title} /></span>
       </div>
       <div class="card-meta">
-        <span class="pr-id"><Icon path={mdiSourcePull} size={12} /> #{pr.number}</span>
         <span class="card-author"><Avatar src={pr.authorAvatar} size={15} /> {pr.author || 'unknown'}</span>
         {#if pr.draft}<span class="tag">draft</span>{/if}
         {#if pr.baseRef && defaultBase && pr.baseRef !== defaultBase}
@@ -301,20 +295,15 @@
               <Icon path={mdiFileDocumentOutline} size={13} /> {pr.signals.resources}
             </span>
           </span>
-        {:else if pr.open && pr.status === 'running'}
-          <span class="card-status running"><Spinner size={14} /> rendering</span>
-        {:else if pr.open && pr.status === 'pending'}
-          <span class="card-status"><Icon path={mdiTrayFull} size={13} /> queued</span>
-        {:else if pr.open}
-          <span class="card-status s-{pr.status}">{statusLabel[pr.status] ?? pr.status}</span>
         {/if}
       </div>
       </button>
       <!-- Link out to the PR on its forge. Sibling of the card <button> (it can't
            nest an anchor), so it sits just right of the resource count. -->
-      <ForgeLink url={pr.url} />
-      <!-- Disclosure for the inline summary. Sibling of the card <button> (a
-           button can't nest), only shown once the PR has rendered signals. -->
+      <ForgeLink url={pr.url} number={pr.number} />
+      <!-- Right column: the expand chevron once a PR has a rendered summary;
+           otherwise a state icon — rendering / queued / failed — carried by the
+           icon and its tooltip, no text (so the row stays compact, incl. mobile). -->
       {#if pr.signals}
         <button
           class="card-expand"
@@ -328,6 +317,18 @@
             <Icon path={isExpanded(pr.number) ? mdiChevronUp : mdiChevronDown} size={18} />
           {/if}
         </button>
+      {:else if pr.open && (pr.status === 'running' || pr.status === 'pending')}
+        <span
+          class="card-state"
+          title={pr.status === 'running' ? 'Rendering…' : 'Queued to render'}
+          aria-label={pr.status === 'running' ? 'Rendering' : 'Queued to render'}
+        >
+          {#if pr.status === 'running'}<Spinner size={16} />{:else}<Icon path={mdiTrayFull} size={16} />{/if}
+        </span>
+      {:else if pr.open && pr.status === 'error'}
+        <span class="card-state error" title={pr.error ? `Render failed: ${pr.error}` : 'Render failed'} aria-label="Render failed">
+          <Icon path={mdiAlertCircleOutline} size={18} />
+        </span>
       {:else}
         <!-- Reserve the disclosure column's width so the forge link aligns into a
              column across rows whether or not a PR has rendered a summary yet. -->

--- a/internal/web/src/lib/Review.svelte
+++ b/internal/web/src/lib/Review.svelte
@@ -9,7 +9,6 @@
     mdiArrowLeft,
     mdiChevronLeft,
     mdiChevronRight,
-    mdiOpenInNew,
     mdiSourceMerge,
     mdiSourcePull,
     mdiTrayFull,
@@ -18,10 +17,10 @@
   } from './icons';
   import Diffs from './Diffs.svelte';
   import Copy from './Copy.svelte';
+  import ForgeLink from './ForgeLink.svelte';
 
   const route = $derived(router.route.name === 'review' ? router.route : null);
   const pr = $derived(currentPR());
-  const forgeUrl = $derived(pr && /^https?:\/\//i.test(pr.url) ? pr.url : null);
   const merged = $derived(pr ? !pr.open : false);
 </script>
 
@@ -43,6 +42,7 @@
       </div>
       <div class="review-title">
         <span class="rt-name"><Breakable text={pr?.title ?? ''} /></span>
+        {#if pr}<ForgeLink url={pr.url} size={16} />{/if}
         <div class="rt-meta">
           <span class="rt-tag pr-id"><Icon path={mdiSourcePull} size={13} /> #{route.pr}</span>
           {#if pr}
@@ -57,11 +57,6 @@
             {#if pr.updatedAt}
               <span class="rt-tag ago" title={`Last rendered ${absolute(pr.updatedAt)}`}><Icon path={mdiRefresh} size={13} /> {timeAgo(pr.updatedAt, clock.now)}</span>
             {/if}
-          {/if}
-          {#if forgeUrl}
-            <a class="rt-tag ext" href={forgeUrl} target="_blank" rel="noopener noreferrer">
-              <Icon path={mdiOpenInNew} size={13} /> open
-            </a>
           {/if}
         </div>
       </div>

--- a/internal/web/src/lib/Review.svelte
+++ b/internal/web/src/lib/Review.svelte
@@ -10,7 +10,6 @@
     mdiChevronLeft,
     mdiChevronRight,
     mdiSourceMerge,
-    mdiSourcePull,
     mdiTrayFull,
     mdiClockOutline,
     mdiRefresh,
@@ -42,9 +41,8 @@
       </div>
       <div class="review-title">
         <span class="rt-name"><Breakable text={pr?.title ?? ''} /></span>
-        {#if pr}<ForgeLink url={pr.url} size={16} />{/if}
+        {#if pr}<ForgeLink url={pr.url} number={pr.number} size={16} />{/if}
         <div class="rt-meta">
-          <span class="rt-tag pr-id"><Icon path={mdiSourcePull} size={13} /> #{route.pr}</span>
           {#if pr}
             <span class="rt-tag rt-author"><Avatar src={pr.authorAvatar} size={16} /> {pr.author}</span>
             <span class="rt-tag sha-wrap">

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -39,10 +39,10 @@ test('list → review → single-page flow', async ({ page }) => {
 
   // Landing list: cards with per-PR signal badges.
   await expect(page.locator('.card')).toHaveCount(3);
-  const card142 = page.locator('.card', { hasText: '#142' });
-  // The PR number lives in the meta row (behind a PR glyph), so the title owns
-  // its own line and carries no "#142".
-  await expect(card142.locator('.pr-id')).toContainText('#142');
+  const card142 = page.locator('.card-shell', { hasText: '#142' });
+  // The PR number now lives in the forge link (right of the badges), clickable
+  // out to the forge — the only place it's shown.
+  await expect(card142.locator('.forge-link')).toContainText('#142');
   await expect(card142.locator('.card-title')).toHaveText(
     'feat(rook-ceph): bump the rook-ceph operator and cluster chart to v1.15.0',
   );
@@ -50,7 +50,7 @@ test('list → review → single-page flow', async ({ page }) => {
   await expect(card142.locator('.ago').first()).toHaveText(/ago|just now/); // humanized timestamps
   // Author avatar renders when present; a PR without one falls back to the icon.
   await expect(card142.locator('img.avatar')).toBeVisible();
-  await expect(page.locator('.card', { hasText: '#138' }).locator('img.avatar')).toHaveCount(0);
+  await expect(page.locator('.card-shell', { hasText: '#138' }).locator('img.avatar')).toHaveCount(0);
   // PR age: a clock icon + relative time (the full "Opened …" date is in the
   // title, so the word itself is dropped), plus a colored label dot.
   await expect(card142.locator('.ago[title^="Opened"]')).toBeVisible();
@@ -65,7 +65,7 @@ test('list → review → single-page flow', async ({ page }) => {
   const forge142 = page.locator('.card-shell', { hasText: '#142' }).locator('.forge-link');
   await expect(forge142).toHaveAttribute('href', 'https://github.com/acme/home-ops/pull/142');
   await expect(forge142).toHaveAttribute('target', '_blank');
-  await expect(forge142).toHaveAttribute('title', 'Open PR on GitHub');
+  await expect(forge142).toHaveAttribute('title', 'Open PR #142 on GitHub');
 
   // Open a PR → the single-page review lands on the Summary (impact, warnings,
   // image changes, render failures), with the tree rail alongside it.
@@ -80,7 +80,7 @@ test('list → review → single-page flow', async ({ page }) => {
     'href',
     'https://github.com/acme/home-ops/pull/142',
   );
-  await expect(page.locator('.review-title .forge-link')).toHaveAttribute('title', 'Open PR on GitHub');
+  await expect(page.locator('.review-title .forge-link')).toHaveAttribute('title', 'Open PR #142 on GitHub');
   // The tree: a Summary node (selected by default) + one leaf per changed
   // resource. A caution surfaces a marker on the Summary node.
   await expect(page.locator('.tree .tree-summary')).toHaveClass(/selected/);
@@ -113,8 +113,8 @@ test('landing health summary + non-default base branch tag', async ({ page }) =>
   await expect(summary.locator('.sum-pill.merged')).toContainText('1 merged');
 
   // Most PRs target main, so only #138 (→ staging) is flagged with a base tag.
-  await expect(page.locator('.card', { hasText: '#138' }).locator('.base-tag')).toContainText('staging');
-  await expect(page.locator('.card', { hasText: '#142' }).locator('.base-tag')).toHaveCount(0);
+  await expect(page.locator('.card-shell', { hasText: '#138' }).locator('.base-tag')).toContainText('staging');
+  await expect(page.locator('.card-shell', { hasText: '#142' }).locator('.base-tag')).toHaveCount(0);
 });
 
 test('a failed refresh keeps the diff and flags it (list badge + review strip)', async ({ page }) => {
@@ -129,7 +129,7 @@ test('a failed refresh keeps the diff and flags it (list badge + review strip)',
   await page.goto('/');
 
   // The card flags the failed refresh but still shows the last-good signal badges.
-  const card = page.locator('.card', { hasText: '#142' });
+  const card = page.locator('.card-shell', { hasText: '#142' });
   await expect(card.locator('.badge[title*="refresh"]')).toBeVisible();
   await expect(card.locator('.badge.danger').first()).toBeVisible();
 
@@ -213,10 +213,16 @@ test('list shows a spinner for rendering PRs and a queued icon for pending', asy
   await page.routeWebSocket('**/ws', () => {});
   await page.goto('/');
 
-  const running = page.locator('.card', { hasText: 'busy pr' });
-  await expect(running.locator('.card-status.running .kspin')).toBeVisible(); // thematic wheel spinner
-  await expect(running).toContainText('rendering');
-  await expect(page.locator('.card', { hasText: 'waiting pr' })).toContainText('queued');
+  // Rendering: a spinner fills the right (disclosure) column — no "rendering" text.
+  const running = page.locator('.card-shell', { hasText: 'busy pr' });
+  await expect(running.locator('.card-state .kspin')).toBeVisible(); // thematic wheel spinner
+  await expect(running.locator('.card-state')).toHaveAttribute('title', 'Rendering…');
+  await expect(running).not.toContainText('rendering');
+
+  // Pending: a queued icon, again with no text — the tooltip carries it.
+  const waiting = page.locator('.card-shell', { hasText: 'waiting pr' });
+  await expect(waiting.locator('.card-state')).toHaveAttribute('title', 'Queued to render');
+  await expect(waiting).not.toContainText('queued');
 });
 
 test('the PR list loads without a loading mascot, then the list arrives', async ({ page }) => {
@@ -291,7 +297,7 @@ test('filter narrows the PR list', async ({ page }) => {
   await page.goto('/');
   await page.getByPlaceholder('Filter pull requests…').fill('plex');
   await expect(page.locator('.card')).toHaveCount(1);
-  await expect(page.locator('.card')).toContainText('#131');
+  await expect(page.locator('.card-shell')).toContainText('#131');
 });
 
 test('the filter understands facet tokens (status:/author:/base:/label:)', async ({ page }) => {
@@ -301,16 +307,16 @@ test('the filter understands facet tokens (status:/author:/base:/label:)', async
 
   await input.fill('status:caution');
   await expect(page.locator('.card')).toHaveCount(1);
-  await expect(page.locator('.card')).toContainText('#142');
+  await expect(page.locator('.card-shell')).toContainText('#142');
 
   // Tokens AND together, and with free text.
   await input.fill('author:octocat base:staging');
   await expect(page.locator('.card')).toHaveCount(1);
-  await expect(page.locator('.card')).toContainText('#138');
+  await expect(page.locator('.card-shell')).toContainText('#138');
 
   await input.fill('label:media plex');
   await expect(page.locator('.card')).toHaveCount(1);
-  await expect(page.locator('.card')).toContainText('#131');
+  await expect(page.locator('.card-shell')).toContainText('#131');
 
   // The clear button empties the query and restores the list.
   await page.locator('.search-box .clear-btn').click();
@@ -376,7 +382,7 @@ test('summary pills filter by status; the sort selector reorders', async ({ page
   await page.goto('/');
 
   // Default sort: created desc → #138 (06-03) > #142 (06-01) > #131 (05-30).
-  const ids = page.locator('.cards .pr-id');
+  const ids = page.locator('.cards .forge-link');
   await expect(ids.nth(0)).toContainText('#138');
   await expect(ids.nth(1)).toContainText('#142');
   await expect(ids.nth(2)).toContainText('#131');
@@ -392,7 +398,7 @@ test('summary pills filter by status; the sort selector reorders', async ({ page
   await caution.click();
   await expect(caution).toHaveAttribute('aria-pressed', 'true');
   await expect(page.locator('.card')).toHaveCount(1);
-  await expect(page.locator('.card')).toContainText('#142');
+  await expect(page.locator('.card-shell')).toContainText('#142');
   await caution.click();
   await expect(page.locator('.card')).toHaveCount(3);
 
@@ -431,7 +437,7 @@ test('the open pill filters back to all open and hides the merged shelf', async 
 test('list sort: direction toggle, and changing field resets to its natural order', async ({ page }) => {
   await stubApi(page);
   await page.goto('/');
-  const ids = page.locator('.cards .pr-id');
+  const ids = page.locator('.cards .forge-link');
   const dir = page.locator('.sort-dir');
 
   // created desc (default) → newest first.
@@ -548,7 +554,7 @@ test('mobile: a long PR title wraps to two lines instead of truncating', async (
   await page.setViewportSize({ width: 390, height: 844 });
   await stubApi(page);
   await page.goto('/');
-  const title = page.locator('.card', { hasText: '#142' }).locator('.card-title');
+  const title = page.locator('.card-shell', { hasText: '#142' }).locator('.card-title');
   await title.waitFor();
   // Two-line clamp is engaged on mobile (single-line truncation uses nowrap).
   await expect(title).toHaveCSS('white-space', 'normal');
@@ -969,7 +975,7 @@ test('list footer: project links, version, license, year — and no topbar GitHu
   await expect(page.locator('.actions a')).toHaveCount(0);
 
   // The review screen stays footer-free (its panes own the space).
-  await page.locator('.card', { hasText: '#142' }).click();
+  await page.locator('.card-shell', { hasText: '#142' }).click();
   await expect(page.locator('.impact')).toBeVisible();
   await expect(page.locator('.footer')).toHaveCount(0);
 });
@@ -1033,7 +1039,7 @@ test('captures list + overview screenshots (light)', async ({ page }) => {
   await expect(page.locator('.card')).toHaveCount(3);
   await page.screenshot({ path: 'screenshots/konflate-list.png' });
 
-  await page.locator('.card', { hasText: '#142' }).click();
+  await page.locator('.card-shell', { hasText: '#142' }).click();
   await expect(page.locator('.impact')).toBeVisible();
   await page.screenshot({ path: 'screenshots/konflate-overview.png' });
 });

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -55,6 +55,17 @@ test('list → review → single-page flow', async ({ page }) => {
   // title, so the word itself is dropped), plus a colored label dot.
   await expect(card142.locator('.ago[title^="Opened"]')).toBeVisible();
   await expect(card142.locator('.label-dot')).toBeVisible();
+  // Signal-icon tooltips spell out the count (images is singular at 1).
+  await expect(card142.locator('.badge.muted')).toHaveAttribute('title', '3 resource changes');
+  await expect(
+    card142.locator('.badge:not(.caution):not(.danger):not(.muted):not(.warn)'),
+  ).toHaveAttribute('title', '1 image change');
+  // A PR-icon link, right of the badges, opens the PR on its forge (named in the
+  // tooltip). It's a sibling of the card button, so scope to the shell.
+  const forge142 = page.locator('.card-shell', { hasText: '#142' }).locator('.forge-link');
+  await expect(forge142).toHaveAttribute('href', 'https://github.com/acme/home-ops/pull/142');
+  await expect(forge142).toHaveAttribute('target', '_blank');
+  await expect(forge142).toHaveAttribute('title', 'Open PR on GitHub');
 
   // Open a PR → the single-page review lands on the Summary (impact, warnings,
   // image changes, render failures), with the tree rail alongside it.
@@ -64,6 +75,12 @@ test('list → review → single-page flow', async ({ page }) => {
   await expect(page.locator('.warning.caution', { hasText: 'StatefulSet' })).toBeVisible();
   await expect(page.locator('.img-list')).toContainText('ghcr.io/rook/ceph');
   await expect(page.locator('.failure')).toContainText('plex');
+  // The same forge link sits next to the PR title on the review header.
+  await expect(page.locator('.review-title .forge-link')).toHaveAttribute(
+    'href',
+    'https://github.com/acme/home-ops/pull/142',
+  );
+  await expect(page.locator('.review-title .forge-link')).toHaveAttribute('title', 'Open PR on GitHub');
   // The tree: a Summary node (selected by default) + one leaf per changed
   // resource. A caution surfaces a marker on the Summary node.
   await expect(page.locator('.tree .tree-summary')).toHaveClass(/selected/);


### PR DESCRIPTION
## What

Forge-link + signal affordances on the PR list and review header.

1. **The PR number is the forge link.** A pull-request-glyph link showing `#N`, clickable out to the PR on its forge, with a forge-named tooltip (`Open PR #N on GitHub` / `GitLab` / `Forgejo`, from `meta.forge`). It's now the **only** place the number is shown — removing the prior duplication (the author-adjacent `#N` on list rows and the `#N` chip in the review meta row).
   - **List:** right of the resource count; a reserved spacer keeps it aligned into a column across rows.
   - **Review header:** next to the PR title (replaces the old `mdiOpenInNew` "open" chip *and* the meta `#N`).
2. **Count tooltips** on the list signal icons: the images / resources badges spell out their count on hover — `3 resource changes`, `1 image change` (singular at 1).
3. **Icon-only render state.** The right-edge (disclosure) column carries the state with no text: the expand chevron once a summary is rendered, a **spinner** while queued/rendering, a red **failed icon** on error. The icon's `title`/`aria-label` carries it (on mobile the icon still reads even without a tooltip; the colored status dot by the title labels state too).

New shared `ForgeLink.svelte` (renders for an absolute `http(s)` url; otherwise shows the number unlinked). Dead `.pr-id` / `.card-status` CSS and the `statusLabel` map removed.

## Verify

`ui-typecheck` (0) ✅ · `ui-test` (60 Playwright) ✅ · `ui-build` ✅ — `ui.spec.ts` covers the forge link's href/target/tooltip + `#N` text on both surfaces, the two badge tooltips, and the spinner/queued/failed state icons (no status text).

_Tooltips are native `title` attributes, so they don't show in static screenshots — they're covered by the Playwright assertions._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
