### PR TITLE
fix(server): coalesce webhook-triggered relists into a single worker

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -455,7 +455,10 @@ func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
 			}
 		}()
 	} else {
-		go s.refreshList(s.runCtx)
+		// Coalesce: a chatty webhook (every check_run/status/push delivered) would
+		// otherwise spawn a goroutine + full ListPRs per event. requestRelist folds
+		// the burst into at most one in-flight relist plus one trailing run.
+		s.requestRelist()
 	}
 	writeJSON(w, http.StatusAccepted, map[string]string{keyStatus: "accepted"})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -51,6 +51,12 @@ type Server struct {
 	queue   *queue
 	runCtx  context.Context
 
+	// relist is the coalescing signal for webhook-triggered re-lists. It holds a
+	// single token, so a burst of inbound events collapses to one in-flight
+	// refreshList plus at most one trailing run (see requestRelist/relistWorker)
+	// rather than a goroutine + forge ListPRs per event. Buffered, created in New.
+	relist chan struct{}
+
 	avatarKey []byte             // HMAC key for signing the same-origin /api/avatar proxy URLs
 	mergeTmpl *template.Template // renders the "copy to merge" command; nil disables it
 }
@@ -67,6 +73,7 @@ func New(cfg *config.Config, prov provider.Provider, eng Engine, ui fs.FS, log *
 		store: newStore(), hub: newHub(log), metrics: newMetrics(),
 		avatarKey: avatarKey,
 		mergeTmpl: newMergeTemplate(cfg, log),
+		relist:    make(chan struct{}, 1),
 	}
 
 	// Durability: persist rendered diffs under the (operator-persisted) cache
@@ -183,6 +190,7 @@ func (s *Server) Run(ctx context.Context) error {
 	// failures are logged inside.
 	go s.refreshList(gctx)
 	go s.refreshLoop(gctx)
+	go s.relistWorker(gctx)
 
 	g.Go(func() error { return serve(mainSrv, "main", s.log) })
 	g.Go(func() error { return serve(metricsSrv, "metrics", s.log) })
@@ -208,6 +216,34 @@ func serve(srv *http.Server, name string, log *slog.Logger) error {
 		return fmt.Errorf("%s server: %w", name, err)
 	}
 	return nil
+}
+
+// requestRelist asks the relist worker to re-list open PRs, coalescing a burst
+// of triggers into at most one in-flight run plus one trailing run. The signal
+// channel holds a single token, so concurrent inbound webhooks collapse onto it
+// instead of each spawning a goroutine + forge ListPRs call. Never blocks.
+func (s *Server) requestRelist() {
+	select {
+	case s.relist <- struct{}{}:
+	default: // a relist is already queued; fold this trigger into it
+	}
+}
+
+// relistWorker serializes webhook-triggered relists: it runs refreshList at most
+// once at a time, and a trigger that arrives mid-run schedules exactly one more
+// run (the buffered signal). This caps the forge-API cost of a chatty
+// "send everything" webhook — where one push's CI activity can fan out into
+// dozens of relist-class deliveries — at one relist in flight plus one pending,
+// instead of a full ListPRs per delivered event. Returns when ctx is cancelled.
+func (s *Server) relistWorker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.relist:
+			s.refreshList(ctx)
+		}
+	}
 }
 
 // refreshLoop is the background refresh. It wakes on a cadence and, once per

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -15,6 +15,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -36,9 +37,13 @@ type fakeProvider struct {
 	details  map[int]api.PR // GetPR overrides (e.g. a departed PR's merged/closed state)
 	notFound map[int]bool   // numbers GetPR reports as deleted (provider.ErrPRNotFound)
 	listErr  error
+	listHook func() // optional seam invoked at the start of each ListPRs (set before use)
 }
 
 func (f *fakeProvider) ListPRs(context.Context) ([]api.PR, error) {
+	if f.listHook != nil {
+		f.listHook() // outside the lock so a hook may block without wedging the fake
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.prs, f.listErr
@@ -149,6 +154,51 @@ func waitFor(t *testing.T, s *Server, number int) api.DiffEnvelope {
 }
 
 // --- tests ---------------------------------------------------------------
+
+// TestServer_WebhookRelistCoalesces verifies a burst of relist triggers collapses
+// to one in-flight refreshList plus one trailing run, rather than a ListPRs per
+// event — the forge-API-quota fix for a chatty "send everything" webhook.
+func TestServer_WebhookRelistCoalesces(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	prov := &fakeProvider{}
+	prov.listHook = func() {
+		if calls.Add(1) == 1 {
+			entered <- struct{}{} // the first relist is now in flight
+			<-release             // hold it so a burst can pile up behind it
+		}
+	}
+	s := newTestServer(t, ghCfg("tok"), prov, okEngine())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.relistWorker(ctx)
+
+	// First trigger: the worker enters ListPRs and blocks there.
+	s.requestRelist()
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("relist worker never started the first run")
+	}
+
+	// A burst arrives while that run is in flight; it must coalesce, not fan out.
+	for range 5 {
+		s.requestRelist()
+	}
+	close(release) // let the in-flight run finish; the worker then drains one token
+
+	// Exactly two ListPRs calls: the in-flight run + one coalesced trailing run.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && calls.Load() < 2 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	time.Sleep(50 * time.Millisecond) // let any erroneous extra run surface
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("ListPRs calls = %d, want 2 (one in-flight + one coalesced trailing run)", got)
+	}
+}
 
 func TestServer_RefreshListAndDiff(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## What

`handleWebhook` spawned `go s.refreshList(...)` for **every** verified delivery that wasn't a single-PR content event — no coalescing, no in-flight dedup. And the relist classification is broad: for GitHub/Forgejo, every non-`pull_request` event (`check_run`, `check_suite`, `status`, `workflow_run`, comments, push, even unparsable JSON) sets `Relist: true`.

A webhook configured to "send everything" (common) turns one push's CI activity (~10 checks × queued/in_progress/completed) into **~30 concurrent full relists** — each a forge `ListPRs` plus a store reconcile sweep. Renders don't multiply (the queue coalesces per-PR), but the forge-API burn is real: ~30 events/min ≈ **1800 redundant list calls/h** against e.g. GitHub's 5000/h token budget, plus goroutine/connection pile-up whenever the forge is slow.

Fixes #130.

## How

Route relist triggers through a single coalescing worker, the same shape the render queue already uses:

- `requestRelist()` does a **non-blocking** send to a cap-1 signal channel.
- `relistWorker(ctx)` runs `refreshList` one at a time; a trigger that arrives mid-run schedules **exactly one** more run (the buffered token).

So a burst of N events collapses to **one in-flight relist plus at most one trailing run**, regardless of N — instead of N goroutines and N `ListPRs` calls. The worker is started in `Run` alongside the existing refresh goroutines (bound to the same errgroup context, so it drains on shutdown). `handleWebhook`'s relist branch becomes `s.requestRelist()`; the per-PR content path (`refreshPR`) is unchanged.

I left the parse-time event classification as-is (the issue floats narrowing it as a secondary "consider"): coalescing fixes the quota cost regardless of how many events request a relist, and narrowing risks dropping a legitimate open/close signal.

## Test

`TestServer_WebhookRelistCoalesces` holds the first `ListPRs` in flight (via a `listHook` seam on the fake provider), fires five more `requestRelist()` calls while it's blocked, then releases it — and asserts `ListPRs` ran **exactly twice** (in-flight + one coalesced trailing run), not six times. Existing `TestServer_WebhookPerPR` still verifies a content event takes the per-PR path and does not relist.

`go test -race ./...` green, `mise run lint` 0 issues, `mise run fmt-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)