### PR TITLE
perf(server): marshal the diff off the store write lock; commit the digest after save

### DIFF
--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -129,13 +129,17 @@ func contentDigest(rec persist.Record) uint64 {
 // save / del run the persistence I/O. Callers snapshot under s.mu, release it,
 // then call these — the file write/remove never holds the store lock. No-ops
 // when durability is disabled.
-func (s *store) save(rec persist.Record) {
+func (s *store) save(rec persist.Record) error {
 	if s.persist == nil {
-		return
+		return nil
 	}
-	if err := s.persist.Save(rec); err != nil && s.log != nil {
-		s.log.Warn("persist render", "pr", rec.PR.Number, "error", err)
+	if err := s.persist.Save(rec); err != nil {
+		if s.log != nil {
+			s.log.Warn("persist render", "pr", rec.PR.Number, "error", err)
+		}
+		return err
 	}
+	return nil
 }
 
 func (s *store) del(number int) {
@@ -205,15 +209,39 @@ func (s *store) setResult(number int, result api.DiffResult) *api.Signals {
 	j.renderedAt = j.updated
 	sig := j.signals
 	rec := j.record()
-	d := contentDigest(rec)
-	changed := d != j.savedDigest
-	j.savedDigest = d
+	prev := j.savedDigest
 	s.mu.Unlock()
 
-	if changed {
-		s.save(rec) // only persist when the diff actually differs from what's on disk
-	}
+	// Hash and persist outside the lock: contentDigest marshals the whole record
+	// (multi-MB of rendered HTML), and holding s.mu across that stalls every
+	// reader (the list/diff/summary handlers) and every mutator. The snapshot is
+	// safe to read unlocked — j.result is replaced wholesale, never mutated in
+	// place, and per-PR coalescing means no second setResult for this PR runs
+	// concurrently.
+	s.persistRecord(number, rec, prev)
 	return sig
+}
+
+// persistRecord computes rec's content digest and, when it differs from prev,
+// writes rec and commits the new digest as savedDigest — but only after the save
+// succeeds. So a failed persist (a full or read-only volume) leaves savedDigest
+// unchanged, and a later identical re-render retries the write rather than
+// skipping it as "already on disk" (which would strand stale content that a
+// restart then restores). The costly marshal runs off the store lock; the digest
+// is committed under a brief re-lock.
+func (s *store) persistRecord(number int, rec persist.Record, prev uint64) {
+	d := contentDigest(rec)
+	if d == prev {
+		return // unchanged: nothing to write, and savedDigest is already current
+	}
+	if err := s.save(rec); err != nil {
+		return // leave savedDigest as-is so the next render retries the write
+	}
+	s.mu.Lock()
+	if j := s.jobs[number]; j != nil {
+		j.savedDigest = d
+	}
+	s.mu.Unlock()
 }
 
 // computeSignals reduces a diff to its at-a-glance counts for the PR list.
@@ -342,10 +370,12 @@ func (s *store) markClosed(number int, when time.Time) {
 	j.pr.Merged = true
 	j.updated = when
 	rec := j.record()
-	j.savedDigest = contentDigest(rec)
+	prev := j.savedDigest
 	s.mu.Unlock()
 
-	s.save(rec) // re-record with the merge stamp so the shelf survives a restart
+	// Re-record with the merge stamp so the shelf survives a restart — off the
+	// lock; the merge always changes the content, so this writes.
+	s.persistRecord(number, rec, prev)
 }
 
 // remove drops a PR from the store entirely (used for abandoned PRs and by

--- a/internal/server/store_persist_test.go
+++ b/internal/server/store_persist_test.go
@@ -153,3 +153,46 @@ func prStatus(s *store, number int) api.PRStatus {
 	}
 	return api.PRStatus{}
 }
+
+// TestStore_FailedPersistRetriesNextRender verifies savedDigest is committed only
+// after a successful save: a render whose persist fails must not advance the
+// digest, so a later identical re-render actually writes — rather than skipping
+// it as "already on disk" and stranding stale content for a restart to restore.
+func TestStore_FailedPersistRetriesNextRender(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	reopen := func() *store {
+		p, err := persist.New(dir, discardLog())
+		if err != nil {
+			t.Fatalf("persist.New: %v", err)
+		}
+		s := newStore()
+		s.loadFrom(p, discardLog())
+		return s
+	}
+
+	s := reopen()
+	s.upsertPR(api.PR{Number: 1, Open: true}, false)
+	s.setResult(1, api.DiffResult{PRNumber: 1, ChromaCSS: ".v1{}"}) // persisted
+
+	// Make the next persist fail by removing the state dir out from under it.
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	s.setResult(1, api.DiffResult{PRNumber: 1, ChromaCSS: ".v2{}"}) // save fails; digest must not advance
+
+	// Persistence works again; the identical re-render must now actually write v2
+	// (it would be wrongly skipped if savedDigest had advanced before the failed save).
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	s.setResult(1, api.DiffResult{PRNumber: 1, ChromaCSS: ".v2{}"})
+
+	env, ok := reopen().get(1)
+	if !ok || env.Diff == nil {
+		t.Fatalf("PR 1 not restored from disk after the retry: ok=%v", ok)
+	}
+	if env.Diff.ChromaCSS != ".v2{}" {
+		t.Fatalf("disk holds %q, want .v2{} — the failed persist must be retried, not skipped", env.Diff.ChromaCSS)
+	}
+}


### PR DESCRIPTION
Fixes #126.

`setResult` (and `markClosed`) computed `contentDigest` — a full JSON marshal of the multi-MB rendered diff — **and** committed `savedDigest` **while holding the store write lock**. That stalled every reader (`list`/`diff`/`summary` handlers) and every other mutator in bursts, exactly during the startup render wave when the UI polls hardest.

### Changes
- **Marshal off the lock.** The lock now covers only the cheap field updates and a `record()` snapshot (a value copy of the PR plus the *immutable* result pointer); the costly `contentDigest` marshal and the `persist.Save` run unlocked. Safe because a job's `result` is replaced wholesale (never mutated in place) and per-PR coalescing serializes a PR's renders.
- **Commit the digest after save.** `savedDigest` was committed *before* `save()`, so a failed persist (full/read-only volume) left it reflecting content that never reached disk — a later identical re-render then skipped the write as "already on disk", and a restart restored the stale record. It's now committed only after `save()` succeeds, so a failed persist is retried on the next render.

### Scope note
The digest and persist marshals stay separate by design — the digest excludes the volatile `Updated`/`RenderedAt` timestamps the persisted record keeps — so this removes the *under-lock* marshal and the stale-persist bug rather than collapsing the marshal count (the issue's third bullet). The startup `loadFrom` reseed (one marshal per record) is left as-is: it's a one-time cost that avoids a post-restart write of every unchanged PR.

### Tests
`TestStore_FailedPersistRetriesNextRender` — a render whose persist fails (state dir removed mid-test) doesn't advance `savedDigest`, so the identical retry writes `v2` once persistence returns; on the old order it would skip and strand `v1`. `go test -race ./...`, `mise run lint` (0 issues), `mise run fmt-check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)