### PR TITLE
perf(server): ETag/304 for the diff endpoint and unescaped JSON bodies

### DIFF
--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -69,6 +69,10 @@ type DiffEnvelope struct {
 	// rendered, so the UI shows an "excluded by the filter" notice rather than a
 	// perpetual "rendering" state.
 	Hidden bool `json:"hidden,omitempty"`
+	// Digest is the store's content version for this PR (its savedDigest). It lets
+	// the diff endpoint build an ETag without re-marshaling the body, and is never
+	// serialized — purely a server-internal handle carried alongside the envelope.
+	Digest uint64 `json:"-"`
 }
 
 // Meta is the non-secret identity of this konflate instance, served at

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -5,8 +5,10 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"hash/fnv"
 	"io"
 	"mime"
 	"net/http"
@@ -105,7 +107,69 @@ func (s *Server) handleDiff(w http.ResponseWriter, r *http.Request) {
 	if env.Status == api.JobPending || env.Status == api.JobRunning {
 		code = http.StatusAccepted
 	}
+	// A rendered diff is immutable until the next render, so serve a validator:
+	// the SPA refetches the full diff on every "ready" event and the staleness
+	// backstop re-renders open PRs ~every interval even when nothing changed, so
+	// without this each of those repaints re-marshals the multi-MB body. With an
+	// ETag they collapse to a 304 — no marshal, no transfer. Only for a ready 200
+	// carrying a diff; pending/error responses are transient or bodyless.
+	if code == http.StatusOK {
+		if etag := s.diffETag(env); etag != "" {
+			w.Header().Set("ETag", etag)
+			w.Header().Set("Cache-Control", "no-cache") // cacheable, but revalidate every use
+			if ifNoneMatch(r, etag) {
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+		}
+	}
 	writeJSON(w, code, env)
+}
+
+// diffETag derives a strong validator for a /diff response that carries a
+// rendered diff. It hashes the response's light fields (the whole envelope minus
+// the heavy Diff body) together with the diff's precomputed content digest
+// (env.Digest, the store's savedDigest), so the ETag changes whenever any part
+// of the response would change — without re-marshaling the multi-MB body. The
+// signed avatar path is part of the light fields, so a restart (which re-signs
+// it with a fresh key) yields a different ETag, never a stale 304. Returns ""
+// when there is no rendered diff to validate.
+func (s *Server) diffETag(env api.DiffEnvelope) string {
+	if env.Diff == nil {
+		return ""
+	}
+	light := env
+	light.Diff = nil // env.Digest already stands in for the body
+	meta, err := json.Marshal(light)
+	if err != nil {
+		return "" // never expected; fall back to an unconditional response
+	}
+	h := fnv.New64a()
+	var d [8]byte
+	binary.LittleEndian.PutUint64(d[:], env.Digest)
+	_, _ = h.Write(d[:])
+	_, _ = h.Write(meta)
+	return `"` + strconv.FormatUint(h.Sum64(), 16) + `"`
+}
+
+// ifNoneMatch reports whether the request's If-None-Match matches etag — an
+// exact strong-validator match, or "*". Per RFC 9110 the header is a
+// comma-separated list; konflate only emits strong ETags, so a strong compare is
+// correct.
+func ifNoneMatch(r *http.Request, etag string) bool {
+	inm := r.Header.Get("If-None-Match")
+	if inm == "" {
+		return false
+	}
+	if strings.TrimSpace(inm) == "*" {
+		return true
+	}
+	for _, candidate := range strings.Split(inm, ",") {
+		if strings.TrimSpace(candidate) == etag {
+			return true
+		}
+	}
+	return false
 }
 
 // handleSummary serves the same envelope as handleDiff but with the heavy
@@ -507,7 +571,12 @@ func (s *Server) reconcileHeadGone(number int) {
 func writeJSON(w http.ResponseWriter, code int, v any) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(code)
-	_ = json.NewEncoder(w).Encode(v)
+	enc := json.NewEncoder(w)
+	// These bodies are application/json with X-Content-Type-Options: nosniff, so
+	// they can't be sniffed as HTML — escaping </>/& to \u00xx only bloats the
+	// payload, and the diff is span-dense chroma HTML (~6x on those bytes).
+	enc.SetEscapeHTML(false)
+	_ = enc.Encode(v)
 }
 
 // writeError writes a JSON error body ({"error": msg}) with the given status.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -165,6 +165,62 @@ func TestServer_RefreshListAndDiff(t *testing.T) {
 	}
 }
 
+// TestServer_DiffETagConditional verifies the diff endpoint serves a strong
+// validator and honors If-None-Match: a matching conditional request gets a
+// bodyless 304 (no re-marshal of the diff), and a new render with different
+// content changes the ETag so a stale validator falls back to a full 200.
+func TestServer_DiffETagConditional(t *testing.T) {
+	t.Parallel()
+	s := newTestServer(t, ghCfg("tok"), &fakeProvider{}, okEngine())
+	h := s.mainHandler()
+	s.store.upsertPR(api.PR{Number: 7, Open: true}, false)
+	s.store.setResult(7, api.DiffResult{PRNumber: 7, ChromaCSS: ".a{}"})
+
+	rec := do(h, "GET", "/api/prs/7/diff", nil, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first diff: got %d, want 200", rec.Code)
+	}
+	etag := rec.Header().Get("ETag")
+	if etag == "" {
+		t.Fatal("a ready diff response must carry an ETag")
+	}
+
+	rec = do(h, "GET", "/api/prs/7/diff", nil, map[string]string{"If-None-Match": etag})
+	if rec.Code != http.StatusNotModified {
+		t.Fatalf("matching If-None-Match: got %d, want 304", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("a 304 must have an empty body, got %d bytes", rec.Body.Len())
+	}
+
+	// New render, different content → the validator changes, so the stale one
+	// no longer matches and the client gets a full response.
+	s.store.setResult(7, api.DiffResult{PRNumber: 7, ChromaCSS: ".b{}"})
+	rec = do(h, "GET", "/api/prs/7/diff", nil, map[string]string{"If-None-Match": etag})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("after a content change, a stale validator must get 200, got %d", rec.Code)
+	}
+	if rec.Header().Get("ETag") == etag {
+		t.Error("the ETag must change when the diff content changes")
+	}
+}
+
+// TestServer_DiffJSONNotHTMLEscaped verifies the API encoder leaves </>/&
+// unescaped (the bodies are application/json + nosniff, so escaping only bloats
+// the span-dense diff HTML).
+func TestServer_DiffJSONNotHTMLEscaped(t *testing.T) {
+	t.Parallel()
+	s := newTestServer(t, ghCfg("tok"), &fakeProvider{}, okEngine())
+	h := s.mainHandler()
+	s.store.upsertPR(api.PR{Number: 7, Open: true}, false)
+	s.store.setResult(7, api.DiffResult{PRNumber: 7, ChromaCSS: "x < y > z & w"})
+
+	body := do(h, "GET", "/api/prs/7/diff", nil, nil).Body.String()
+	if !strings.Contains(body, "x < y > z & w") {
+		t.Errorf("API JSON should not HTML-escape diff content; body = %s", body)
+	}
+}
+
 func TestServer_PRFilterExpr(t *testing.T) {
 	t.Parallel()
 	cfg := ghCfg("tok")

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -262,7 +262,15 @@ func (s *store) get(number int) (api.DiffEnvelope, bool) {
 	if j == nil {
 		return api.DiffEnvelope{}, false
 	}
-	return api.DiffEnvelope{Status: j.status, PR: j.pr, Diff: j.result, Error: j.errMsg, RefreshError: j.refreshErr, Hidden: j.hidden}, true
+	return api.DiffEnvelope{
+		Status:       j.status,
+		PR:           j.pr,
+		Diff:         j.result,
+		Error:        j.errMsg,
+		RefreshError: j.refreshErr,
+		Hidden:       j.hidden,
+		Digest:       j.savedDigest,
+	}, true
 }
 
 // activeNumbers returns the PRs currently treated as open (not yet marked


### PR DESCRIPTION
Fixes #139.

`GET /api/prs/{n}/diff` re-serialized the full pre-rendered `DiffResult` (multi-MB of chroma HTML, unified + side-by-side) on **every** request. The SPA refetches it on every websocket `ready` event, and the staleness backstop re-renders open PRs ~every interval even when nothing changed — so each repaint paid a full marshal on a GOMEMLIMIT-bounded pod.

### Changes

- **ETag + 304** — `handleDiff` serves a strong `ETag` (with `Cache-Control: no-cache`) on ready responses and returns `304 Not Modified` on a matching `If-None-Match`. The validator is `fnv(savedDigest, marshal(envelope−Diff))` — it **never touches the multi-MB body** (the store's precomputed `savedDigest` stands in for it), and the signed avatar path is part of the light fields so a restart (fresh signing key) can't serve a stale 304. The browser's default `fetch` revalidates automatically, so the SPA's per-`ready` refetch collapses to a conditional GET → 304, no marshal, no body.
- **No HTML escaping** — `writeJSON` sets `SetEscapeHTML(false)`. API bodies are `application/json` with `X-Content-Type-Options: nosniff`, so escaping `<`/`>`/`&` to `\u00xx` only inflated the span-dense diff HTML (~6× on those bytes) with no security benefit.

### Deliberately out of scope

- **Byte-caching the marshaled diff** (the issue's other suggestion) — it would double each PR's in-memory footprint, the wrong trade on a memory-bounded pod; a 304 saves both the CPU *and* the bytes for the dominant unchanged-refetch case.
- **gzip** — handled by the reverse proxy (see #129).

### Tests / verification

New: `TestServer_DiffETagConditional` (ETag present → matching `If-None-Match` → bodyless 304 → content change busts the ETag) and `TestServer_DiffJSONNotHTMLEscaped`. `go test -race ./...`, `mise run lint` (0 issues), `mise run fmt-check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)