### PR TITLE
fix(ui): level the review top bars and close the sticky-header seam

### DIFF
--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -1056,7 +1056,10 @@ button.sum-pill:hover {
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: 6px;
-  padding: 3px 9px;
+  /* 2px vertical (not 3): keeps the chip inside the Summary header's uniform
+     40px bar height instead of stretching that one bar taller than the rest
+     (issue #163). */
+  padding: 2px 9px;
   text-align: left;
   cursor: pointer;
   appearance: none;
@@ -1363,16 +1366,22 @@ button.sum-pill:hover {
 
 /* ---- tree rail ------------------------------------------------------- */
 .tree {
-  padding: 6px 0 24px;
+  /* No top padding: the Summary node is the rail's header bar and sits flush
+     under the review chrome, mirroring the diff pane's .res-header across the
+     rail border (issue #163). */
+  padding: 0 0 24px;
 }
 /* The Summary node — first entry, set apart from the resource leaves by a rule
-   and a document icon. Selecting it shows the impact/warnings/images panel. */
+   and a document icon. Selecting it shows the impact/warnings/images panel.
+   min-height matches .res-header so the two bars' bottom borders meet in one
+   continuous line across the rail border (issue #163). */
 .tree-summary {
   width: 100%;
   display: flex;
   align-items: center;
   gap: 6px;
   padding: 7px 12px;
+  min-height: 40px;
   margin-bottom: 4px;
   border: none;
   border-bottom: 1px solid var(--border);
@@ -1453,14 +1462,23 @@ button.sum-pill:hover {
 }
 
 /* ---- diff view ------------------------------------------------------- */
+/* min-height keeps every header bar — Summary (with the taller merge-command
+   chip) and each resource — one uniform 40px height, level with the rail's
+   Summary node across the rail border. Stuck 1px above the scrollport edge
+   (top: -1px): at top: 0, fractional scroll offsets (hi-dpi wheels, browser
+   zoom) round the header to a subpixel below the pane top and a hairline of
+   the diff text scrolling underneath shows above it; overlapping the edge by
+   1px puts the rounding inside the overlap so the seam can never open.
+   (Issue #163.) */
 .res-header {
   display: flex;
   align-items: center;
   gap: 10px;
   padding: 7px 14px;
+  min-height: 40px;
   border-bottom: 1px solid var(--border);
   position: sticky;
-  top: 0;
+  top: -1px;
   background: var(--panel);
   z-index: 1;
 }

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -1089,3 +1089,37 @@ test('captures diffs screenshot (dark, deep-linked)', async ({ page }) => {
   await expect(page.locator('html.dark')).toBeAttached();
   await page.screenshot({ path: 'screenshots/konflate-diffs-dark.png' });
 });
+
+test('review chrome: rail Summary and section headers form one level bar (regression #163)', async ({ page }) => {
+  await stubApi(page);
+  await page.goto('/#/pr/142');
+  await page.locator('.res-header').first().waitFor();
+
+  // The rail's Summary node and the diff pane's summary header sit flush at
+  // the same top (no blank band above the Summary) and share one height, so
+  // their bottom borders form a single continuous line across the rail border.
+  const box = (sel: string) =>
+    page.locator(sel).first().evaluate((el) => {
+      const b = el.getBoundingClientRect();
+      return { top: b.top, bottom: b.bottom };
+    });
+  const tree = await box('.tree-summary');
+  const head = await box('.diff-section[data-sel="summary"] .res-header');
+  expect(Math.abs(tree.top - head.top)).toBeLessThanOrEqual(0.5);
+  expect(Math.abs(tree.bottom - head.bottom)).toBeLessThanOrEqual(0.5);
+
+  // A stuck section header must overlap the scrollport's top edge (top <= pane
+  // top) so fractional scroll offsets can't open a hairline of the content
+  // scrolling beneath it ("text inside the bar", issue #163).
+  await page.evaluate(() => {
+    const pane = document.querySelector('.diff-pane') as HTMLElement;
+    pane.scrollTop = 150.25; // inside the summary section's body
+  });
+  await page.waitForTimeout(100);
+  const stuck = await page.evaluate(() => {
+    const pane = document.querySelector('.diff-pane') as HTMLElement;
+    const h = document.querySelector('.diff-section[data-sel="summary"] .res-header')!;
+    return h.getBoundingClientRect().top - pane.getBoundingClientRect().top;
+  });
+  expect(stuck).toBeLessThanOrEqual(0);
+});


### PR DESCRIPTION
## Summary

Three review-screen chrome nits from #163, reproduced and pixel-verified with live Playwright measurements at `deviceScaleFactor: 2`.

**Blank space above Summary** — the tree rail had 6px top padding, so the Summary node floated below the review header while the diff pane's header sat flush. The tree now starts flush; the Summary node reads as the rail's header bar.

**Misalignment with the bar on the right** — the rail's Summary node (~34.5px), resource headers (~35px), and the Summary section header (~41.75px — stretched by the merge-command chip) were all different heights, so their bottom borders broke at the rail edge. All bars now share `min-height: 40px`, and the merge-command chip drops 1px of vertical padding so it fits inside the uniform bar. Measured before → after: tree row `108→142.5` / right header `102→143.75` became both exactly `102→142`.

**Text visible in the sticky bar while scrolling** — a stuck section header pinned at `top: 0` can land a subpixel below the scrollport edge under fractional scroll offsets (hi-dpi wheels, browser zoom), opening a hairline above it where the diff text scrolling beneath shows through. Pinned at `top: -1px`, the rounding happens inside a 1px overlap so the seam can never open (measured stuck position: exactly −1). The scrollspy is unaffected — it measures the `<section>` rects, not the header.

## Tests

- New regression test in `ui.spec.ts`: the rail Summary node and the summary section header share top and bottom within 0.5px, and a stuck header overlaps the scrollport edge (`top ≤ pane top`). **Fails pre-fix** (reports the 6px gap).
- `svelte-check` 0 errors; all 63 Playwright tests pass.

> Adversarially reviewed (finder over the diff + every consumer of the touched classes, 2 skeptics per finding): 4 candidates raised, all refuted against the actual code (scrollspy measures section rects; suite is Chromium-pinned; the summary section is never lazy-mounted; `top` is inert under the mobile `position: static` override).

Fixes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)