### PR TITLE
fix(config,engine): key the bare mirror and persisted state by repository

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -126,10 +128,20 @@ type Config struct {
 	// layers, git objects). Shared across diff jobs; persisted across restarts.
 	CacheDir string `env:"KONFLATE_CACHE_DIR"`
 
+	// RepoCacheDir is the per-repository subtree of CacheDir holding the two
+	// on-disk areas tied to one specific repository: the bare git mirror and the
+	// persisted diff state. It is keyed by a hash of the clone URL (see repoKey)
+	// so several konflate instances tracking different repositories can share a
+	// single CacheDir volume — worthwhile because flate's content-addressed source
+	// cache (which stays directly under CacheDir) is safe to share — without one
+	// instance silently fetching another's repo or colliding on its state files.
+	// Derived in [Load]; not configurable.
+	RepoCacheDir string `env:"-"`
+
 	// StateDir is where konflate persists its rendered diffs (one zstd-compressed
-	// JSON per PR) so the store survives restarts. Derived as <CacheDir>/state in
-	// [Load] — it rides on the same volume as the source cache, so persistence is
-	// automatic once that volume is durable, and there is no separate knob. It
+	// JSON per PR) so the store survives restarts. Derived as <RepoCacheDir>/state
+	// in [Load] — it rides on the same volume as the source cache, so persistence
+	// is automatic once that volume is durable, and there is no separate knob. It
 	// sits beside flate's cache entries, which the cache GC leaves untouched.
 	StateDir string `env:"-"`
 
@@ -297,7 +309,14 @@ func Load() (*Config, error) {
 	if cfg.CacheDir == "" {
 		cfg.CacheDir = filepath.Join(xdgCacheHome(), "konflate")
 	}
-	cfg.StateDir = filepath.Join(cfg.CacheDir, "state")
+	// The bare mirror and persisted state are specific to this repository, so key
+	// their parent directory by the clone URL. Without this, two instances sharing
+	// a CacheDir volume (to share flate's safe content-addressed source cache)
+	// collide: one fetches into the other's mirror — silently rendering the wrong
+	// repo — and overwrites its state files. flate's cache stays directly under
+	// CacheDir and remains shared.
+	cfg.RepoCacheDir = filepath.Join(cfg.CacheDir, "repos", repoKey(cfg.Forge.CloneURL()))
+	cfg.StateDir = filepath.Join(cfg.RepoCacheDir, "state")
 	if cfg.CloneDir == "" {
 		cfg.CloneDir = filepath.Join(os.TempDir(), "konflate")
 	}
@@ -348,4 +367,15 @@ func xdgCacheHome() string {
 		return filepath.Join(os.TempDir(), ".cache")
 	}
 	return filepath.Join(home, ".cache")
+}
+
+// repoKey derives a stable, filesystem-safe directory name from a clone URL so
+// the per-repository cache subtree (RepoCacheDir) is unique per repo. A hash
+// rather than the raw URL keeps the name bounded and free of path separators or
+// other characters that would escape the cache root; the 16-hex-char (64-bit)
+// prefix is collision-resistant for the handful of repos that might ever share
+// one CacheDir volume.
+func repoKey(cloneURL string) string {
+	sum := sha256.Sum256([]byte(cloneURL))
+	return hex.EncodeToString(sum[:])[:16]
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -264,7 +266,38 @@ func TestLoad_StateDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if want := "/var/cache/konflate/state"; cfg.StateDir != want {
-		t.Errorf("StateDir = %q, want %q (derived from CacheDir)", cfg.StateDir, want)
+	// The mirror and state live under a per-repo subtree (CacheDir/repos/<key>),
+	// not directly under CacheDir, so a CacheDir volume shared across
+	// different-repo instances can't cross-fetch or collide on state files.
+	reposRoot := filepath.Join("/var/cache/konflate", "repos")
+	if filepath.Dir(cfg.RepoCacheDir) != reposRoot {
+		t.Errorf("RepoCacheDir = %q, want a per-repo child of %q", cfg.RepoCacheDir, reposRoot)
+	}
+	if want := filepath.Join(cfg.RepoCacheDir, "state"); cfg.StateDir != want {
+		t.Errorf("StateDir = %q, want %q (under the repo-keyed dir)", cfg.StateDir, want)
+	}
+}
+
+// TestRepoKey verifies the per-repo cache key: distinct clone URLs must map to
+// distinct directory names (else two repos collide on one mirror/state dir —
+// the bug this fixes), the same URL maps stably (so the cache survives
+// restarts), and the name is filesystem-safe (no separators that escape the
+// cache root).
+func TestRepoKey(t *testing.T) {
+	t.Parallel()
+	const urlA = "https://github.com/owner/repo-a.git"
+	const urlB = "https://github.com/owner/repo-b.git"
+	a, b := repoKey(urlA), repoKey(urlB)
+	if a == b {
+		t.Errorf("distinct clone URLs must yield distinct keys; both = %q", a)
+	}
+	if a != repoKey(urlA) {
+		t.Error("repoKey must be deterministic for the same clone URL")
+	}
+	if a == "" {
+		t.Error("repoKey must not be empty")
+	}
+	if strings.ContainsAny(a, `/\.`) {
+		t.Errorf("key %q contains path-unsafe characters", a)
 	}
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -81,10 +81,14 @@ func New(cfg *config.Config) Engine {
 		conc = runtime.NumCPU() * 4 // flate's default for I/O-bound reconcile work
 	}
 	return &flateEngine{
-		clusterPath:            cfg.ClusterPath,
-		selfURLs:               []string{cfg.Forge.CloneURL()},
-		cacheDir:               cfg.CacheDir,
-		mirror:                 gitclone.NewMirror(cfg.CacheDir, cfg.CloneDir, cfg.Forge.CloneURL(), cfg.Token, cfg.FetchTimeout),
+		clusterPath: cfg.ClusterPath,
+		selfURLs:    []string{cfg.Forge.CloneURL()},
+		cacheDir:    cfg.CacheDir,
+		// The bare mirror is repo-specific, so it hangs off the per-repo subtree
+		// (RepoCacheDir), not the shared CacheDir — otherwise a CacheDir volume
+		// shared across different-repo instances would cross-fetch. flate's
+		// content-addressed source cache below stays on CacheDir and is shared.
+		mirror:                 gitclone.NewMirror(cfg.RepoCacheDir, cfg.CloneDir, cfg.Forge.CloneURL(), cfg.Token, cfg.FetchTimeout),
 		pullHeadRef:            cfg.Forge.PullHeadRef,
 		cache:                  source.NewCache(cacheroot.New(cfg.CacheDir)),
 		stageCacheBytes:        int64(cfg.StageCacheMB) * mib,


### PR DESCRIPTION
## What

The bare mirror (`<CacheDir>/git/mirror.git`) and persisted diff state (`<CacheDir>/state/<n>.json.zst`) hung directly off `CacheDir`, keyed by nothing. Two konflate instances tracking **different** repos but sharing one `CacheDir` volume — a plausible setup, since flate's content-addressed source cache *is* safe (and beneficial) to share — silently corrupt each other:

- `openOrClone` `PlainOpen`s whatever mirror exists, and `fetchSpec` sets no `RemoteURL`, so go-git resolves `origin` from the **on-disk config** — i.e. whichever repo seeded the mirror first. Instance B fetches instance A's `refs/pull/N/head` + base branch (both typically exist, so nothing errors) and **renders the wrong repository's diffs**.
- Both instances collide on `state/<n>.json.zst` and restore each other's PRs after a restart.

It's non-default config, but the failure is silent wrong output rather than an error.

Fixes #135.

## How

Root both repo-specific areas under a per-repo subtree keyed by a hash of the clone URL:

```
<CacheDir>/repos/<repoKey(cloneURL)>/git/mirror.git   # the mirror
<CacheDir>/repos/<repoKey(cloneURL)>/state/<n>.json.zst # persisted diffs
```

- `config.Load` computes `cfg.RepoCacheDir = <CacheDir>/repos/<key>` and derives `StateDir` under it; `engine.New` passes `RepoCacheDir` (not `CacheDir`) to `NewMirror`.
- `repoKey` is a 16-hex-char SHA-256 prefix of the clone URL — bounded, filesystem-safe, collision-resistant for the handful of repos that could share a volume.
- **flate's source cache stays directly under `CacheDir`** (`cacheroot.New(cfg.CacheDir)`) and remains shared — that's the whole point of sharing the volume. Confirmed flate's cacheroot subdirs (`sources`, `baselines`, `blobs`, `git-mirrors`, …) don't include `repos`, so the new subtree is a sibling its GC sweep leaves untouched, exactly as it did for the old `git/`+`state/`.

Distinct repos now get distinct dirs (no cross-fetch, no state collision); the same repo keys stably, so the cache still survives restarts.

### Upgrade note

After upgrade the old `<CacheDir>/git` and `<CacheDir>/state` are orphaned — a one-time re-clone of the mirror and re-render of persisted diffs. They're cache data, so no migration is performed.

## Test

- `TestRepoKey` — distinct URLs → distinct keys (the bug), same URL → stable key (cache survives restarts), key is non-empty and path-separator-free.
- `TestLoad_StateDir` — updated: `RepoCacheDir` is a child of `<CacheDir>/repos`, and `StateDir` is `<RepoCacheDir>/state`.
- `go test -race ./...` green, `mise run lint` 0 issues, `mise run fmt-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)