### PR TITLE
fix(engine): sweep the source cache at startup and surface silent sweep errors

### DIFF
--- a/internal/engine/cachegc.go
+++ b/internal/engine/cachegc.go
@@ -9,13 +9,13 @@ import (
 	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
-// RunCacheGC periodically prunes flate's on-disk source cache under cacheDir,
-// removing entries (fetched Helm charts, OCI layers, git sources) whose mtime is
-// older than ttl. Without it the cache only grows — every distinct source any PR
-// ever rendered persists on the operator-mounted volume. Bare git mirrors are
-// preserved (re-hydrating one is an expensive full clone). It blocks until ctx
-// is cancelled; ttl <= 0 (or an empty cacheDir) disables GC and returns
-// immediately.
+// RunCacheGC prunes flate's on-disk source cache under cacheDir, removing entries
+// (fetched Helm charts, OCI layers, git sources) whose mtime is older than ttl.
+// Without it the cache only grows — every distinct source any PR ever rendered
+// persists on the operator-mounted volume. Bare git mirrors are preserved
+// (re-hydrating one is an expensive full clone). It sweeps once immediately and
+// then on a cadence, blocking until ctx is cancelled; ttl <= 0 (or an empty
+// cacheDir) disables GC and returns immediately.
 //
 // The sweep is safe to run alongside live renders: flate's source.Sweep holds an
 // exclusive GC lock that the cache's writers cooperate with, so a freshly
@@ -28,22 +28,43 @@ func RunCacheGC(ctx context.Context, cacheDir string, ttl time.Duration, log *sl
 		log = slog.Default()
 	}
 	layout := cacheroot.New(cacheDir)
-	ticker := time.NewTicker(cacheGCInterval(ttl))
+	sweepCacheGC(ctx, func() {
+		res, err := source.Sweep(layout, source.SweepOpts{MaxAge: ttl})
+		logSweep(log, res, err)
+	}, cacheGCInterval(ttl))
+}
+
+// sweepCacheGC is the testable core of RunCacheGC. It runs sweep once immediately
+// — so a pod that restarts more often than the interval still reclaims the cache,
+// instead of dying before the first tick (a full interval away) ever fires — then
+// on every tick until ctx is cancelled.
+func sweepCacheGC(ctx context.Context, sweep func(), interval time.Duration) {
+	sweep()
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			res, err := source.Sweep(layout, source.SweepOpts{MaxAge: ttl})
-			switch {
-			case err != nil:
-				log.Warn("source cache gc failed", "error", err)
-			case len(res.Removed) > 0:
-				log.Info("source cache gc",
-					"pruned", len(res.Removed), "bytes", res.Bytes, "errors", len(res.Errors))
-			}
+			sweep()
 		}
+	}
+}
+
+// logSweep records a sweep's outcome. A hard failure, or per-entry errors, are
+// surfaced even when nothing was removed — otherwise a chronically failing GC
+// (e.g. a permissions error on the cache volume) stays silent while the cache
+// grows toward a full disk.
+func logSweep(log *slog.Logger, res source.SweepResult, err error) {
+	switch {
+	case err != nil:
+		log.Warn("source cache gc failed", "error", err)
+	case len(res.Errors) > 0:
+		log.Warn("source cache gc completed with errors",
+			"pruned", len(res.Removed), "bytes", res.Bytes, "errors", len(res.Errors))
+	case len(res.Removed) > 0:
+		log.Info("source cache gc", "pruned", len(res.Removed), "bytes", res.Bytes)
 	}
 }
 

--- a/internal/engine/cachegc_test.go
+++ b/internal/engine/cachegc_test.go
@@ -1,8 +1,16 @@
 package engine
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/home-operations/flate/pkg/source"
 )
 
 // TestCacheGCInterval pins the sweep cadence: a fraction of the TTL clamped to
@@ -24,5 +32,53 @@ func TestCacheGCInterval(t *testing.T) {
 		if got := cacheGCInterval(c.ttl); got != c.want {
 			t.Errorf("cacheGCInterval(%s) = %s, want %s", c.ttl, got, c.want)
 		}
+	}
+}
+
+// TestSweepCacheGC_SweepsAtStartup verifies the first sweep runs immediately, not
+// a full interval later — so a pod that restarts more often than the interval
+// still reclaims the cache. The interval is huge so no tick can fire during the
+// test; any sweep observed is therefore the startup one.
+func TestSweepCacheGC_SweepsAtStartup(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	swept := make(chan struct{}, 1)
+	sweep := func() {
+		calls.Add(1)
+		select {
+		case swept <- struct{}{}:
+		default:
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		sweepCacheGC(ctx, sweep, time.Hour)
+		close(done)
+	}()
+
+	select {
+	case <-swept:
+	case <-time.After(2 * time.Second):
+		t.Fatal("no sweep at startup — the first sweep waited for a tick")
+	}
+	cancel()
+	<-done
+	if n := calls.Load(); n != 1 {
+		t.Fatalf("sweep ran %d times, want exactly 1 (startup only; no tick at a 1h interval)", n)
+	}
+}
+
+// TestLogSweep_SurfacesErrorsWithoutRemovals verifies a sweep that removed nothing
+// but hit per-entry errors is still logged, not silently dropped.
+func TestLogSweep_SurfacesErrorsWithoutRemovals(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logSweep(log, source.SweepResult{Errors: []error{errors.New("permission denied")}}, nil)
+	if out := buf.String(); !strings.Contains(out, "completed with errors") {
+		t.Errorf("a sweep with errors but no removals must be logged; got %q", out)
 	}
 }


### PR DESCRIPTION
Fixes #127.

`RunCacheGC` only swept on a `time.Ticker` tick, and the first tick is a full interval away (the interval is `clamp(ttl/8, 1h, 6h)`, so 6h at the default 168h TTL). A pod that restarts more often than that — OOM-killed, rescheduled, redeployed — died before its first sweep ever fired, so the source cache grew **unbounded** despite GC being enabled and the disk eventually filled.

It also had a silent-failure hole: the result switch logged only on a hard error or a non-empty `Removed`, so a sweep that removed nothing but hit per-entry errors (e.g. `EACCES` on the volume, failing before any removal) logged nothing at all — a chronically broken GC was invisible.

### Changes
- Sweep **once immediately**, then on the cadence. The sweep logic is pulled into a small testable seam (`sweepCacheGC(ctx, sweep func(), interval)`).
- `logSweep` now also warns when the result carries per-entry `Errors`, not just when something was pruned.

### Tests
- `TestSweepCacheGC_SweepsAtStartup` — with a 1h interval (so no tick fires), a sweep still happens exactly once.
- `TestLogSweep_SurfacesErrorsWithoutRemovals` — a result with errors but no removals is logged.

`go test -race ./...`, `mise run lint` (0 issues), `mise run fmt-check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)