### PR TITLE
fix(provider): paginate ListPRs across all pages (github/gitlab/forgejo)

### DIFF
--- a/internal/provider/forgejo.go
+++ b/internal/provider/forgejo.go
@@ -42,17 +42,24 @@ func (p *forgejoProvider) ListPRs(ctx context.Context) ([]api.PR, error) {
 	// can't be threaded through; ctx is accepted only to satisfy the Provider
 	// interface and is intentionally unused.
 	_ = ctx
-	prs, _, err := p.client.ListRepoPullRequests(p.owner, p.repo, forgejo.ListPullRequestsOptions{
+	opts := forgejo.ListPullRequestsOptions{
 		State:       forgejo.StateOpen,
 		Sort:        "recentupdate",
-		ListOptions: forgejo.ListOptions{PageSize: 50},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("forgejo: list PRs: %w", err)
+		ListOptions: forgejo.ListOptions{PageSize: 50}, // Gitea/Forgejo caps the page size server-side
 	}
-	out := make([]api.PR, 0, len(prs))
-	for _, pr := range prs {
-		out = append(out, forgejoToPR(pr))
+	var out []api.PR
+	for {
+		prs, resp, err := p.client.ListRepoPullRequests(p.owner, p.repo, opts)
+		if err != nil {
+			return nil, fmt.Errorf("forgejo: list PRs: %w", err)
+		}
+		for _, pr := range prs {
+			out = append(out, forgejoToPR(pr))
+		}
+		if resp.NextPage == 0 {
+			break // last page: without this loop, repos with >50 open PRs lost the rest
+		}
+		opts.Page = resp.NextPage
 	}
 	return out, nil
 }

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -37,15 +37,21 @@ func (p *githubProvider) ListPRs(ctx context.Context) ([]api.PR, error) {
 		State:       stateOpen,
 		Sort:        "updated",
 		Direction:   "desc",
-		ListOptions: github.ListOptions{PerPage: 50},
+		ListOptions: github.ListOptions{PerPage: 100},
 	}
-	prs, _, err := p.client.PullRequests.List(ctx, p.owner, p.repo, opts)
-	if err != nil {
-		return nil, fmt.Errorf("github: list PRs: %w", err)
-	}
-	out := make([]api.PR, 0, len(prs))
-	for _, pr := range prs {
-		out = append(out, githubToPR(pr))
+	var out []api.PR
+	for {
+		prs, resp, err := p.client.PullRequests.List(ctx, p.owner, p.repo, opts)
+		if err != nil {
+			return nil, fmt.Errorf("github: list PRs: %w", err)
+		}
+		for _, pr := range prs {
+			out = append(out, githubToPR(pr))
+		}
+		if resp.NextPage == 0 {
+			break // last page: without this loop, repos with >100 open PRs lost the rest
+		}
+		opts.Page = resp.NextPage
 	}
 	return out, nil
 }

--- a/internal/provider/gitlab.go
+++ b/internal/provider/gitlab.go
@@ -31,17 +31,24 @@ func newGitLab(cfg *config.Config) (*gitlabProvider, error) {
 func (p *gitlabProvider) ListPRs(ctx context.Context) ([]api.PR, error) {
 	state := "opened"
 	order := "updated_at"
-	mrs, _, err := p.client.MergeRequests.ListProjectMergeRequests(p.project, &gitlab.ListProjectMergeRequestsOptions{
+	opts := &gitlab.ListProjectMergeRequestsOptions{
 		State:       &state,
 		OrderBy:     &order,
-		ListOptions: gitlab.ListOptions{PerPage: 50},
-	}, gitlab.WithContext(ctx))
-	if err != nil {
-		return nil, fmt.Errorf("gitlab: list MRs: %w", err)
+		ListOptions: gitlab.ListOptions{PerPage: 100},
 	}
-	out := make([]api.PR, 0, len(mrs))
-	for _, mr := range mrs {
-		out = append(out, gitlabToPR(mr))
+	var out []api.PR
+	for {
+		mrs, resp, err := p.client.MergeRequests.ListProjectMergeRequests(p.project, opts, gitlab.WithContext(ctx))
+		if err != nil {
+			return nil, fmt.Errorf("gitlab: list MRs: %w", err)
+		}
+		for _, mr := range mrs {
+			out = append(out, gitlabToPR(mr))
+		}
+		if resp.NextPage == 0 {
+			break // last page: without this loop, projects with >100 open MRs lost the rest
+		}
+		opts.Page = resp.NextPage
 	}
 	return out, nil
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -79,6 +79,44 @@ func TestGitHubProvider_ListPRs(t *testing.T) {
 	}
 }
 
+// TestGitHubProvider_ListPRsPaginates verifies ListPRs follows rel="next" across
+// pages — without it, a repo with more open PRs than one page silently lost the
+// rest. (The loop is structurally identical in the gitlab and forgejo providers.)
+func TestGitHubProvider_ListPRsPaginates(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/acme/web/pulls", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") == "2" {
+			_, _ = w.Write([]byte(`[{"number":2,"state":"open","head":{"ref":"b","sha":"s2"},"base":{"ref":"main"}}]`))
+			return
+		}
+		// Page 1 advertises a next page, so the provider must request page 2.
+		w.Header().Set("Link", `<`+r.URL.Path+`?page=2>; rel="next"`)
+		_, _ = w.Write([]byte(`[{"number":1,"state":"open","head":{"ref":"a","sha":"s1"},"base":{"ref":"main"}}]`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	raw := srv.URL + "/"
+	client, err := github.NewClient(github.WithURLs(&raw, &raw))
+	if err != nil {
+		t.Fatalf("github.NewClient: %v", err)
+	}
+	p := &githubProvider{client: client, owner: "acme", repo: "web"}
+
+	prs, err := p.ListPRs(context.Background())
+	if err != nil {
+		t.Fatalf("ListPRs: %v", err)
+	}
+	if len(prs) != 2 {
+		t.Fatalf("got %d PRs across pages, want 2 (pagination must follow rel=next)", len(prs))
+	}
+	if prs[0].Number != 1 || prs[1].Number != 2 {
+		t.Errorf("paged PR numbers = %d, %d; want 1, 2", prs[0].Number, prs[1].Number)
+	}
+}
+
 func TestNew_DispatchesByForge(t *testing.T) {
 	t.Parallel()
 	cases := []struct {


### PR DESCRIPTION
Fixes #123.

`ListPRs` fetched a single page (50, sorted by most-recently-updated) and discarded the pagination cursor in **all three** providers. Above one page of open PRs the overflow (least-recently-updated, and shifting with activity) fell out of the tracked set, so `reconcileClosed` fired a **serial `GetPR` per missing PR every refresh** (recurring quota churn), and on a fresh install PRs outside the top page were **never discovered**.

### Fix
Loop each provider's list call until the next-page cursor (`resp.NextPage`) is exhausted, and bump GitHub/GitLab to their 100-per-page maximum (Forgejo stays at 50, the Gitea server cap) to halve round-trips.

### Test
`TestGitHubProvider_ListPRsPaginates` — an httptest server advertises a second page via `Link: rel="next"`; the provider must return PRs from both pages. The gitlab/forgejo loops are structurally identical (same `resp.NextPage` idiom); they had no prior unit coverage. `go test -race ./...`, lint, fmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)