### PR TITLE
fix: PR-filter data-loss, image-collapse, CronJob lint, and shutdown-lifecycle fixes

### DIFF
--- a/cmd/konflate/main.go
+++ b/cmd/konflate/main.go
@@ -67,11 +67,18 @@ func run() error {
 	srv := server.New(cfg, prov, engine.New(cfg), web.FS(), logger)
 	srv.Version = version // surfaced at /api/meta for the UI footer
 
-	// Honour the usual termination signals plus SIGHUP/SIGQUIT (matching the
-	// org's services) for a graceful shutdown.
-	ctx, stop := signal.NotifyContext(context.Background(),
-		syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT)
+	// Graceful shutdown on the usual termination signals. SIGQUIT is deliberately
+	// left to Go's default (goroutine dump + crash) so a wedged drain stays
+	// diagnosable, and SIGHUP is not captured. stop() runs as soon as the first
+	// signal arrives — not just deferred to run's end — so a second signal restores
+	// default handling and force-terminates instead of being swallowed during a
+	// slow drain.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+	go func() {
+		<-ctx.Done()
+		stop() // re-arm default termination for a second signal
+	}()
 
 	// Best-effort background GC of flate's on-disk source cache so it doesn't
 	// grow without bound across the process lifetime. Stops with ctx; disabled

--- a/internal/diff/lint.go
+++ b/internal/diff/lint.go
@@ -252,12 +252,20 @@ func intField(m map[string]any, keys ...string) (int64, bool) {
 	}
 }
 
-// hasPrivilegedContainer reports whether any container in the pod spec — at the
-// pod location (spec) or the workload template location (spec.template.spec) —
-// sets securityContext.privileged: true.
+// hasPrivilegedContainer reports whether any container in the pod spec sets
+// securityContext.privileged: true, at any of the locations a pod template
+// appears: the bare Pod (spec), the workload template most kinds use
+// (spec.template.spec), and the CronJob's nested job template
+// (spec.jobTemplate.spec.template.spec). Without the last, a privileged
+// container in a CronJob would slip past the caution that an identical one in a
+// Deployment raises.
 func hasPrivilegedContainer(m map[string]any) bool {
 	const spec = "spec"
-	for _, base := range [][]string{{spec}, {spec, "template", spec}} {
+	for _, base := range [][]string{
+		{spec},
+		{spec, "template", spec},
+		{spec, "jobTemplate", spec, "template", spec},
+	} {
 		podSpec, ok := nestedMap(m, base...)
 		if !ok {
 			continue

--- a/internal/diff/lint_test.go
+++ b/internal/diff/lint_test.go
@@ -48,6 +48,29 @@ func privilegedDeploymentManifest() map[string]any {
 	}
 }
 
+// privilegedCronJobManifest puts a privileged container at the deeper location a
+// CronJob nests its pod template: spec.jobTemplate.spec.template.spec.containers.
+func privilegedCronJobManifest() map[string]any {
+	return map[string]any{
+		"spec": map[string]any{
+			"jobTemplate": map[string]any{
+				"spec": map[string]any{
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name":            "backup",
+									"securityContext": map[string]any{"privileged": true},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func TestLint(t *testing.T) {
 	t.Parallel()
 
@@ -97,6 +120,14 @@ func TestLint(t *testing.T) {
 				New: privilegedDeploymentManifest(),
 			}},
 			want: []api.Warning{{Level: api.LevelCaution, Rule: "privileged", Resource: "Deployment web/api"}},
+		},
+		{
+			name: "a privileged container in a CronJob is flagged (deeper pod-template nesting)",
+			changes: []Change{{
+				Status: "changed", Kind: "CronJob", Namespace: "ops", Name: "backup",
+				New: privilegedCronJobManifest(),
+			}},
+			want: []api.Warning{{Level: api.LevelCaution, Rule: "privileged", Resource: "CronJob ops/backup"}},
 		},
 		{
 			name:    "added ClusterRoleBinding widens RBAC (caution)",

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -294,6 +294,41 @@ func TestImageChanges(t *testing.T) {
 	}
 }
 
+// deployWithInit builds a Deployment with a main container and (when init != "")
+// an init container, so a single resource can reference one repo at two tags.
+func deployWithInit(ns, name, main, init string) map[string]any {
+	spec := map[string]any{"containers": []any{map[string]any{"name": "c", "image": main}}}
+	if init != "" {
+		spec["initContainers"] = []any{map[string]any{"name": "i", "image": init}}
+	}
+	return res("Deployment", ns, name, map[string]any{
+		"spec": map[string]any{"template": map[string]any{"spec": spec}},
+	})
+}
+
+// TestImageChanges_SameRepoMultipleTags guards against the last-write-wins
+// collapse: a repository referenced at two tags at once (a main and an init
+// container) must not be flattened to one version and reported as a transition
+// no container underwent. Here the PR only deletes the init container (which
+// pinned the newer tag) and leaves the main container's tag untouched, so the
+// one honest change is the removal of the init's tag — never a "1.26 → 1.25"
+// downgrade of the main container.
+func TestImageChanges_SameRepoMultipleTags(t *testing.T) {
+	t.Parallel()
+	changes := []diff.Change{{
+		Status: "changed", Kind: "Deployment", Namespace: "apps", Name: "web",
+		Old: deployWithInit("apps", "web", "ghcr.io/app:1.25", "ghcr.io/app:1.26"),
+		New: deployWithInit("apps", "web", "ghcr.io/app:1.25", ""),
+	}}
+	got := imageChanges(changes)
+	if len(got) != 1 {
+		t.Fatalf("got %d image changes, want 1 (the init tag removed): %+v", len(got), got)
+	}
+	if c := got[0]; c.Name != "ghcr.io/app" || c.From != "1.26" || c.To != "" {
+		t.Errorf("got %+v, want ghcr.io/app 1.26→'' (a removal), not a fabricated downgrade", c)
+	}
+}
+
 // splitImageRef's behavior now lives in flate's image.Split (tested in
 // flate); konflate's collectImages composes image.Extract + image.Split,
 // exercised end to end by TestImageChanges above.

--- a/internal/engine/images.go
+++ b/internal/engine/images.go
@@ -43,7 +43,9 @@ func imageChanges(changes []diff.Change) []api.ImageChange {
 		oldImgs := collectImages(c.Old)
 		newImgs := collectImages(c.New)
 		for _, repo := range unionKeys(oldImgs, newImgs) {
-			record(repo, oldImgs[repo], newImgs[repo], ref)
+			for _, t := range repoTransitions(oldImgs[repo], newImgs[repo]) {
+				record(repo, t.from, t.to, ref)
+			}
 		}
 	}
 
@@ -62,19 +64,81 @@ func imageChanges(changes []diff.Change) []api.ImageChange {
 	return out
 }
 
-// collectImages returns a map of image repository → tag or digest for every
-// container image referenced in a manifest. The detection is flate's
-// image.Extract — value-based, so it finds references anywhere in the tree
-// (not just under containers[]/initContainers[]: CNPG spec.imageName, a CRD
-// default, a sidecar under an arbitrary field) — and image.Split separates
-// each into (repository, version) robustly (a digest beats a tag; a
-// registry port is not mistaken for the version). nil manifest yields an
-// empty map.
-func collectImages(m map[string]any) map[string]string {
-	out := map[string]string{}
+// repoTransition is one before→after move of a single image repository; an empty
+// from is a pure addition, an empty to a pure removal.
+type repoTransition struct{ from, to string }
+
+// repoTransitions pairs the before/after versions of one image repository into
+// from→to moves. The everyday case — exactly one version on each side — is the
+// familiar tag bump (old → new). When a repository appears at several versions
+// at once (the same image in a main and an init container on different tags),
+// pairing is ambiguous, so the symmetric difference is reported as discrete
+// removals (to == "") and additions (from == "") rather than inventing a
+// transition no container underwent — e.g. deleting an init container that
+// pinned a newer tag must not read as a downgrade of the main container.
+// Versions present on both sides are unchanged and yield nothing.
+func repoTransitions(oldVers, newVers []string) []repoTransition {
+	removed := setDiff(oldVers, newVers)
+	added := setDiff(newVers, oldVers)
+	if len(removed) == 1 && len(added) == 1 {
+		return []repoTransition{{from: removed[0], to: added[0]}}
+	}
+	out := make([]repoTransition, 0, len(removed)+len(added))
+	for _, v := range removed {
+		out = append(out, repoTransition{from: v})
+	}
+	for _, v := range added {
+		out = append(out, repoTransition{to: v})
+	}
+	return out
+}
+
+// setDiff returns the sorted elements of a that are absent from b.
+func setDiff(a, b []string) []string {
+	inB := make(map[string]struct{}, len(b))
+	for _, v := range b {
+		inB[v] = struct{}{}
+	}
+	out := make([]string, 0, len(a))
+	for _, v := range a {
+		if _, ok := inB[v]; !ok {
+			out = append(out, v)
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
+// collectImages returns a map of image repository → the distinct versions (tags
+// or digests) it is referenced at in a manifest. A repository may appear at more
+// than one version at once — the same image used by a main and an init container
+// on different tags — so versions are collected as a set per repository rather
+// than collapsed to a single (arbitrary, last-write-wins) value, which would let
+// imageChanges report a from→to transition no container actually underwent.
+//
+// The detection is flate's image.Extract — value-based, so it finds references
+// anywhere in the tree (not just under containers[]/initContainers[]: CNPG
+// spec.imageName, a CRD default, a sidecar under an arbitrary field) — and
+// image.Split separates each into (repository, version) robustly (a digest beats
+// a tag; a registry port is not mistaken for the version). nil manifest yields
+// an empty map.
+func collectImages(m map[string]any) map[string][]string {
+	seen := map[string]map[string]struct{}{}
 	for _, ref := range image.Extract(m) {
 		repo, ver := image.Split(ref)
-		out[repo] = ver
+		if seen[repo] == nil {
+			seen[repo] = map[string]struct{}{}
+		}
+		seen[repo][ver] = struct{}{}
+	}
+	out := make(map[string][]string, len(seen))
+	for repo, vers := range seen {
+		list := make([]string, 0, len(vers))
+		for v := range vers {
+			list = append(list, v)
+		}
+		slices.Sort(list)
+		out[repo] = list
 	}
 	return out
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -302,28 +302,40 @@ func (s *Server) refreshPR(ctx context.Context, number int, reason string) error
 	return nil
 }
 
-// prAllowed reports whether a PR should be rendered. Two gates, AND-ed: the fork
-// gate (KONFLATE_RENDER_FORK_PRS, default off) excludes forks regardless of the
-// expression — so editing the filter can't accidentally enable untrusted fork
-// rendering — and the CEL filter (KONFLATE_PR_FILTER_EXPR) decides the rest. A
-// PR that fails either is still tracked, but hidden and never rendered. A nil
-// filter admits every non-fork PR; that only happens when a Config is built
-// without Load (i.e. in tests). A runtime eval error hides the PR (and logs) —
-// but the expression is type-checked at startup, so a well-formed filter won't.
+// prAllowed reports whether a PR should be rendered — the render decision used
+// everywhere live. It collapses prVerdict's (allowed, error) result: a filter
+// evaluation error hides the PR (and logs). dropFilteredOnLoad is the one caller
+// that must tell an eval error apart from an intentional exclusion, so it uses
+// prVerdict directly (an error there must never delete persisted state).
 func (s *Server) prAllowed(pr api.PR) bool {
-	if pr.Fork && !s.cfg.RenderForkPRs {
-		return false // untrusted fork code: never rendered unless explicitly enabled
-	}
-	if s.cfg.PRFilter == nil {
-		return true
-	}
-	ok, err := s.cfg.PRFilter.Eval(prFilterVars(pr))
+	allowed, err := s.prVerdict(pr)
 	if err != nil {
 		s.log.Error("PR filter evaluation failed; hiding PR",
 			"pr", pr.Number, "expr", s.cfg.PRFilter.Source(), "error", err)
 		return false
 	}
-	return ok
+	return allowed
+}
+
+// prVerdict decides whether pr should be rendered, separating an intentional
+// exclusion (allowed=false, err=nil) from a filter evaluation error (err!=nil).
+// Two gates are AND-ed for the verdict: the fork gate (KONFLATE_RENDER_FORK_PRS,
+// default off) excludes forks regardless of the expression — so editing the
+// filter can't accidentally enable untrusted fork rendering — and the CEL filter
+// (KONFLATE_PR_FILTER_EXPR) decides the rest. A PR that fails either is still
+// tracked, but hidden and never rendered. A nil filter admits every non-fork PR;
+// that only happens when a Config is built without Load (i.e. in tests). The
+// error is non-nil only when the expression fails to evaluate (e.g. it
+// references a field the PR map doesn't carry); checkFilter turns that class of
+// mistake into a fail-fast startup error.
+func (s *Server) prVerdict(pr api.PR) (allowed bool, err error) {
+	if pr.Fork && !s.cfg.RenderForkPRs {
+		return false, nil // untrusted fork code: never rendered unless explicitly enabled
+	}
+	if s.cfg.PRFilter == nil {
+		return true, nil
+	}
+	return s.cfg.PRFilter.Eval(prFilterVars(pr))
 }
 
 // prFilterVars projects a PR into the `pr` variable the CEL filter evaluates

--- a/internal/server/queue.go
+++ b/internal/server/queue.go
@@ -43,6 +43,7 @@ type queue struct {
 	wg  sync.WaitGroup
 
 	mu       sync.Mutex
+	closing  bool // set by wait() during shutdown; a closing queue accepts no new work
 	inflight map[int]struct{}
 	pending  map[int]api.PR
 }
@@ -70,19 +71,26 @@ func (q *queue) enqueue(pr api.PR) {
 	// (config.PRFilterExpr) — forks are excluded by default and only tracked when
 	// an operator's expression admits them. So whatever arrives here renders.
 	q.mu.Lock()
+	if q.closing {
+		// Draining for shutdown: accept no new work. Gating wg.Add(1) here, under
+		// the same lock wait() uses to set closing, is what keeps an Add from
+		// racing wait()'s wg.Wait — a sync.WaitGroup misuse that can panic.
+		q.mu.Unlock()
+		return
+	}
 	if _, ok := q.inflight[pr.Number]; ok {
 		q.pending[pr.Number] = pr // coalesce; remember the freshest metadata
 		q.mu.Unlock()
 		return
 	}
 	q.inflight[pr.Number] = struct{}{}
+	q.wg.Add(1) // under mu and gated by !closing → never concurrent with wait()'s Wait
 	q.setDepthLocked()
 	q.mu.Unlock()
 
 	q.store.setStatus(pr, api.JobPending)
 	q.emit(pr.Number, api.JobPending, "")
 
-	q.wg.Add(1)
 	go q.run(pr)
 }
 
@@ -201,8 +209,19 @@ func (q *queue) clear(number int) {
 	q.mu.Unlock()
 }
 
-// wait blocks until all in-flight jobs finish (call after cancelling ctx).
-func (q *queue) wait() { q.wg.Wait() }
+// wait stops the queue accepting new work, then blocks until all in-flight jobs
+// finish. Setting closing under mu before wg.Wait — paired with enqueue calling
+// wg.Add only while holding mu and not closing — guarantees no Add runs
+// concurrently with this Wait (a refresh tick or webhook goroutine landing
+// mid-drain would otherwise risk Go's "WaitGroup misuse" panic, and any job it
+// enqueued would leak past shutdown). Call after the context is cancelled so
+// in-flight renders observe it and drain promptly.
+func (q *queue) wait() {
+	q.mu.Lock()
+	q.closing = true
+	q.mu.Unlock()
+	q.wg.Wait()
+}
 
 func (q *queue) emit(number int, status api.JobStatus, errMsg string) {
 	if q.notify != nil {

--- a/internal/server/queue_test.go
+++ b/internal/server/queue_test.go
@@ -258,3 +258,26 @@ func TestQueue_RunsConcurrently(t *testing.T) {
 	waitTerminal(t, st, 1)
 	waitTerminal(t, st, 2)
 }
+
+// TestQueue_ClosingRejectsNewWork verifies the shutdown gate: once wait() has
+// marked the queue closing, enqueue is a no-op — it starts no render and records
+// nothing. That gate (wg.Add only while holding mu and not closing) is what keeps
+// a refresh tick or webhook landing mid-drain from racing wg.Add against wg.Wait
+// or leaking a job past shutdown.
+func TestQueue_ClosingRejectsNewWork(t *testing.T) {
+	t.Parallel()
+	diff := func(context.Context, api.PR) (api.DiffResult, error) {
+		t.Error("a render started after the queue was marked closing")
+		return api.DiffResult{}, nil
+	}
+	st := newStore()
+	q := newQueue(context.Background(), diff, st, nil, nil, newMetrics(), discardLog(), 1)
+
+	q.wait() // no in-flight work: returns at once and marks the queue closing
+	q.enqueue(api.PR{Number: 1})
+
+	if _, ok := st.get(1); ok {
+		t.Fatal("enqueue on a closing queue must not record the PR")
+	}
+	q.wait() // must still return; would block here if enqueue had started a render
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -88,10 +88,20 @@ func New(cfg *config.Config, prov provider.Provider, eng Engine, ui fs.FS, log *
 // shelf is never re-listed — so without this, a merged entry the current filter
 // now excludes (e.g. a fork after tightening to !pr.fork) would linger across a
 // restart, reclaimed only by retention. Drop those, which deletes their files.
+//
+// It removes a PR only on a clean exclusion (the filter genuinely says no). A
+// filter *evaluation* error never deletes anything: a typo'd expression — which
+// CEL accepts at compile time, since pr is a dynamic map — would otherwise wipe
+// the whole recently-merged shelf on the next restart. Such a PR is kept as-is;
+// checkFilter (in Run) fails startup on the same error, so the operator fixes
+// the filter without losing persisted diffs.
 func (s *Server) dropFilteredOnLoad() {
-	dropped := 0
+	dropped, errored := 0, 0
 	for _, pr := range s.store.list() {
-		if !s.prAllowed(pr.PR) {
+		switch allowed, err := s.prVerdict(pr.PR); {
+		case err != nil:
+			errored++ // keep it; never delete on an eval error (see above)
+		case !allowed:
 			s.store.remove(pr.Number)
 			dropped++
 		}
@@ -99,15 +109,59 @@ func (s *Server) dropFilteredOnLoad() {
 	if dropped > 0 {
 		s.log.Info("dropped restored PRs no longer matching the filter", "count", dropped)
 	}
+	if errored > 0 {
+		s.log.Warn("kept restored PRs the filter could not evaluate; check KONFLATE_PR_FILTER_EXPR", "count", errored)
+	}
+}
+
+// checkFilter smoke-tests the compiled PR filter against a fully-populated
+// sample PR. The filter's pr variable is a dynamic map, so CEL accepts a
+// reference to a field that doesn't exist (e.g. pr.isDraft for the real
+// pr.draft) at compile time and only errors when evaluated — which at runtime
+// would silently hide every PR. Evaluating one representative PR here turns that
+// class of typo back into a fail-fast startup error, making good on the
+// documented "fails fast at startup" guarantee. The sample carries every
+// documented field (and one label, so label-field access is exercised — exists()
+// over an empty list never runs its body). A nil filter (only in tests) is a
+// no-op.
+func (s *Server) checkFilter() error {
+	if s.cfg.PRFilter == nil {
+		return nil
+	}
+	sample := api.PR{
+		Number: 1, Title: "sample", Author: "octocat", State: "open",
+		Open: true, Merged: false, Draft: false, Fork: false,
+		HeadRef: "feature", HeadSHA: "0000000", BaseRef: "main",
+		URL:       "https://example.invalid/pr/1",
+		CreatedAt: time.Unix(0, 0).UTC(),
+		Labels:    []api.Label{{Name: "example", Color: "ededed"}},
+	}
+	if _, err := s.cfg.PRFilter.Eval(prFilterVars(sample)); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Run starts both servers and blocks until ctx is cancelled or a server fails,
 // then drains in-flight diffs and shuts both down. It returns nil on a clean,
 // signal-triggered shutdown.
 func (s *Server) Run(ctx context.Context) error {
-	s.runCtx = ctx
+	// Fail fast on a filter that compiles but can't evaluate (e.g. a field typo,
+	// which CEL accepts on the dynamic pr map) — it would otherwise hide every PR
+	// at runtime. Before any goroutine starts or anything is served.
+	if err := s.checkFilter(); err != nil {
+		return fmt.Errorf("config: KONFLATE_PR_FILTER_EXPR: %w", err)
+	}
+
+	// gctx cancels when ctx is cancelled (shutdown) OR any server goroutine
+	// returns an error. Bind the render queue, the refresh loops, and the
+	// inbound-trigger goroutines (s.runCtx) to it so a server failure cancels
+	// in-flight renders too — the drain below then returns promptly instead of
+	// waiting out each render's full DiffTimeout while refreshLoop keeps feeding it.
+	g, gctx := errgroup.WithContext(ctx)
+	s.runCtx = gctx
 	s.queue = newQueue(
-		ctx, s.engine.Diff, s.store, s.hub.broadcast, s.reconcileHeadGone,
+		gctx, s.engine.Diff, s.store, s.hub.broadcast, s.reconcileHeadGone,
 		s.metrics, s.log, s.cfg.MaxDiffConcurrency,
 	)
 
@@ -127,10 +181,9 @@ func (s *Server) Run(ctx context.Context) error {
 	// Warm the PR list at startup so the UI has content immediately, then run the
 	// periodic refresh (re-list + per-PR staleness). Both are best effort —
 	// failures are logged inside.
-	go s.refreshList(ctx)
-	go s.refreshLoop(ctx)
+	go s.refreshList(gctx)
+	go s.refreshLoop(gctx)
 
-	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error { return serve(mainSrv, "main", s.log) })
 	g.Go(func() error { return serve(metricsSrv, "metrics", s.log) })
 	g.Go(func() error {
@@ -139,7 +192,7 @@ func (s *Server) Run(ctx context.Context) error {
 		defer cancel()
 		_ = mainSrv.Shutdown(sctx)
 		_ = metricsSrv.Shutdown(sctx)
-		s.queue.wait() // ctx is already cancelled; drain in-flight renders
+		s.queue.wait() // gctx is cancelled, so in-flight renders observe it and drain promptly
 		return nil
 	})
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -224,6 +224,75 @@ func TestServer_PRFilterExpr(t *testing.T) {
 	}
 }
 
+// TestServer_CheckFilterCatchesFieldTypo verifies the startup smoke-test: an
+// expression that references a field by the wrong name compiles (pr is a dynamic
+// map, so CEL can't catch it) but checkFilter rejects it, turning a runtime
+// "hide every PR" into a fail-fast startup error. A well-formed filter passes.
+func TestServer_CheckFilterCatchesFieldTypo(t *testing.T) {
+	t.Parallel()
+	typo, err := prfilter.Compile(`!pr.isDraft`) // real field is pr.draft
+	if err != nil {
+		t.Fatalf("the typo should compile (caught only at eval); got %v", err)
+	}
+	cfg := ghCfg("")
+	cfg.PRFilter = typo
+	s := newTestServer(t, cfg, &fakeProvider{}, okEngine())
+	if err := s.checkFilter(); err == nil {
+		t.Fatal("checkFilter must reject a filter referencing a nonexistent field")
+	}
+
+	good, err := prfilter.Compile(`!pr.draft && pr.baseRef == "main"`)
+	if err != nil {
+		t.Fatalf("compile good filter: %v", err)
+	}
+	s.cfg.PRFilter = good
+	if err := s.checkFilter(); err != nil {
+		t.Fatalf("checkFilter on a valid filter: %v", err)
+	}
+}
+
+// TestServer_DropFilteredOnLoadKeepsOnEvalError verifies a filter evaluation
+// error never deletes persisted state: a typo'd expression would otherwise wipe
+// the recently-merged shelf on restart. A cleanly-excluded PR is still dropped.
+func TestServer_DropFilteredOnLoadKeepsOnEvalError(t *testing.T) {
+	t.Parallel()
+	cfg := ghCfg("")
+	typo, err := prfilter.Compile(`pr.isMerged`) // real field is pr.merged
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	cfg.PRFilter = typo
+	s := newTestServer(t, cfg, &fakeProvider{}, okEngine())
+
+	// A merged PR on the shelf with a rendered diff — exactly what a filter typo
+	// must not destroy.
+	s.store.upsertPR(api.PR{Number: 5, Merged: true}, false)
+	s.store.setResult(5, api.DiffResult{PRNumber: 5})
+	s.store.markClosed(5, s.store.now())
+
+	s.dropFilteredOnLoad()
+	if _, ok := s.store.get(5); !ok {
+		t.Fatal("a filter eval error deleted persisted state; PR 5 must be kept")
+	}
+
+	// A clean exclusion still drops (the function's original job): pr.merged
+	// evaluates fine and excludes a non-merged PR.
+	good, err := prfilter.Compile(`pr.merged`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	s.cfg.PRFilter = good
+	s.store.upsertPR(api.PR{Number: 6, Open: true}, false)
+	s.store.setResult(6, api.DiffResult{PRNumber: 6})
+	s.dropFilteredOnLoad()
+	if _, ok := s.store.get(6); ok {
+		t.Fatal("a cleanly-excluded PR should be dropped on load")
+	}
+	if _, ok := s.store.get(5); !ok {
+		t.Fatal("PR 5 (merged, matches pr.merged) must still be kept")
+	}
+}
+
 func TestServer_RenderForkPRs(t *testing.T) {
 	t.Parallel()
 	fork := api.PR{Number: 7, Title: "fork PR", HeadRef: "patch", BaseRef: "main", HeadSHA: "s7", Open: true, Fork: true}


### PR DESCRIPTION
Resolves the four highest-severity findings from the full-codebase review, in one PR.

### Fixes #116 — filter eval error no longer deletes persisted state
`dropFilteredOnLoad` removed any PR `prAllowed` rejected — but that includes a *runtime eval error*, and since `pr` is a dynamic CEL map a field typo (`pr.isDraft` for `pr.draft`) compiles cleanly and only errors at eval. On restart that wiped the entire recently-merged shelf. Now it removes only on a clean exclusion (`prVerdict` surfaces the eval error so the load path keeps the PR), and a new `checkFilter` smoke-test evaluates a representative PR at the top of `Run`, turning that typo class into a **fail-fast startup error** — making the documented "fails fast at startup" guarantee true.

### Fixes #117 — image diffs no longer fabricate transitions
`collectImages` mapped each repository to one version (last-write-wins), so a repo referenced at two tags at once (a main + an init container) collapsed and `imageChanges` reported a from→to no container underwent (deleting an init container that pinned a newer tag read as a *downgrade* of the main), also feeding false major-image-bump cautions. Versions are now collected per repository and paired by symmetric difference: the everyday one-each-side case stays a clean bump; a genuinely multi-tag repo reports discrete add/remove instead of an invented swap.

### Fixes #118 — privileged containers in CronJobs are flagged
`hasPrivilegedContainer` only checked `spec` and `spec.template.spec`; the CronJob pod-template location `spec.jobTemplate.spec.template.spec` was added so a privileged container in a CronJob raises the same caution a Deployment's would.

### Fixes #119 — shutdown lifecycle
- The render queue, refresh loops, and inbound-trigger goroutines now run on the errgroup context, so a server failure cancels in-flight renders and the drain returns promptly instead of waiting out each render's full `DiffTimeout`.
- `queue.wait()` marks the queue *closing* under the same lock `enqueue` takes before `wg.Add`, so a refresh tick or webhook landing mid-drain can't race `wg.Add` against `wg.Wait` (a panic) or leak a job past shutdown.
- `main` traps only SIGINT/SIGTERM and re-arms default handling on the first signal (a second force-terminates a wedged drain); SIGQUIT is left to Go's default goroutine dump, and SIGHUP is no longer captured.

### Tests / verification
New tests: CronJob privileged lint, same-repo multi-tag image change, `checkFilter` typo rejection, `dropFilteredOnLoad` keeps-on-eval-error, queue closing-gate. `go test -race ./...`, `mise run lint` (0 issues), and `mise run fmt-check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)