### PR TITLE
fix(web): make status:hidden work in the list filter and palette

### DIFF
--- a/internal/web/src/lib/List.svelte
+++ b/internal/web/src/lib/List.svelte
@@ -1,6 +1,15 @@
 <script lang="ts">
   import type { PRStatus } from './types';
-  import { store, filteredPRs, matchesStatus, sortPRs, openPR, ensurePreview, type StatusFilter } from './store.svelte';
+  import {
+    store,
+    filteredPRs,
+    matchesStatus,
+    statusFromQuery,
+    sortPRs,
+    openPR,
+    ensurePreview,
+    type StatusFilter,
+  } from './store.svelte';
   import { clock, timeAgo, absolute } from './time.svelte';
   import { slide } from 'svelte/transition';
   import Icon from './Icon.svelte';
@@ -39,8 +48,11 @@
   const prs = $derived(filteredPRs());
   // The active pill (or default = open, non-hidden) selects what's shown, then
   // the sort orders it. Rendered as one flat list — merged and hidden PRs are
-  // reached via their pills, not a separate group.
-  const shown = $derived(sortPRs(prs.filter((p) => matchesStatus(p, store.statusFilter))));
+  // reached via their pills, not a separate group. A typed `status:` facet acts
+  // like the matching pill, so `status:hidden` / `status:merged` in the search
+  // box reveal those sections instead of being re-hidden by the default pill.
+  const effectiveStatus = $derived(statusFromQuery(store.query) ?? store.statusFilter);
+  const shown = $derived(sortPRs(prs.filter((p) => matchesStatus(p, effectiveStatus))));
   // The full open, non-hidden set — for the default-base heuristic and the pill
   // counts (which hold steady while a pill narrows what's shown).
   const openPrs = $derived(prs.filter((p) => p.open && !p.hidden));

--- a/internal/web/src/lib/store.svelte.ts
+++ b/internal/web/src/lib/store.svelte.ts
@@ -120,7 +120,13 @@ export interface ParsedQuery {
 }
 
 const FACETS = ['status', 'author', 'base', 'label'];
-const STATUS_VALUES = ['caution', 'merged', 'open'];
+// Every queryable status:<v> value — i.e. StatusFilter minus the unfiltered ''.
+// `satisfies readonly StatusFilter[]` makes the compiler reject a typo or a value
+// that isn't a real StatusFilter, so this list can't silently drift out of sync
+// with matchesStatus again. ('hidden' was missing here, so `status:hidden` typed
+// in the filter or palette matched nothing — the pill worked only because it sets
+// statusFilter directly, bypassing this grammar.)
+const STATUS_VALUES = ['open', 'caution', 'merged', 'hidden'] as const satisfies readonly StatusFilter[];
 
 export function parseQuery(raw: string): ParsedQuery {
   const tokens: ParsedQuery['tokens'] = [];
@@ -140,9 +146,10 @@ export function matchesQuery(p: PRStatus, q: ParsedQuery): boolean {
   for (const t of q.tokens) {
     switch (t.key) {
       case 'status': {
-        // Prefix-match the canonical names so "status:cau" works.
+        // Prefix-match the canonical names so "status:cau" works. want is already
+        // a StatusFilter (STATUS_VALUES is typed), so no cast is needed.
         const want = STATUS_VALUES.find((v) => v.startsWith(t.value));
-        if (!want || !matchesStatus(p, want as StatusFilter)) return false;
+        if (!want || !matchesStatus(p, want)) return false;
         break;
       }
       case 'author':
@@ -176,6 +183,22 @@ export function filteredPRs(): PRStatus[] {
   if (!raw) return store.prs;
   const q = parseQuery(raw);
   return store.prs.filter((p) => matchesQuery(p, q));
+}
+
+// statusFromQuery resolves a status: facet in the raw query to its StatusFilter,
+// or null when the query carries none. The List uses it so a typed
+// `status:hidden` / `status:merged` selects that section like the matching pill
+// would; without it the default pill ('' = open, non-hidden) re-hides exactly the
+// PRs the query asked for. Prefix-matched like matchesQuery, so `status:mer`
+// resolves too; the first status token wins if several are present.
+export function statusFromQuery(raw: string): StatusFilter | null {
+  for (const t of parseQuery(raw).tokens) {
+    if (t.key === 'status') {
+      const want = STATUS_VALUES.find((v) => v.startsWith(t.value));
+      if (want) return want;
+    }
+  }
+  return null;
 }
 
 // matchesStatus is the per-PR predicate for a summary-pill filter.

--- a/internal/web/tests/list-triage.spec.ts
+++ b/internal/web/tests/list-triage.spec.ts
@@ -4,8 +4,9 @@ import type { Meta, PRStatus } from '../src/lib/types';
 const meta: Meta = { forge: 'github', repo: 'acme/home-ops', refreshIntervalSeconds: 1800 };
 
 // A self-contained PR set covering the triage axes: a caution-free bump, a PR
-// carrying cautions, and one still rendering. Kept separate from the shared
-// fixture so the existing card-count assertions there stay valid.
+// carrying cautions, one still rendering, and one filter-excluded (hidden). Kept
+// separate from the shared fixture so the existing card-count assertions there
+// stay valid.
 function pr(over: Partial<PRStatus> & { number: number; title: string }): PRStatus {
   return {
     author: 'renovate[bot]',
@@ -36,6 +37,13 @@ const prs: PRStatus[] = [
     signals: { resources: 5, caution: 2, images: 0, failures: 0 },
   }),
   pr({ number: 3, title: 'still rendering', status: 'running' }),
+  pr({
+    number: 4,
+    title: 'excluded by filter',
+    hidden: true,
+    status: 'pending',
+    signals: { resources: 0, caution: 0, images: 0, failures: 0 },
+  }),
 ];
 
 async function stubApi(page: Page) {
@@ -70,4 +78,18 @@ test('status:caution query facet matches the pill filter', async ({ page }) => {
   await page.locator('input.pr-search').fill('status:caution');
   await expect(cards(page)).toHaveCount(1);
   await expect(cards(page).first()).toContainText('risky rbac change');
+});
+
+test('status:hidden query facet reveals the filter-excluded PRs', async ({ page }) => {
+  await stubApi(page);
+  await page.goto('/');
+
+  // The default view excludes hidden PRs — only the three rendered ones show.
+  await expect(cards(page)).toHaveCount(3);
+
+  // Typing the facet (not clicking the pill) must narrow to the hidden PR.
+  // STATUS_VALUES omitted 'hidden', so this previously matched nothing.
+  await page.locator('input.pr-search').fill('status:hidden');
+  await expect(cards(page)).toHaveCount(1);
+  await expect(cards(page).first()).toContainText('excluded by filter');
 });


### PR DESCRIPTION
## What

`'hidden'` is a first-class `StatusFilter` (its own pill and `matchesStatus` arm), but `STATUS_VALUES` — the grammar the `status:` facet resolves against — was `['caution', 'merged', 'open']`, omitting it. So `status:hidden` typed in the list filter or the ⌘K palette did `STATUS_VALUES.find(v => v.startsWith('hidden'))` → `undefined` → false for every PR ("No pull requests match"). The pill worked only because it sets `statusFilter` directly, bypassing the grammar; the `want as StatusFilter` cast is why TypeScript never flagged the drift.

Fixes #136.

## How

- **Grammar + type safety:** add `'hidden'` to `STATUS_VALUES` and type it `['open','caution','merged','hidden'] as const satisfies readonly StatusFilter[]`, so a future typo or a value that isn't a real `StatusFilter` fails to compile. The `find()` result is now a `StatusFilter`, so the `as StatusFilter` cast in `matchesQuery` is dropped. This alone fixes the **palette**, whose match list is `matchesQuery`-only.
- **List double-gate:** the list computes `shown = filteredPRs() ∩ matchesStatus(statusFilter)`, and the default pill (`'' = open, non-hidden`) re-hid the very PRs a typed `status:hidden` (or `status:merged`) asked for — so the grammar fix wasn't enough there. A typed `status:` facet now acts like the matching pill via a new `statusFromQuery(query)` (`effectiveStatus = statusFromQuery(query) ?? statusFilter`), so those sections actually appear. Clicking a pill is unchanged (no query token → falls back to `statusFilter`).

## Test

`list-triage.spec.ts` gains a hidden PR to the fixture (excluded from the default view, so existing counts hold) and a `status:hidden query facet reveals the filter-excluded PRs` case: default view shows the 3 rendered PRs, typing `status:hidden` narrows to the 1 hidden PR. Mirrors the existing `status:caution` case.

`npm run typecheck` 0 errors; full Playwright suite 62 passed / 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)