### PR TITLE
fix(server): render a PR that becomes filter-allowed without a new push

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -477,7 +477,7 @@ func (s *Server) refreshList(ctx context.Context) {
 	}
 	s.metrics.prsKnown.Set(float64(len(prs)))
 	open := make(map[int]struct{}, len(prs))
-	var added, advanced int
+	var added, advanced, unhidden int
 	for _, pr := range prs {
 		// Every open PR is tracked. One the filter excludes is kept as hidden —
 		// listed (greyed, under the "hidden" pill) but never enqueued, so a fork's
@@ -486,23 +486,33 @@ func (s *Server) refreshList(ctx context.Context) {
 		open[pr.Number] = struct{}{}
 		prev, known := s.store.get(pr.Number)
 		s.store.upsertPR(pr, !allowed)
-		if allowed && (!known || prev.PR.HeadSHA != pr.HeadSHA) {
+		// Render a PR that is newly tracked, whose head advanced, or that just
+		// became filter-allowed without a push (e.g. draft → ready under a
+		// !pr.draft filter). That last case is easy to miss: in polling mode
+		// nothing else enqueues it, and the staleness backstop skips never-rendered
+		// jobs, so it would sit pending forever.
+		nowAllowed := known && prev.Hidden && allowed
+		if allowed && (!known || prev.PR.HeadSHA != pr.HeadSHA || nowAllowed) {
 			reason := "head advanced"
-			if !known {
+			switch {
+			case !known:
 				reason = "new PR"
 				added++
-			} else {
+			case nowAllowed:
+				reason = "filter now admits"
+				unhidden++
+			default:
 				advanced++
 			}
 			s.log.Debug("queuing render", "pr", pr.Number, "reason", reason)
-			s.queue.enqueue(pr) // new PR, or its head advanced → (re)render now
+			s.queue.enqueue(pr)
 		}
 	}
 	s.reconcileClosed(ctx, open)
 	// One summary line per refresh, with counts, instead of one "queuing render"
 	// line per PR: at startup every PR is "new", which would be a burst of
 	// near-identical lines on a busy instance. The per-PR detail stays at debug.
-	s.log.Info("refresh listed", "prs", len(prs), "new", added, "advanced", advanced)
+	s.log.Info("refresh listed", "prs", len(prs), "new", added, "advanced", advanced, "unhidden", unhidden)
 }
 
 // reconcileClosed handles PRs that have left the forge's open set. Each is

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -349,6 +349,44 @@ func TestServer_DropFilteredOnLoadKeepsOnEvalError(t *testing.T) {
 	}
 }
 
+// TestServer_HiddenToAllowedRenders verifies a PR that becomes filter-allowed
+// without a head push (draft → ready under !pr.draft) is enqueued on the next
+// re-list — it would otherwise sit pending forever, since nothing else enqueues
+// it in polling mode and the staleness backstop skips never-rendered jobs.
+func TestServer_HiddenToAllowedRenders(t *testing.T) {
+	t.Parallel()
+	cfg := ghCfg("tok")
+	prg, err := prfilter.Compile(`!pr.draft`)
+	if err != nil {
+		t.Fatalf("compile filter: %v", err)
+	}
+	cfg.PRFilter = prg
+
+	draft := api.PR{Number: 1, Title: "wip", HeadRef: "f", BaseRef: "main", HeadSHA: "s1", Open: true, Draft: true}
+	prov := &fakeProvider{prs: []api.PR{draft}}
+	s := newTestServer(t, cfg, prov, okEngine())
+
+	// First list: the draft is tracked but hidden, never rendered.
+	s.refreshList(s.runCtx)
+	if env, _ := s.store.get(1); !env.Hidden {
+		t.Fatal("a draft under !pr.draft must be tracked as hidden")
+	}
+
+	// Marked ready for review — same head SHA, no push.
+	ready := draft
+	ready.Draft = false
+	prov.setPRs(ready)
+	s.refreshList(s.runCtx)
+
+	env := waitFor(t, s, 1) // before the fix this never reached a terminal status
+	if env.Status != api.JobReady {
+		t.Fatalf("draft→ready (no push) should render; status=%q err=%q", env.Status, env.Error)
+	}
+	if env.Hidden {
+		t.Error("PR 1 should no longer be hidden")
+	}
+}
+
 func TestServer_RenderForkPRs(t *testing.T) {
 	t.Parallel()
 	fork := api.PR{Number: 7, Title: "fork PR", HeadRef: "patch", BaseRef: "main", HeadSHA: "s7", Open: true, Fork: true}


### PR DESCRIPTION
Fixes #120.

A PR the filter excluded — tracked **hidden**, never rendered — that later becomes allowed **without its head advancing** (draft → ready under a `!pr.draft` filter, or a label added) was never enqueued. `refreshList` only enqueues on new-or-head-advanced, and the staleness backstop (`stalePRs`) skips never-rendered jobs (`renderedAt` zero). In polling mode (no webhooks) nothing else triggers it, so it sat **pending forever** — the spinner never resolved and a CI gate polling `/summary` never got a verdict.

### Fix
`refreshList` now also enqueues on the **hidden→allowed** transition (`prev.Hidden && allowed`), alongside new and head-advanced. Forks stay excluded (the fork gate keeps `allowed` false regardless), and the summary log gains an `unhidden` count.

### Test
`TestServer_HiddenToAllowedRenders` — a draft under `!pr.draft` is tracked hidden, then (un-drafted, same SHA) renders to ready. Before the fix it never reached a terminal status. `go test -race`, lint, fmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)