### PR TITLE
fix(server,provider): reap a deleted PR/MR instead of looping on a 404 forever

### DIFF
--- a/internal/provider/forgejo.go
+++ b/internal/provider/forgejo.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	forgejo "codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
@@ -66,8 +67,11 @@ func (p *forgejoProvider) ListPRs(ctx context.Context) ([]api.PR, error) {
 
 func (p *forgejoProvider) GetPR(ctx context.Context, number int) (api.PR, error) {
 	_ = ctx // see ListPRs: the Forgejo SDK can't take a context.
-	pr, _, err := p.client.GetPullRequest(p.owner, p.repo, int64(number))
+	pr, resp, err := p.client.GetPullRequest(p.owner, p.repo, int64(number))
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return api.PR{}, fmt.Errorf("forgejo: get PR #%d: %w", number, ErrPRNotFound)
+		}
 		return api.PR{}, fmt.Errorf("forgejo: get PR #%d: %w", number, err)
 	}
 	return forgejoToPR(pr), nil

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/google/go-github/v88/github"
 
@@ -57,8 +58,11 @@ func (p *githubProvider) ListPRs(ctx context.Context) ([]api.PR, error) {
 }
 
 func (p *githubProvider) GetPR(ctx context.Context, number int) (api.PR, error) {
-	pr, _, err := p.client.PullRequests.Get(ctx, p.owner, p.repo, number)
+	pr, resp, err := p.client.PullRequests.Get(ctx, p.owner, p.repo, number)
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return api.PR{}, fmt.Errorf("github: get PR #%d: %w", number, ErrPRNotFound)
+		}
 		return api.PR{}, fmt.Errorf("github: get PR #%d: %w", number, err)
 	}
 	return githubToPR(pr), nil

--- a/internal/provider/gitlab.go
+++ b/internal/provider/gitlab.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
@@ -54,8 +55,11 @@ func (p *gitlabProvider) ListPRs(ctx context.Context) ([]api.PR, error) {
 }
 
 func (p *gitlabProvider) GetPR(ctx context.Context, number int) (api.PR, error) {
-	mr, _, err := p.client.MergeRequests.GetMergeRequest(p.project, int64(number), nil, gitlab.WithContext(ctx))
+	mr, resp, err := p.client.MergeRequests.GetMergeRequest(p.project, int64(number), nil, gitlab.WithContext(ctx))
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return api.PR{}, fmt.Errorf("gitlab: get MR !%d: %w", number, ErrPRNotFound)
+		}
 		return api.PR{}, fmt.Errorf("gitlab: get MR !%d: %w", number, err)
 	}
 	return gitlabToPR(&mr.BasicMergeRequest), nil

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,6 +6,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -16,6 +17,11 @@ import (
 // stateOpen is the forge state string for an open PR on GitHub and Forgejo
 // (GitLab uses "opened"). The normalized api.PR.Open flag is derived from it.
 const stateOpen = "open"
+
+// ErrPRNotFound is returned by GetPR when the forge reports the pull/merge
+// request does not exist (HTTP 404) — it was deleted, not merged or closed. The
+// server reaps such a PR instead of retrying the lookup every refresh.
+var ErrPRNotFound = errors.New("provider: pull request not found")
 
 // Provider lists and fetches pull requests for the configured repository.
 type Provider interface {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -114,6 +115,30 @@ func TestGitHubProvider_ListPRsPaginates(t *testing.T) {
 	}
 	if prs[0].Number != 1 || prs[1].Number != 2 {
 		t.Errorf("paged PR numbers = %d, %d; want 1, 2", prs[0].Number, prs[1].Number)
+	}
+}
+
+// TestGitHubProvider_GetPRNotFound verifies a 404 maps to ErrPRNotFound (so the
+// server reaps a deleted PR rather than looping). The gitlab/forgejo providers
+// use the same resp.StatusCode == 404 check.
+func TestGitHubProvider_GetPRNotFound(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/acme/web/pulls/9", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"Not Found"}`, http.StatusNotFound)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	raw := srv.URL + "/"
+	client, err := github.NewClient(github.WithURLs(&raw, &raw))
+	if err != nil {
+		t.Fatalf("github.NewClient: %v", err)
+	}
+	p := &githubProvider{client: client, owner: "acme", repo: "web"}
+
+	if _, err := p.GetPR(context.Background(), 9); !errors.Is(err, ErrPRNotFound) {
+		t.Fatalf("GetPR on a 404 = %v, want ErrPRNotFound", err)
 	}
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"hash/fnv"
 	"io"
 	"mime"
@@ -18,6 +19,7 @@ import (
 	"time"
 
 	"github.com/home-operations/konflate/internal/api"
+	"github.com/home-operations/konflate/internal/provider"
 	"github.com/home-operations/konflate/internal/webhook"
 )
 
@@ -529,8 +531,14 @@ func (s *Server) reconcileClosed(ctx context.Context, open map[int]struct{}) {
 		}
 		pr, err := s.prov.GetPR(ctx, number)
 		if err != nil {
+			if errors.Is(err, provider.ErrPRNotFound) {
+				// Deleted on the forge (not merged/closed): reap it, rather than
+				// 404ing on this lookup every refresh forever.
+				s.dropPR(number)
+				continue
+			}
 			s.log.Warn("refresh: classify closed PR failed", "pr", number, "error", err)
-			continue // leave as-is; retry on the next refresh
+			continue // transient: leave as-is, retry on the next refresh
 		}
 		s.reconcileState(pr)
 	}
@@ -557,11 +565,17 @@ func (s *Server) reconcileState(pr api.PR) {
 		s.store.markClosed(pr.Number, s.store.now())
 	default:
 		// Abandoned, or filtered-out (a hidden PR that merged kept no diff worth
-		// shelving): drop it and tell clients to remove it. remove is a no-op for a
-		// PR we weren't tracking, so a webhook for an unrelated PR is harmless.
-		s.store.remove(pr.Number)
-		s.hub.broadcast(api.Event{Type: eventTypeRemoved, Number: pr.Number})
+		// shelving): drop it and tell clients to remove it.
+		s.dropPR(pr.Number)
 	}
+}
+
+// dropPR removes a PR from the store and tells connected clients to drop it.
+// store.remove is a no-op for an untracked PR, so this is safe to call for a PR
+// we may not be tracking (e.g. a webhook for an unrelated one).
+func (s *Server) dropPR(number int) {
+	s.store.remove(number)
+	s.hub.broadcast(api.Event{Type: eventTypeRemoved, Number: number})
 }
 
 // reconcileHeadGone is called by the queue when a render finds the PR's head
@@ -572,6 +586,10 @@ func (s *Server) reconcileState(pr api.PR) {
 func (s *Server) reconcileHeadGone(number int) {
 	pr, err := s.prov.GetPR(s.runCtx, number)
 	if err != nil {
+		if errors.Is(err, provider.ErrPRNotFound) {
+			s.dropPR(number) // deleted on the forge: reap it rather than loop on the gone head ref
+			return
+		}
 		s.log.Warn("reconcile head-gone PR failed", "pr", number, "error", err)
 		return
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -25,15 +25,17 @@ import (
 	"github.com/home-operations/konflate/internal/config"
 	"github.com/home-operations/konflate/internal/gitclone"
 	"github.com/home-operations/konflate/internal/prfilter"
+	"github.com/home-operations/konflate/internal/provider"
 )
 
 // --- fakes ---------------------------------------------------------------
 
 type fakeProvider struct {
-	mu      sync.Mutex
-	prs     []api.PR       // the open list ListPRs returns
-	details map[int]api.PR // GetPR overrides (e.g. a departed PR's merged/closed state)
-	listErr error
+	mu       sync.Mutex
+	prs      []api.PR       // the open list ListPRs returns
+	details  map[int]api.PR // GetPR overrides (e.g. a departed PR's merged/closed state)
+	notFound map[int]bool   // numbers GetPR reports as deleted (provider.ErrPRNotFound)
+	listErr  error
 }
 
 func (f *fakeProvider) ListPRs(context.Context) ([]api.PR, error) {
@@ -45,6 +47,9 @@ func (f *fakeProvider) ListPRs(context.Context) ([]api.PR, error) {
 func (f *fakeProvider) GetPR(_ context.Context, n int) (api.PR, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.notFound[n] {
+		return api.PR{}, fmt.Errorf("fake: %w", provider.ErrPRNotFound)
+	}
 	if d, ok := f.details[n]; ok {
 		return d, nil
 	}
@@ -54,6 +59,16 @@ func (f *fakeProvider) GetPR(_ context.Context, n int) (api.PR, error) {
 		}
 	}
 	return api.PR{}, io.EOF
+}
+
+// setNotFound makes GetPR(n) report the PR as deleted (provider.ErrPRNotFound).
+func (f *fakeProvider) setNotFound(n int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.notFound == nil {
+		f.notFound = map[int]bool{}
+	}
+	f.notFound[n] = true
 }
 
 // setPRs swaps the open-PR set the forge reports (simulates a PR opening or
@@ -708,6 +723,34 @@ func TestUIHandler_CacheControl(t *testing.T) {
 		if got := rec.Header().Get("Cache-Control"); got != tc.want {
 			t.Errorf("%s: Cache-Control = %q, want %q", tc.path, got, tc.want)
 		}
+	}
+}
+
+// TestServer_DeletedPRReaped verifies a PR deleted on the forge (GetPR →
+// ErrPRNotFound) is removed rather than retried forever — via both the periodic
+// reconcileClosed and the queue's reconcileHeadGone.
+func TestServer_DeletedPRReaped(t *testing.T) {
+	t.Parallel()
+	a := api.PR{Number: 1, Open: true, HeadSHA: "s1", BaseRef: "main"}
+	b := api.PR{Number: 2, Open: true, HeadSHA: "s2", BaseRef: "main"}
+	prov := &fakeProvider{prs: []api.PR{a, b}}
+	s := newTestServer(t, ghCfg("tok"), prov, okEngine())
+	s.store.upsertPR(a, false)
+	s.store.upsertPR(b, false)
+
+	// #1 is deleted: gone from the open list and GetPR now 404s.
+	prov.setPRs(b)
+	prov.setNotFound(1)
+	s.refreshList(s.runCtx) // reconcileClosed must reap #1, not loop on it
+	if _, ok := s.store.get(1); ok {
+		t.Fatal("reconcileClosed must reap a deleted PR (GetPR not-found)")
+	}
+
+	// #2 is then deleted while still tracked; the head-gone path must reap it too.
+	prov.setNotFound(2)
+	s.reconcileHeadGone(2)
+	if _, ok := s.store.get(2); ok {
+		t.Fatal("reconcileHeadGone must reap a deleted PR, not loop on the gone head ref")
 	}
 }
 


### PR DESCRIPTION
Fixes #124.

A PR/MR **deleted** on the forge (its pull head ref gone — distinct from merged/closed) became a permanent self-sustaining zombie: the in-flight render hit `ErrHeadRefGone` → `reconcileHeadGone` → `GetPR` **404** → logged as transient, PR kept. Its `renderedAt` never advanced, so the staleness backstop re-enqueued it → fetch → `ErrHeadRefGone` → 404 → warn, **every refresh forever**, surviving restarts. `reconcileClosed` did the same on each periodic re-list. (GitLab Owners / Forgejo admins can delete MRs; GitHub PRs can't, so it's forge-conditional — but permanent once hit.)

### Fix
- Providers return a typed **`provider.ErrPRNotFound`** when the forge replies 404 to `GetPR` (checked via `resp.StatusCode` in all three; verified the Forgejo SDK returns a non-nil `*Response` on error).
- `reconcileClosed` and `reconcileHeadGone` reap the PR (`remove` + broadcast `removed`) on `ErrPRNotFound` instead of treating it as transient. `reconcileState`'s drop path is factored into a shared `dropPR` helper.

### Tests
- `TestGitHubProvider_GetPRNotFound` — a 404 maps to `ErrPRNotFound` (gitlab/forgejo use the same `resp.StatusCode` check).
- `TestServer_DeletedPRReaped` — a deleted PR is reaped via both `reconcileClosed` (periodic) and `reconcileHeadGone` (the queue's path).

`go test -race ./...`, lint (0 issues), fmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)