### PR TITLE
fix(chart): tpl-render existingSecret/existingClaim/serviceAccount.name/prFilterExpr

### DIFF
--- a/charts/konflate/templates/_helpers.tpl
+++ b/charts/konflate/templates/_helpers.tpl
@@ -52,10 +52,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Service account name to use.
 */}}
 {{- define "konflate.serviceAccountName" -}}
+{{- $name := tpl (.Values.serviceAccount.name | default "") $ -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "konflate.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "konflate.fullname" .) $name }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- default "default" $name }}
 {{- end }}
 {{- end }}
 
@@ -89,7 +90,7 @@ least one inline value is set.
 */}}
 {{- define "konflate.secretName" -}}
 {{- if .Values.secret.existingSecret -}}
-{{- .Values.secret.existingSecret -}}
+{{- tpl .Values.secret.existingSecret $ -}}
 {{- else if or .Values.secret.token .Values.secret.webhookSecret .Values.secret.pushToken -}}
 {{- include "konflate.fullname" . -}}
 {{- end -}}
@@ -99,5 +100,5 @@ least one inline value is set.
 Name of the PVC backing the source cache (existingClaim wins).
 */}}
 {{- define "konflate.cacheClaimName" -}}
-{{- default (printf "%s-cache" (include "konflate.fullname" .)) .Values.persistence.existingClaim -}}
+{{- default (printf "%s-cache" (include "konflate.fullname" .)) (tpl (.Values.persistence.existingClaim | default "") $) -}}
 {{- end }}

--- a/charts/konflate/templates/deployment.tpl
+++ b/charts/konflate/templates/deployment.tpl
@@ -36,7 +36,7 @@ spec:
       imagePullSecrets:
         {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "konflate.serviceAccountName" . }}
+      serviceAccountName: {{ include "konflate.serviceAccountName" . | quote }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
       securityContext:
         {{- tpl (toYaml .Values.podSecurityContext) $ | nindent 8 }}
@@ -63,7 +63,7 @@ spec:
             {{- end }}
             {{- with .Values.config.prFilterExpr }}
             - name: KONFLATE_PR_FILTER_EXPR
-              value: {{ . | quote }}
+              value: {{ tpl . $ | quote }}
             {{- end }}
             {{- if .Values.config.renderForkPrs }}
             - name: KONFLATE_RENDER_FORK_PRS
@@ -138,7 +138,7 @@ spec:
           {{- with (include "konflate.secretName" .) }}
           envFrom:
             - secretRef:
-                name: {{ . }}
+                name: {{ . | quote }}
           {{- end }}
           ports:
             - name: http
@@ -167,7 +167,7 @@ spec:
         - name: cache
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ include "konflate.cacheClaimName" . }}
+            claimName: {{ include "konflate.cacheClaimName" . | quote }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/charts/konflate/templates/pvc.tpl
+++ b/charts/konflate/templates/pvc.tpl
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "konflate.cacheClaimName" . }}
+  name: {{ include "konflate.cacheClaimName" . | quote }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "konflate.labels" . | nindent 4 }}

--- a/charts/konflate/templates/serviceaccount.tpl
+++ b/charts/konflate/templates/serviceaccount.tpl
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "konflate.serviceAccountName" . }}
+  name: {{ include "konflate.serviceAccountName" . | quote }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "konflate.labels" . | nindent 4 }}

--- a/charts/konflate/tests/deployment_test.yaml
+++ b/charts/konflate/tests/deployment_test.yaml
@@ -168,3 +168,39 @@ tests:
           content:
             name: KONFLATE_FETCH_TIMEOUT
             value: "30s"
+
+  # The values.yaml contract: string values (except mergeCommand) are tpl-rendered.
+  - it: renders config.prFilterExpr through tpl
+    set:
+      config.prFilterExpr: 'pr.baseRef == "{{ .Release.Name }}"'
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KONFLATE_PR_FILTER_EXPR
+            value: 'pr.baseRef == "RELEASE-NAME"'
+
+  - it: renders secret.existingSecret through tpl for the envFrom secretRef
+    set:
+      secret.existingSecret: "{{ .Release.Name }}-creds"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
+          value: RELEASE-NAME-creds
+
+  - it: renders serviceAccount.name through tpl for the pod serviceAccountName
+    set:
+      serviceAccount.name: "{{ .Release.Name }}-sa"
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-sa
+
+  - it: renders persistence.existingClaim through tpl for the cache volume claim
+    set:
+      persistence.enabled: true
+      persistence.existingClaim: "{{ .Release.Name }}-data"
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          value: RELEASE-NAME-data

--- a/charts/konflate/tests/serviceaccount_test.yaml
+++ b/charts/konflate/tests/serviceaccount_test.yaml
@@ -18,3 +18,11 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: renders a templated serviceAccount.name (tpl contract)
+    set:
+      serviceAccount.name: "{{ .Release.Name }}-sa"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-sa


### PR DESCRIPTION
Fixes #125.

`values.yaml`'s header documents that string values (except `mergeCommand`) are rendered through Helm's `tpl`, but four bypassed it:

- **`secret.existingSecret`, `persistence.existingClaim`, `serviceAccount.name`** were emitted **raw and unquoted**. A templated value like `existingSecret: "{{ .Release.Name }}-creds"` — a documented-supported pattern — reached the manifest as literal braces and crashed `helm install` with `YAML parse error … did not find expected key`.
- **`config.prFilterExpr`** reached CEL with literal braces: it compiled fine and silently matched **nothing**, so no PR ever rendered.

### Fix
Wrap each user-supplied value in `tpl` (inside its helper, or at the `prFilterExpr` emission) and `quote` the three name consumers (deployment `serviceAccountName` / `secretRef.name` / `claimName`, plus `serviceaccount.tpl` and `pvc.tpl`).

Verified with `helm template` using the exact crashing values — all four now render templated + quoted, no leaked braces, exit 0.

### Tests
helm-unittest (now 37, +5): `prFilterExpr`, `existingSecret`, `serviceAccount.name`, and `existingClaim` each rendering through `tpl`. `helm lint` and `generate-check` (no values.yaml change → no docs/schema drift) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)