### PR TITLE
ci: path-filter triggers, add concurrency, cache golangci-lint

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   workflow_dispatch:
 
 concurrency:
@@ -44,6 +48,13 @@ jobs:
             ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
           restore-keys: ${{ runner.os }}-go-
+
+      - name: Cache golangci-lint
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-${{ hashFiles('go.sum', '.golangci.yml') }}
+          restore-keys: ${{ runner.os }}-golangci-lint-
 
       - name: Run linter
         run: mise run lint

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -8,6 +8,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,9 +6,16 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   release:
     types:
       - published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded main builds (rolling tag); never interrupt a published release.
+  cancel-in-progress: ${{ github.event_name != 'release' }}
 
 jobs:
   versions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Cancel superseded main builds (rolling tag); never interrupt a published release.
   cancel-in-progress: ${{ github.event_name != 'release' }}
 
 jobs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## What

Mirrors the CI-efficiency changes merged in home-operations/kromgo#239, tailored to konflate's workflow files.

### Path filters (`paths-ignore: ["**.md"]`)
Skip CI on Markdown-only changes. Added under each `push:`/`pull_request:` trigger of:
- `tests.yaml`
- `lint.yaml`
- `e2e.yaml`
- `release.yaml` — added under the `push:` trigger only (not the `release:` trigger)

### Concurrency
- `release.yaml` — cancels superseded `main` builds (rolling tag) but never interrupts a published release (`cancel-in-progress: ${{ github.event_name != 'release' }}`).
- `release-please.yaml` — serialize per ref with `cancel-in-progress: false`.

`tests.yaml`, `lint.yaml`, and `e2e.yaml` already have a `concurrency:` block, so they were left untouched.

### golangci-lint cache
- `lint.yaml` (Go Lint job) — cache `~/.cache/golangci-lint` keyed on `go.sum` + `.golangci.yml`, added right after the existing Go module/build cache step. The job runs `mise run lint` (not `golangci/golangci-lint-action`), so an explicit cache helps.

## Skipped / not touched
- `release-please.yaml`, `renovate.yaml`, `stale.yaml` triggers — no path filters added (per scope).
- The `release:` trigger in `release.yaml` — `paths-ignore` is meaningless on a `release` event.
- `e2e.yaml`/`tests.yaml`/`lint.yaml` concurrency — already present.

## Safety
No required status checks are affected — these only change *when* workflows run and add caching/concurrency, so the change is safe. Verified with `zizmor --offline` on every changed workflow: no new findings.
