### PR TITLE
fix(config): normalize an explicit cloud host (github://github.com/... → api.github.com)

### DIFF
--- a/internal/config/forge.go
+++ b/internal/config/forge.go
@@ -105,6 +105,16 @@ func ParseForgeURI(raw string) (ForgeURI, error) {
 		repoPath = strings.TrimPrefix(u.Host+u.Path, "/")
 	}
 
+	// An explicit cloud host is the same as omitting it. Without this,
+	// github://github.com/owner/repo would be treated as a self-hosted (GHES)
+	// instance and derive https://github.com/api/v3 — but GitHub cloud's REST API
+	// lives at api.github.com, so every call 404s. Normalizing to the cloud
+	// defaults is also harmless and consistent for gitlab.com / codeberg.org,
+	// whose API host already matches their web host.
+	if cloudHost := strings.TrimPrefix(defaults.web, "https://"); strings.EqualFold(host, cloudHost) {
+		host = ""
+	}
+
 	if err := validateRepoPath(repoPath, raw); err != nil {
 		return ForgeURI{}, err
 	}

--- a/internal/config/forge_test.go
+++ b/internal/config/forge_test.go
@@ -36,6 +36,41 @@ func TestParseForgeURI(t *testing.T) {
 				WebBase:  "https://github.com",
 			},
 		},
+		{
+			// An explicit cloud host must normalize to the cloud API base, not be
+			// treated as a GHES instance (github.com/api/v3, which 404s).
+			name:  "github explicit cloud host normalizes to the cloud API",
+			input: "github://github.com/owner/repo",
+			want: ForgeURI{
+				Kind:     ForgeGitHub,
+				Host:     "",
+				RepoPath: "owner/repo",
+				APIBase:  "https://api.github.com",
+				WebBase:  "https://github.com",
+			},
+		},
+		{
+			name:  "gitlab explicit cloud host normalizes",
+			input: "gitlab://gitlab.com/group/repo",
+			want: ForgeURI{
+				Kind:     ForgeGitLab,
+				Host:     "",
+				RepoPath: "group/repo",
+				APIBase:  "https://gitlab.com",
+				WebBase:  "https://gitlab.com",
+			},
+		},
+		{
+			name:  "forgejo explicit cloud host normalizes",
+			input: "forgejo://codeberg.org/owner/repo",
+			want: ForgeURI{
+				Kind:     ForgeForgejo,
+				Host:     "",
+				RepoPath: "owner/repo",
+				APIBase:  "https://codeberg.org",
+				WebBase:  "https://codeberg.org",
+			},
+		},
 
 		// ── GitHub Enterprise Server ──────────────────────────────────────
 		{


### PR DESCRIPTION
Fixes #121.

`ParseForgeURI` treated any host-looking first segment as self-hosted, so `github://github.com/owner/repo` — the natural URI mirroring the repo's web address — was parsed as a GitHub **Enterprise** instance and derived `https://github.com/api/v3`. GitHub cloud's REST API lives at `api.github.com`, so every `ListPRs`/`GetPR` 404'd and the UI stayed permanently empty with only periodic "refresh: list PRs failed" logs.

### Fix
After host detection, an explicit cloud host (matching the kind's `cloudDefaults` web host) normalizes to `host = ""`, so the cloud API base is used. `gitlab://gitlab.com/...` and `forgejo://codeberg.org/...` already worked (their API host equals their web host); the normalization is harmless and consistent for them.

### Tests
Three table cases added — `github://github.com/...` → `api.github.com`, and the gitlab.com / codeberg.org equivalents → cloud bases, all with `Host: ""`. `go test`, lint, fmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)