### PR TITLE
fix(gitclone): repack the bare mirror once packfiles accumulate

### DIFF
--- a/internal/gitclone/gitclone.go
+++ b/internal/gitclone/gitclone.go
@@ -197,6 +197,23 @@ func (m *Mirror) fetch(ctx context.Context, headRef, baseRef string) (head, base
 		return nil, nil, fmt.Errorf("gitclone: fetch head %q: %w", headRef, err)
 	}
 
+	// Each fetch above appends a packfile, and go-git never consolidates them on
+	// its own (it has no `git gc`), so the mirror's pack count climbs by one per
+	// render and its object store grows without bound. Once the packs pile up
+	// past the threshold, fold them into one. The repack deletes the old packs,
+	// which invalidates this handle's cached pack set, so re-open before resolving
+	// commits off it.
+	repacked, err := m.maybeRepack(repo)
+	if err != nil {
+		return nil, nil, err
+	}
+	if repacked {
+		repo, err = git.PlainOpen(m.bareDir)
+		if err != nil {
+			return nil, nil, fmt.Errorf("gitclone: reopen mirror after repack: %w", err)
+		}
+	}
+
 	head, err = resolveCommit(repo, localHeadRef)
 	if err != nil {
 		return nil, nil, fmt.Errorf("gitclone: head %q: %w", headRef, err)
@@ -206,6 +223,56 @@ func (m *Mirror) fetch(ctx context.Context, headRef, baseRef string) (head, base
 		return nil, nil, fmt.Errorf("gitclone: base %q: %w", baseRef, err)
 	}
 	return head, base, nil
+}
+
+// repackPackThreshold is the packfile count at which a fetch consolidates the
+// mirror into a single pack. go-git appends one pack per fetch and never runs
+// the equivalent of `git gc`, so without an occasional repack the pack directory
+// would grow one file per render forever — slowing every object lookup and
+// bloating the cache volume. 50 matches git's gc.autoPackLimit default. A var,
+// not a const, so tests can lower it.
+var repackPackThreshold = 50
+
+// maybeRepack folds the mirror's packfiles into one when they have piled up past
+// repackPackThreshold, reporting whether it did. go-git's RepackObjects writes a
+// single new pack holding every object reachable from the mirror's refs — so the
+// unreachable objects a force-push leaves behind are reclaimed too — then deletes
+// the superseded packs. That deletion invalidates the open handle's cached pack
+// set, so the caller must re-open the mirror before reading objects through it.
+// Caller holds the write lock.
+func (m *Mirror) maybeRepack(repo *git.Repository) (bool, error) {
+	n, err := m.countPacks()
+	if err != nil {
+		return false, err
+	}
+	if n < repackPackThreshold {
+		return false, nil
+	}
+	// The zero RepackConfig uses OFS deltas and a zero OnlyDeletePacksOlderThan,
+	// which imposes no age floor — every superseded pack is removed.
+	if err := repo.RepackObjects(&git.RepackConfig{}); err != nil {
+		return false, fmt.Errorf("gitclone: repack mirror: %w", err)
+	}
+	return true, nil
+}
+
+// countPacks returns the number of *.pack files in the mirror's object store. A
+// missing pack directory (objects still loose, or none fetched yet) counts as zero.
+func (m *Mirror) countPacks() (int, error) {
+	entries, err := os.ReadDir(filepath.Join(m.bareDir, "objects", "pack"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("gitclone: read pack dir: %w", err)
+	}
+	n := 0
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".pack") {
+			n++
+		}
+	}
+	return n, nil
 }
 
 // openOrClone opens the bare mirror, seeding it with a single-branch bare clone

--- a/internal/gitclone/gitclone_test.go
+++ b/internal/gitclone/gitclone_test.go
@@ -82,6 +82,71 @@ func buildRepo(t *testing.T) string {
 	return dir
 }
 
+// TestMirror_RepacksWhenPacksAccumulate verifies the mirror folds its packfiles
+// into one once they pile up past the threshold. go-git appends a pack per fetch
+// and never gc's them, so without the repack the bare repo would grow one pack
+// per render forever. Each render here advances the head branch so the fetch
+// actually transfers objects (and thus writes a new pack); after enough renders
+// to cross the lowered threshold, the pack count must collapse — and renders must
+// still resolve correct trees off the consolidated pack.
+func TestMirror_RepacksWhenPacksAccumulate(t *testing.T) {
+	orig := repackPackThreshold
+	repackPackThreshold = 3
+	t.Cleanup(func() { repackPackThreshold = orig })
+
+	src := buildRepo(t)
+	repo, err := git.PlainOpen(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// buildRepo leaves the worktree checked out on "feature"; keep committing
+	// there so each fetch of refs/heads/feature pulls a fresh object set.
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := newTestMirror(t, src)
+	const renders = 6 // > threshold+1, so at least one fetch crosses the bound
+	var last *Result
+	for i := range renders {
+		write(t, src, "app/config.yaml", fmt.Sprintf("replicas: %d\n", 10+i))
+		commit(t, wt, fmt.Sprintf("advance feature %d", i))
+
+		if last != nil {
+			last.Cleanup()
+		}
+		last, err = m.Trees(context.Background(), "refs/heads/feature", "master")
+		if err != nil {
+			t.Fatalf("render %d: %v", i, err)
+		}
+	}
+	t.Cleanup(last.Cleanup)
+
+	// The repack must keep the pack count bounded. Without it, `renders`
+	// object-transferring fetches would leave roughly renders+1 packs.
+	n, err := m.countPacks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n > repackPackThreshold {
+		t.Errorf("pack count = %d after %d renders; repack should keep it ≤ %d", n, renders, repackPackThreshold)
+	}
+
+	// And renders must still resolve correct trees off the consolidated pack:
+	// head is feature's latest tip, base is the merge-base (C0), not main's tip.
+	wantHead := fmt.Sprintf("replicas: %d\n", 10+renders-1)
+	if got, ok := read(last.HeadDir, "app/config.yaml"); !ok || got != wantHead {
+		t.Errorf("head config.yaml = %q (ok=%v) after repack, want %q", got, ok, wantHead)
+	}
+	if got, ok := read(last.BaseDir, "app/config.yaml"); !ok || got != "replicas: 3\n" {
+		t.Errorf("base config.yaml = %q (ok=%v) after repack, want merge-base %q", got, ok, "replicas: 3\n")
+	}
+	if _, ok := read(last.BaseDir, "app/other.yaml"); ok {
+		t.Error("base tree contains other.yaml after repack — merge-base resolution broke")
+	}
+}
+
 func TestWithinRoot(t *testing.T) {
 	t.Parallel()
 	const dir = "/tmp/extract"


### PR DESCRIPTION
## What

The bare mirror under `<CacheDir>/git/mirror.git` gained one packfile on **every** fetch (one per render) and was never consolidated — go-git has no `git gc` equivalent and runs none on its own. The cache-GC sweep deliberately spares the git dir, so nothing ever reclaimed those packs. Left running, the pack directory grows without bound: object lookups slow as the pack count climbs, and the cache volume slowly fills.

Fixes #131.

## How

`fetch` (which already holds the mirror write lock) now folds the packs into a single one via go-git's `RepackObjects` once the pack count crosses a threshold:

- **Threshold = 50**, matching git's own `gc.autoPackLimit` default. A package-level `var` so the test can lower it.
- The repack writes one new pack containing every object **reachable from the mirror's refs** (`refs/heads/<base>` + `refs/konflate/pull-head`), then deletes the superseded packs. As a side benefit it reclaims the commits a force-push orphaned (they become unreachable, so they're dropped).
- `RepackObjects` deletes the old packs, which invalidates the open handle's cached pack set, so the mirror is **re-opened** before the head/base commits are resolved off the consolidated pack. The whole thing runs under the write lock the fetch already holds, so it can never race a concurrent tree extraction (those run under the read lock).

The repack is local-only disk work and rare (≈once per 50 fetches), so the amortized cost is negligible against the alternative of unbounded growth.

## Test

`TestMirror_RepacksWhenPacksAccumulate` lowers the threshold to 3, then runs several renders that each advance the head branch (so each fetch actually transfers objects and writes a new pack). It asserts the pack count stays bounded (≤ threshold) instead of climbing one-per-render, and that renders still resolve correct head/merge-base trees off the consolidated pack. Confirmed non-vacuous: with the repack disabled, the same six renders leave 7 packs.

- `go test -race ./...` — green
- `mise run lint` — 0 issues
- `mise run fmt-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)