### PR TITLE
perf(gitclone): stream blobs and dedupe MkdirAll in extractTree

### DIFF
--- a/internal/gitclone/gitclone.go
+++ b/internal/gitclone/gitclone.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -353,13 +354,20 @@ var maxFileBytes int64 = 10 << 20 // 10 MiB
 // skipped: entries whose path escapes dir (a maliciously crafted repository —
 // konflate may be pointed at a public repo it does not own — could carry a tree
 // entry like "../../etc/x", and writing it via filepath.Join would land outside
-// dir, a zip-slip), and files larger than maxFileBytes. go-git's File.Contents
+// dir, a zip-slip), and files larger than maxFileBytes. go-git's blob reader
 // yields blob bytes, not symlinks, so regular files are the only thing written.
+//
+// Both trees are extracted under the mirror read lock, so per-file work is kept
+// lean: the blob streams straight to disk (no Contents() buffer→string→[]byte
+// copies), and MkdirAll is skipped when an entry shares the previous one's
+// directory — tree iteration is path-sorted, so same-dir files arrive in a run.
 func extractTree(c *object.Commit, dir string) error {
 	tree, err := c.Tree()
 	if err != nil {
 		return err
 	}
+	var lastDir string
+	var haveDir bool
 	return tree.Files().ForEach(func(f *object.File) error {
 		dst := filepath.Join(dir, filepath.FromSlash(f.Name))
 		if !withinRoot(dir, dst) {
@@ -368,15 +376,42 @@ func extractTree(c *object.Commit, dir string) error {
 		if f.Size > maxFileBytes {
 			return nil // oversized blob; not review-relevant, skip to bound memory/disk
 		}
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return err
+		if d := filepath.Dir(dst); !haveDir || d != lastDir {
+			if err := os.MkdirAll(d, 0o755); err != nil {
+				return err
+			}
+			lastDir, haveDir = d, true
 		}
-		contents, err := f.Contents()
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(dst, []byte(contents), 0o644)
+		return writeBlob(f, dst)
 	})
+}
+
+// writeBlob streams f's blob contents into a new file at dst. Copying through
+// f.Reader() avoids the two full-content copies File.Contents() makes (it reads
+// the blob into a bytes.Buffer, then a string, which extractTree would copy
+// again into a []byte) — wasteful per file across two whole trees under the read
+// lock. The named return lets a deferred Close surface a flush error.
+func writeBlob(f *object.File, dst string) (err error) {
+	r, err := f.Reader()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := r.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := out.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+	_, err = io.Copy(out, r)
+	return err
 }
 
 // withinRoot reports whether path stays inside dir (no traversal escape).

--- a/internal/gitclone/gitclone_test.go
+++ b/internal/gitclone/gitclone_test.go
@@ -405,10 +405,59 @@ func TestMirror_SkipsOversizedFiles(t *testing.T) {
 	}
 }
 
+// TestMirror_ExtractsNestedDirectories guards the per-directory MkdirAll dedupe
+// in extractTree: files spread across several directories (two in the same dir,
+// plus a deeper nesting) must all materialize with their contents. A MkdirAll
+// wrongly skipped for a genuinely new directory would drop that directory's
+// files, so this exercises directory transitions, not just same-dir runs.
+func TestMirror_ExtractsNestedDirectories(t *testing.T) {
+	src := t.TempDir()
+	repo, err := git.PlainInit(src, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := map[string]string{
+		"root.yaml":       "r: 0\n",
+		"app/one.yaml":    "a: 1\n",
+		"app/two.yaml":    "a: 2\n", // second file in app/ — the dedupe's common case
+		"infra/net.yaml":  "i: 1\n", // a new directory after app/
+		"app/deep/x.yaml": "d: 1\n", // a deeper nesting
+	}
+	for rel, content := range files {
+		write(t, src, rel, content)
+	}
+	commit(t, wt, "C0")
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Storer.SetReference(
+		plumbing.NewHashReference(plumbing.NewBranchReferenceName("feature"), head.Hash()),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := newTestMirror(t, src).Trees(context.Background(), "refs/heads/feature", "master")
+	if err != nil {
+		t.Fatalf("Trees: %v", err)
+	}
+	t.Cleanup(res.Cleanup)
+
+	for rel, want := range files {
+		if got, ok := read(res.HeadDir, rel); !ok || got != want {
+			t.Errorf("%s = %q (ok=%v), want %q", rel, got, ok, want)
+		}
+	}
+}
+
 // TestMirror_ExtractsSymlinkAsRegularFile verifies a symlink committed to the
 // repo is materialized as a regular file whose contents are the link target
-// string — never a live symlink. go-git's File.Contents yields the blob (the
-// target path), and extractTree writes it with os.WriteFile, so flate later
+// string — never a live symlink. go-git's blob reader yields the blob (the
+// target path), and extractTree streams it to a regular file, so flate later
 // reads inert text instead of following a link out of the tree. A hostile repo
 // konflate doesn't own could otherwise smuggle host files (e.g. a link to
 // /etc/passwd, or one escaping the extraction root) into a render.


### PR DESCRIPTION
## What

`extractTree` runs under the mirror **read lock** over every file in **both** trees, and per file did four avoidable things:

- `os.MkdirAll(dir)` — a stat even when the dir repeats (tree iteration is path-sorted, so it's almost always the same dir as the previous entry),
- `f.Contents()` — go-git reads the blob into a `bytes.Buffer`, then converts to a `string`,
- `[]byte(contents)` — a second full copy,
- `os.WriteFile` — open/write/close.

At a realistic 3–10k-file repo × 2 trees per render that's tens of thousands of redundant syscalls plus two extra full-content copies per blob (tens to hundreds of MiB of transient garbage), all extending the window a pending fetch (write lock) — and everything queued behind it — waits.

Fixes #132.

## How

Both changes are local to `extractTree`:

- **Stream the blob:** `io.Copy` from `f.Reader()` straight into the output file, dropping both the buffer→string and string→`[]byte` copies. (`File.Contents` is itself just `Reader()` + buffer + `String()`, so this is strictly less work.)
- **Dedupe MkdirAll:** skip it when an entry shares the previous entry's directory. Git trees are name-sorted, so same-dir files arrive in a run; a genuinely new directory still triggers `MkdirAll` (which is idempotent, so even an out-of-run repeat is harmless — correctness doesn't depend on the sort).

Output is byte-identical to before. The oversize cap and zip-slip / symlink guards are unchanged (still checked before any write).

## Test

Existing merge-base, oversized-file, and symlink tests already pin the output. Added `TestMirror_ExtractsNestedDirectories`: files across `root`, `app/` (two files), `infra/`, and `app/deep/` all materialize with their contents — exercising directory transitions, not just same-dir runs, so a wrongly-skipped `MkdirAll` would be caught. (Also corrected the now-stale `Contents`/`os.WriteFile` mention in the symlink test's comment.)

`go test -race ./...` green, `mise run lint` 0 issues, `mise run fmt-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)