### PR TITLE
fix(diff): drop type-only "changed" resources that render an empty panel

### DIFF
--- a/internal/diff/lint.go
+++ b/internal/diff/lint.go
@@ -29,6 +29,13 @@ type Change struct {
 	NewChart string
 }
 
+// Change.Status values — the api status union. ("changed" is the default arm
+// everywhere, so it has no named constant.)
+const (
+	statusAdded   = "added"
+	statusRemoved = "removed"
+)
+
 // Lint runs the danger-lint rules over the changed resources (and the diff's
 // image changes) and returns the warnings, most-severe first (all dangers
 // before all cautions). Advisory only — konflate never blocks on these; they
@@ -40,7 +47,7 @@ func Lint(changes []Change, images []api.ImageChange) []api.Warning {
 	}
 
 	for _, c := range changes {
-		if c.Status == "removed" {
+		if c.Status == statusRemoved {
 			switch c.Kind {
 			case "StatefulSet":
 				add("removed-statefulset", "removed StatefulSet — its PersistentVolumeClaims and data may be deleted", c)
@@ -67,7 +74,7 @@ func Lint(changes []Change, images []api.ImageChange) []api.Warning {
 			}
 		}
 
-		if c.Status == "added" && c.Kind == "ClusterRoleBinding" {
+		if c.Status == statusAdded && c.Kind == "ClusterRoleBinding" {
 			add("rbac-widened", "new ClusterRoleBinding — grants cluster-wide permissions", c)
 		}
 	}

--- a/internal/diff/render.go
+++ b/internal/diff/render.go
@@ -51,24 +51,53 @@ func Render(in RenderInput) (api.DiffResult, error) {
 	}
 	hl := b.hl
 
+	// flate classifies a change by typed inequality (reflect.DeepEqual over the
+	// normalized values), so a difference that is only a type — e.g. replicas: 3
+	// (int) vs 3.0 (float64) — arrives as "changed" yet marshals to identical YAML
+	// through sigs.k8s.io/yaml (both via JSON → "3"). Rendered, that's zero diff
+	// rows: an empty panel, still counted in Summary.Changed and listed in the
+	// tree as +0/−0. Marshal each side once here and drop those no-ops before
+	// anything counts or renders them, so a resource appears only when it has a
+	// real textual difference. (Added/removed always have one populated side, so
+	// only "changed" can collapse to a no-op.)
+	kept := make([]marshaledChange, 0, len(in.Changes))
+	for _, c := range in.Changes {
+		oldYAML, err := marshalYAML(c.Old)
+		if err != nil {
+			return api.DiffResult{}, err
+		}
+		newYAML, err := marshalYAML(c.New)
+		if err != nil {
+			return api.DiffResult{}, err
+		}
+		if c.Status != statusAdded && c.Status != statusRemoved && oldYAML == newYAML {
+			continue
+		}
+		kept = append(kept, marshaledChange{change: c, oldYAML: oldYAML, newYAML: newYAML})
+	}
+	changes := make([]Change, len(kept))
+	for i := range kept {
+		changes[i] = kept[i].change
+	}
+
 	out := api.DiffResult{
 		PRNumber:  in.PRNumber,
 		HeadSHA:   in.HeadSHA,
 		ChromaCSS: b.css,
-		Impact:    Summarize(in.Changes),
+		Impact:    Summarize(changes),
 		Images:    in.Images,
 		Failures:  in.Failures,
-		Warnings:  Lint(in.Changes, in.Images),
+		Warnings:  Lint(changes, in.Images),
 	}
 
-	// Summary reflects the true totals across every change, even when the
+	// Summary reflects the true totals across every (real) change, even when the
 	// per-resource render below is capped — so the topbar counts and the impact
 	// banner agree on the real blast radius regardless of truncation.
-	for _, c := range in.Changes {
+	for _, c := range changes {
 		switch c.Status {
-		case "added":
+		case statusAdded:
 			out.Summary.Added++
-		case "removed":
+		case statusRemoved:
 			out.Summary.Removed++
 		default:
 			out.Summary.Changed++
@@ -80,32 +109,31 @@ func Render(in RenderInput) (api.DiffResult, error) {
 	// or pathological PR is truncated to MaxResources rendered diffs; the counts
 	// above already reflect the full set, and Truncated tells the UI the review
 	// is partial.
-	rendered := in.Changes
+	rendered := kept
 	if in.MaxResources > 0 && len(rendered) > in.MaxResources {
 		out.Truncated = len(rendered) - in.MaxResources
 		rendered = rendered[:in.MaxResources]
 	}
-	for i, c := range rendered {
-		res, err := buildResource(fmt.Sprintf("r%d", i), c, hl)
-		if err != nil {
-			return api.DiffResult{}, err
-		}
-		out.Resources = append(out.Resources, res)
+	for i, mc := range rendered {
+		out.Resources = append(out.Resources, buildResource(fmt.Sprintf("r%d", i), mc, hl))
 	}
 	out.Tree = buildTree(out.Resources)
 	return out, nil
 }
 
-// buildResource diffs one change's old→new YAML and pre-renders both views.
-func buildResource(id string, c Change, hl *highlighter) (api.DiffResource, error) {
-	oldYAML, err := marshalYAML(c.Old)
-	if err != nil {
-		return api.DiffResource{}, err
-	}
-	newYAML, err := marshalYAML(c.New)
-	if err != nil {
-		return api.DiffResource{}, err
-	}
+// marshaledChange is a Change with both sides already rendered to YAML — done
+// once in Render so the type-only no-op filter and buildResource share the work
+// instead of marshaling twice.
+type marshaledChange struct {
+	change           Change
+	oldYAML, newYAML string
+}
+
+// buildResource diffs one change's already-marshaled old→new YAML and
+// pre-renders both views. The sides are marshaled in Render, so this is pure
+// string work and cannot fail.
+func buildResource(id string, mc marshaledChange, hl *highlighter) api.DiffResource {
+	c, oldYAML, newYAML := mc.change, mc.oldYAML, mc.newYAML
 
 	a := difflib.SplitLines(oldYAML)
 	b := difflib.SplitLines(newYAML)
@@ -136,7 +164,7 @@ func buildResource(id string, c Change, hl *highlighter) (api.DiffResource, erro
 			res.Del++
 		}
 	}
-	return res, nil
+	return res
 }
 
 // gap is one collapsed run of unchanged lines — the context GetGroupedOpCodes

--- a/internal/diff/render_test.go
+++ b/internal/diff/render_test.go
@@ -75,6 +75,54 @@ func TestRender_Changed(t *testing.T) {
 	}
 }
 
+// TestRender_DropsTypeOnlyNoOpChange verifies a "changed" pair whose two sides
+// marshal to identical YAML is dropped, not rendered as an empty panel. flate
+// flags changes by typed inequality (reflect.DeepEqual), so replicas typed int 3
+// vs float64 3.0 arrives as "changed" yet marshals the same — it must not count
+// in the summary, the impact, or the tree, while a genuine change beside it
+// still renders.
+func TestRender_DropsTypeOnlyNoOpChange(t *testing.T) {
+	t.Parallel()
+	// Built directly (not via the YAML doc helper, which would coerce both
+	// numbers to float64) so the no-op pair really differs only by Go type.
+	dep := func(name string, replicas any) map[string]any {
+		return map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]any{"name": name},
+			"spec":       map[string]any{"replicas": replicas},
+		}
+	}
+	res, err := Render(RenderInput{
+		PRNumber: 1,
+		Changes: []Change{
+			{Status: "changed", Kind: "Deployment", Name: "noop", Old: dep("noop", 3), New: dep("noop", 3.0)},
+			{Status: "changed", Kind: "Deployment", Name: "real", Old: dep("real", 3), New: dep("real", 5)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if res.Summary.Changed != 1 {
+		t.Errorf("Summary.Changed = %d, want 1 (the type-only no-op must not count)", res.Summary.Changed)
+	}
+	if res.Impact.Resources != 1 {
+		t.Errorf("Impact.Resources = %d, want 1 (no-op excluded from impact too)", res.Impact.Resources)
+	}
+	if len(res.Resources) != 1 {
+		t.Fatalf("Resources = %d, want 1 (only the real change renders — no empty panel)", len(res.Resources))
+	}
+	if res.Resources[0].Name != "real" {
+		t.Errorf("rendered resource = %q, want the real change", res.Resources[0].Name)
+	}
+	if res.Resources[0].Add == 0 && res.Resources[0].Del == 0 {
+		t.Error("the surviving real change must carry non-empty diff rows")
+	}
+	if len(res.Tree) != 1 {
+		t.Errorf("Tree parents = %d, want 1 (the no-op is absent from the tree)", len(res.Tree))
+	}
+}
+
 func TestRender_FoldsContext(t *testing.T) {
 	t.Parallel()
 	// A single change surrounded by many unchanged lines: context beyond 3 lines

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -224,11 +224,17 @@ func joinPath(dir, sub string) string {
 
 // pairChanges diffs two flate render outputs (each keyed by producing
 // parent) into konflate's resource-level changes. The pairing,
-// normalization, byte-equality drop, and chart-label capture are flate's
+// normalization, equality drop, and chart-label capture are flate's
 // diff.Changes; konflate layers only its secret/cert scrub (the redact
 // hook) on top of flate's default strip lists. flate.Change maps 1:1 onto
 // our diff.Change (Parent struct → "Kind ns/name" label), already sorted
 // by parent then identity.
+//
+// flate's equality is typed (reflect.DeepEqual over the normalized values),
+// not byte equality, so a pair differing only by Go type — replicas: 3 (int)
+// vs 3.0 (float64) — survives as "changed" even though it marshals to the same
+// YAML. diff.Render collapses those type-only no-ops after marshaling, so they
+// don't show as empty changed resources.
 func pairChanges(base, head map[manifest.NamedResource][]map[string]any) []diff.Change {
 	fc := flatediff.Changes(
 		flatediff.DocsFromManifests(base, nil),
@@ -275,8 +281,8 @@ func unionKeys[K comparable, V any](ms ...map[K]V) []K {
 // Options.Normalize. flate already strips the chart-bump attributes and
 // render-clock spec fields (via DefaultStripAttrs / DefaultStripFields)
 // and summarizes ConfigMap binaryData; this adds the two scrubs flate
-// leaves to the consumer's policy, run on the deep copy before the
-// byte-equality check so they never read as a change (nor reach a
+// leaves to the consumer's policy, run on the deep copy before flate's
+// equality check so they never read as a change (nor reach a
 // response):
 //
 //   - Secret data/stringData values — opaque and often render-random or


### PR DESCRIPTION
## What

flate classifies a change by **typed** inequality (`reflect.DeepEqual` over the normalized values — `changes.go:91`), so a difference that is only a Go type — `replicas: 3` (int) vs `3.0` (float64) — arrives as `StatusChanged`. konflate then marshals both sides with `sigs.k8s.io/yaml`, which (via JSON) renders them **byte-identical**, so `GetGroupedOpCodes` returns zero groups and zero diff rows are emitted.

The resource was still counted in `Summary.Changed`, listed in the navigation tree as `+0/−0`, and folded into the impact banner — but selecting it showed a **completely empty panel**. Reproduced end-to-end through flate v0.3.3's real pipeline (per the issue).

Fixes #128.

## How

`Render` now marshals each side **once** up front and drops a `"changed"` pair whose two sides marshal to identical YAML, *before* anything counts or renders it. So a resource appears only when it has a real textual difference, and the drop flows consistently through the summary counts, the impact banner (`Summarize`), the danger lint (`Lint`), the per-resource render, and the tree.

- Added/removed always have one populated side, so only `"changed"` can collapse to a no-op — the filter is scoped to that.
- The marshaled YAML is threaded into `buildResource` (no second marshal); since it no longer marshals, `buildResource` no longer returns an error.
- The stale "byte-equality drop" comments on `pairChanges`/`redact` are corrected to describe flate's actual `reflect.DeepEqual` classification, and note that konflate collapses the type-only no-ops after marshaling.

A type-only change is a genuine no-op in the *rendered* manifest (both apply identically), so dropping it — rather than showing a blank "changed" entry — is what the reviewer wants.

## Test

`TestRender_DropsTypeOnlyNoOpChange` feeds two `"changed"` resources: one whose only difference is `replicas` typed int `3` vs float64 `3.0` (built directly, since the YAML `doc` helper would coerce both to float64), and one genuine `3→5`. It asserts the no-op is absent from `Summary.Changed`, `Impact.Resources`, `Resources`, and the tree, while the real change still renders with non-empty rows.

`go test -race ./...` green, `mise run lint` 0 issues, `mise run fmt-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)