### PR TITLE
fix(chart): document and enforce konflate's single-instance design

### DIFF
--- a/charts/konflate/README.md
+++ b/charts/konflate/README.md
@@ -113,7 +113,7 @@ Kubernetes: `>=1.25.0-0`
 | podLabels | object | `{}` | Labels added to the pod. |
 | podSecurityContext | object | `{"fsGroup":65532,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod-level securityContext (runs as non-root uid/gid 65532 with the RuntimeDefault seccomp profile). |
 | readinessProbe | object | `{"httpGet":{"path":"/readyz","port":"http"},"initialDelaySeconds":5,"periodSeconds":10}` | Readiness probe. |
-| replicaCount | int | `1` | Number of konflate replicas (it's stateless behind the Service). |
+| replicaCount | int | `1` | Replica count; konflate is single-instance, so 0 or 1 only (a value >1 is rejected at render time). |
 | resources | object | `{"limits":{"memory":"1Gi"},"requests":{"cpu":"50m","memory":"256Mi"}}` | Pod resource requests/limits. The memory limit is the hard ceiling: it drives GOMEMLIMIT (90%) so the GC reclaims before the kernel OOM-kills a runaway render. Default bounds memory out of the box; raise it for very large clusters. |
 | secret.existingSecret | string | `""` | Existing Secret holding the KONFLATE_* keys; takes precedence over the inline values below. |
 | secret.pushToken | string | `""` | Push token; enables POST /api/prs/{n}/refresh (authenticated mode). |

--- a/charts/konflate/templates/deployment.tpl
+++ b/charts/konflate/templates/deployment.tpl
@@ -1,3 +1,13 @@
+{{- /*
+  konflate is single-instance: its PR/diff state lives in memory and is served
+  from one pod (strategy: Recreate below). Two replicas wedge on the RWO cache
+  volume's Multi-Attach error with persistence, or round-robin between divergent
+  in-memory stores without it. Reject >1 at render so the misconfiguration is a
+  clear install error rather than a confusing runtime one; 0 is allowed (pause).
+*/ -}}
+{{- if gt (int .Values.replicaCount) 1 -}}
+{{- fail (printf "konflate is single-instance (in-memory PR/diff state); replicaCount must be 0 or 1, got %d" (int .Values.replicaCount)) -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/konflate/tests/deployment_test.yaml
+++ b/charts/konflate/tests/deployment_test.yaml
@@ -204,3 +204,24 @@ tests:
       - equal:
           path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
           value: RELEASE-NAME-data
+
+  - it: defaults to a single replica
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: allows scaling to zero (pause) without uninstalling
+    set:
+      replicaCount: 0
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 0
+
+  - it: rejects more than one replica (konflate is single-instance)
+    set:
+      replicaCount: 2
+    asserts:
+      - failedTemplate:
+          errorMessage: konflate is single-instance (in-memory PR/diff state); replicaCount must be 0 or 1, got 2

--- a/charts/konflate/values.schema.json
+++ b/charts/konflate/values.schema.json
@@ -674,7 +674,7 @@
     },
     "replicaCount": {
       "default": 1,
-      "description": "Number of konflate replicas (it's stateless behind the Service).",
+      "description": "Replica count; konflate is single-instance, so 0 or 1 only (a value \u003e1 is rejected at render time).",
       "title": "replicaCount",
       "type": "integer"
     },

--- a/charts/konflate/values.yaml
+++ b/charts/konflate/values.yaml
@@ -14,7 +14,14 @@
 # text/template konflate renders per-PR with .Number/.Repo — plus plain numbers and
 # booleans. To emit a literal brace, escape it: write `{{ "{{" }}` for `{{`.
 
-# -- Number of konflate replicas (it's stateless behind the Service).
+# konflate keeps its PR/diff state in memory and serves it from one instance
+# (the Deployment uses strategy: Recreate, never overlapping pods). It does NOT
+# scale horizontally: a second replica wedges on the RWO cache volume's
+# Multi-Attach error, or — without persistence — round-robins behind the Service
+# between two divergent in-memory stores. So this must be 0 or 1; a value >1 is
+# rejected at render. 0 scales it down (pause) without uninstalling.
+
+# -- Replica count; konflate is single-instance, so 0 or 1 only (a value >1 is rejected at render time).
 replicaCount: 1
 
 image:


### PR DESCRIPTION
## What

`values.yaml` documented `replicaCount` as *"Number of konflate replicas (it's stateless behind the Service)"* — directly contradicting `deployment.tpl`, which says the opposite (*"konflate keeps PR/diff state in memory, so run a single instance and replace … on rollout"*, hence `strategy: Recreate`). And nothing guarded `replicaCount > 1` (`helm template --set replicaCount=2 --set persistence.enabled=true` rendered cleanly).

An operator who trusts the values comment and sets `replicaCount: 2`:
- **with persistence** — the second pod wedges on the RWO volume's Multi-Attach error;
- **without it** — one Service round-robins between two **divergent in-memory stores** (list/diff responses flap, webhooks land on only one replica).

The in-process `sync.RWMutex` doesn't coordinate across pods, so there's no safe >1.

Fixes #133.

## How

- **Doc:** rewrite the `values.yaml` comment (and the regenerated README + `values.schema.json`) to state the single-instance design — `0` or `1` only, why it can't scale, and that `0` is a scale-to-zero pause.
- **Enforce:** reject `replicaCount > 1` at render with a `fail` (same pattern as the existing `networkPolicy.type` guard), so the misconfiguration is a clear `helm install` error instead of a confusing runtime one. `0` stays allowed.

I used a template `fail` rather than a `values.schema.json` `maximum: 1` because the schema is generated by helm-schema (the repo uses no `@schema` annotations) and the render-time guard is the stronger, always-enforced check.

## Test

`deployment_test.yaml` gains three cases: default → `spec.replicas: 1`; `replicaCount: 0` → `spec.replicas: 0`; `replicaCount: 2` → `failedTemplate` with the message. helm-unittest 40/40, `helm lint` clean, `mise run generate-check` clean. Verified by hand: `--set replicaCount=2` fails the render, `1`/`0` render `replicas: 1`/`0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)