### PR TITLE
feat(lint): caution on immutable-field changes that wedge the apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ front.
    context), a navigation tree (`HelmRelease`/`Kustomization` → kind →
    resource), plus the review signals — **impact** (blast radius), **image
    changes**, **render failures**, and **danger lint** (data-loss, privilege,
-   RBAC, availability).
+   RBAC, availability, and immutable-field changes — a StatefulSet
+   `volumeClaimTemplates` bump, a workload selector edit, a PVC storage-class
+   swap or shrink, a `roleRef` change — that read like ordinary diffs but
+   wedge the apply with "field is immutable" until the resource is recreated).
 
     The **image changes** signal lists the `container` and `initContainer` image
     references that changed across _every rendered workload_ — so it captures

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	gitlab.com/gitlab-org/api/client-go/v2 v2.37.0
 	golang.org/x/sync v0.21.0
+	k8s.io/apimachinery v0.36.1
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -192,7 +193,6 @@ require (
 	helm.sh/helm/v4 v4.2.0 // indirect
 	k8s.io/api v0.36.1 // indirect
 	k8s.io/apiextensions-apiserver v0.36.1 // indirect
-	k8s.io/apimachinery v0.36.1 // indirect
 	k8s.io/apiserver v0.36.1 // indirect
 	k8s.io/cli-runtime v0.36.1 // indirect
 	k8s.io/client-go v0.36.1 // indirect

--- a/internal/diff/immutable.go
+++ b/internal/diff/immutable.go
@@ -1,0 +1,186 @@
+package diff
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/home-operations/konflate/internal/api"
+)
+
+// Immutable-field lint: a changed resource whose diff touches a field the API
+// server refuses to update looks like any other "~ changed" hunk in review,
+// but the apply will be rejected ("field is immutable" / "Forbidden: updates
+// to statefulset spec for fields other than …"), wedging the Flux
+// reconciliation until the object is recreated (or force is enabled on the
+// Kustomization/HelmRelease). These rules surface that before merge.
+//
+// The rule set is deliberately the short list of immutability wedges that
+// actually occur in GitOps repos — not a schema-complete validator:
+//
+//   - StatefulSet: everything in spec outside the API's mutable allowlist
+//     (replicas, ordinals, template, updateStrategy,
+//     persistentVolumeClaimRetentionPolicy, minReadySeconds). Catches the
+//     classic volumeClaimTemplates storage bump.
+//   - Deployment / DaemonSet / ReplicaSet: spec.selector.
+//   - Job: spec.selector and spec.template.
+//   - PersistentVolumeClaim: every spec field except the expand-only
+//     spec.resources and spec.volumeAttributesClassName — plus a dedicated
+//     rule for a storage request *decrease* (PVCs can only grow).
+//   - RoleBinding / ClusterRoleBinding: roleRef.
+//   - Service: spec.clusterIP, when both sides pin one (an unset side means
+//     the server allocated it, which never appears in a rendered diff).
+//
+// Kind / field names shared across the lint rules (goconst).
+const (
+	kindStatefulSet = "StatefulSet"
+	fieldTemplate   = "template"
+)
+
+func immutableFieldWarnings(c Change) []api.Warning {
+	// Only a changed resource can trip an immutable-field update; adds and
+	// removes never in-place-update anything.
+	if c.Old == nil || c.New == nil {
+		return nil
+	}
+
+	var fields []string
+	var out []api.Warning
+
+	switch c.Kind {
+	case kindStatefulSet:
+		fields = changedSpecKeysOutside(c, map[string]bool{
+			"replicas": true, "ordinals": true, fieldTemplate: true,
+			"updateStrategy": true, "persistentVolumeClaimRetentionPolicy": true,
+			"minReadySeconds": true,
+		})
+	case "Deployment", "DaemonSet", "ReplicaSet":
+		fields = changedFields(c, "selector")
+	case "Job":
+		fields = changedFields(c, "selector", fieldTemplate)
+	case "PersistentVolumeClaim":
+		fields = changedSpecKeysOutside(c, map[string]bool{
+			"resources": true, "volumeAttributesClassName": true,
+		})
+		if w, ok := pvcShrinkWarning(c); ok {
+			out = append(out, w)
+		}
+	case "RoleBinding", "ClusterRoleBinding":
+		if !jsonEqual(c.Old["roleRef"], c.New["roleRef"]) {
+			fields = []string{"roleRef"}
+		}
+	case "Service":
+		oldIP, _ := stringField(c.Old, "spec", "clusterIP")
+		newIP, _ := stringField(c.New, "spec", "clusterIP")
+		if oldIP != "" && newIP != "" && oldIP != newIP {
+			fields = []string{"spec.clusterIP"}
+		}
+	}
+
+	if len(fields) > 0 {
+		out = append(out, api.Warning{
+			Level:    api.LevelCaution,
+			Rule:     "immutable-field",
+			Resource: resourceLabel(c),
+			Detail: fmt.Sprintf("%s changed — immutable on %s; the apply fails until the resource is recreated (or Flux force is enabled)",
+				strings.Join(fields, ", "), c.Kind),
+		})
+	}
+	return out
+}
+
+// pvcShrinkWarning flags a PersistentVolumeClaim whose storage request got
+// smaller: expansion is the one mutation PVCs allow, and only upward — the API
+// server rejects a shrink outright. Values that don't parse as quantities are
+// ignored (better silent than a false caution on an exotic value).
+func pvcShrinkWarning(c Change) (api.Warning, bool) {
+	oldRaw, ok1 := stringField(c.Old, "spec", "resources", "requests", "storage")
+	newRaw, ok2 := stringField(c.New, "spec", "resources", "requests", "storage")
+	if !ok1 || !ok2 || oldRaw == newRaw {
+		return api.Warning{}, false
+	}
+	oldQ, err1 := resource.ParseQuantity(oldRaw)
+	newQ, err2 := resource.ParseQuantity(newRaw)
+	if err1 != nil || err2 != nil || newQ.Cmp(oldQ) >= 0 {
+		return api.Warning{}, false
+	}
+	return api.Warning{
+		Level:    api.LevelCaution,
+		Rule:     "pvc-shrink",
+		Resource: resourceLabel(c),
+		Detail: fmt.Sprintf("storage request decreased %s → %s — PersistentVolumeClaims can only grow; the apply will be rejected",
+			oldRaw, newRaw),
+	}, true
+}
+
+// changedSpecKeysOutside returns "spec.<key>" for every top-level spec key —
+// across both sides — whose value differs and is not in the mutable allowlist.
+// Sorted, so a multi-field caution reads deterministically.
+func changedSpecKeysOutside(c Change, mutable map[string]bool) []string {
+	oldSpec, _ := nestedMap(c.Old, "spec")
+	newSpec, _ := nestedMap(c.New, "spec")
+	keys := make(map[string]struct{}, len(oldSpec)+len(newSpec))
+	for k := range oldSpec {
+		keys[k] = struct{}{}
+	}
+	for k := range newSpec {
+		keys[k] = struct{}{}
+	}
+	var out []string
+	for k := range keys {
+		if mutable[k] || jsonEqual(oldSpec[k], newSpec[k]) {
+			continue
+		}
+		out = append(out, "spec."+k)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// changedFields returns "spec.<key>" for each named spec key whose value
+// differs between the two sides, in the given order.
+func changedFields(c Change, keys ...string) []string {
+	var out []string
+	for _, k := range keys {
+		oldV, _ := nestedMap(c.Old, "spec")
+		newV, _ := nestedMap(c.New, "spec")
+		if !jsonEqual(oldV[k], newV[k]) {
+			out = append(out, "spec."+k)
+		}
+	}
+	return out
+}
+
+// jsonEqual compares two decoded YAML/JSON values through their canonical JSON
+// encoding. reflect.DeepEqual would read int64(3) and float64(3) — the same
+// manifest value decoded via different paths — as a difference; the JSON
+// round-trip collapses that numeric skew (and map ordering is keyed, so
+// marshaling is deterministic).
+func jsonEqual(a, b any) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	ab, errA := json.Marshal(a)
+	bb, errB := json.Marshal(b)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return string(ab) == string(bb)
+}
+
+// stringField reads a string at the given path (false when missing or not a
+// string).
+func stringField(m map[string]any, keys ...string) (string, bool) {
+	if len(keys) == 0 {
+		return "", false
+	}
+	parent, ok := nestedMap(m, keys[:len(keys)-1]...)
+	if !ok {
+		return "", false
+	}
+	s, ok := parent[keys[len(keys)-1]].(string)
+	return s, ok
+}

--- a/internal/diff/immutable_test.go
+++ b/internal/diff/immutable_test.go
@@ -1,0 +1,211 @@
+package diff
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/home-operations/konflate/internal/api"
+)
+
+// changed builds a "changed" Change for kind with the given old/new spec maps
+// (wrapped under "spec" — pass extra top-level fields via top).
+func changed(kind string, oldSpec, newSpec map[string]any) Change {
+	return Change{
+		Status: "changed", Kind: kind, Namespace: "default", Name: "x",
+		Old: map[string]any{"spec": oldSpec},
+		New: map[string]any{"spec": newSpec},
+	}
+}
+
+func lintOne(c Change) []api.Warning { return Lint([]Change{c}, nil) }
+
+func TestImmutable_StatefulSetSpecOutsideAllowlist(t *testing.T) {
+	t.Parallel()
+
+	// The classic wedge: a volumeClaimTemplates storage bump.
+	vct := func(size string) []any {
+		return []any{map[string]any{
+			"metadata": map[string]any{"name": "data"},
+			"spec": map[string]any{
+				"resources": map[string]any{"requests": map[string]any{"storage": size}},
+			},
+		}}
+	}
+	ws := lintOne(changed("StatefulSet",
+		map[string]any{"serviceName": "db", "volumeClaimTemplates": vct("10Gi")},
+		map[string]any{"serviceName": "db", "volumeClaimTemplates": vct("20Gi")},
+	))
+	n, w := countRule(ws, "immutable-field")
+	if n != 1 {
+		t.Fatalf("immutable-field warnings = %d, want 1: %+v", n, ws)
+	}
+	if !strings.Contains(w.Detail, "spec.volumeClaimTemplates") || !strings.Contains(w.Detail, "StatefulSet") {
+		t.Errorf("detail should name the field and kind, got %q", w.Detail)
+	}
+
+	// Several immutable fields at once: one caution, fields sorted.
+	ws = lintOne(changed("StatefulSet",
+		map[string]any{"serviceName": "a", "podManagementPolicy": "OrderedReady"},
+		map[string]any{"serviceName": "b", "podManagementPolicy": "Parallel"},
+	))
+	if n, w := countRule(ws, "immutable-field"); n != 1 || !strings.HasPrefix(w.Detail, "spec.podManagementPolicy, spec.serviceName changed") {
+		t.Errorf("want one caution listing both fields sorted, got %d: %q", n, w.Detail)
+	}
+}
+
+func TestImmutable_StatefulSetMutableFieldsAreQuiet(t *testing.T) {
+	t.Parallel()
+	// Everything the API allows updating must not trip the rule.
+	ws := lintOne(changed("StatefulSet",
+		map[string]any{
+			"replicas": 1, "minReadySeconds": 0,
+			"template":                             map[string]any{"spec": map[string]any{"x": "a"}},
+			"updateStrategy":                       map[string]any{"type": "RollingUpdate"},
+			"persistentVolumeClaimRetentionPolicy": map[string]any{"whenDeleted": "Retain"},
+			"ordinals":                             map[string]any{"start": 0},
+		},
+		map[string]any{
+			"replicas": 3, "minReadySeconds": 10,
+			"template":                             map[string]any{"spec": map[string]any{"x": "b"}},
+			"updateStrategy":                       map[string]any{"type": "OnDelete"},
+			"persistentVolumeClaimRetentionPolicy": map[string]any{"whenDeleted": "Delete"},
+			"ordinals":                             map[string]any{"start": 1},
+		},
+	))
+	if hasRule(ws, "immutable-field") {
+		t.Errorf("mutable StatefulSet fields flagged: %+v", ws)
+	}
+}
+
+func TestImmutable_SelectorOnWorkloads(t *testing.T) {
+	t.Parallel()
+	sel := func(v string) map[string]any {
+		return map[string]any{"matchLabels": map[string]any{"app": v}}
+	}
+	for _, kind := range []string{"Deployment", "DaemonSet", "ReplicaSet", "Job"} {
+		ws := lintOne(changed(kind, map[string]any{"selector": sel("a")}, map[string]any{"selector": sel("b")}))
+		if n, w := countRule(ws, "immutable-field"); n != 1 || !strings.Contains(w.Detail, "spec.selector") {
+			t.Errorf("%s selector change: want 1 immutable-field naming spec.selector, got %d (%q)", kind, n, w.Detail)
+		}
+		// A template change on a Deployment is everyday business.
+		if kind == "Deployment" {
+			ws := lintOne(changed(kind,
+				map[string]any{"selector": sel("a"), "template": map[string]any{"spec": map[string]any{"img": "1"}}},
+				map[string]any{"selector": sel("a"), "template": map[string]any{"spec": map[string]any{"img": "2"}}},
+			))
+			if hasRule(ws, "immutable-field") {
+				t.Errorf("Deployment template change flagged: %+v", ws)
+			}
+		}
+	}
+
+	// Job templates are immutable, unlike every other workload's.
+	ws := lintOne(changed("Job",
+		map[string]any{"template": map[string]any{"spec": map[string]any{"img": "1"}}},
+		map[string]any{"template": map[string]any{"spec": map[string]any{"img": "2"}}},
+	))
+	if n, w := countRule(ws, "immutable-field"); n != 1 || !strings.Contains(w.Detail, "spec.template") {
+		t.Errorf("Job template change: want immutable-field naming spec.template, got %d (%q)", n, w.Detail)
+	}
+}
+
+func TestImmutable_NumericTypeSkewIsNotAChange(t *testing.T) {
+	t.Parallel()
+	// int vs float64 for the same value — two YAML decode paths — must compare
+	// equal, not read as an immutable-field change.
+	ws := lintOne(changed("Deployment",
+		map[string]any{"selector": map[string]any{"matchLabels": map[string]any{"n": int64(3)}}},
+		map[string]any{"selector": map[string]any{"matchLabels": map[string]any{"n": float64(3)}}},
+	))
+	if hasRule(ws, "immutable-field") {
+		t.Errorf("numeric type skew flagged as a change: %+v", ws)
+	}
+}
+
+func TestImmutable_PVCFieldsAndShrink(t *testing.T) {
+	t.Parallel()
+	pvc := func(class, size string) map[string]any {
+		return map[string]any{
+			"storageClassName": class,
+			"resources":        map[string]any{"requests": map[string]any{"storage": size}},
+		}
+	}
+
+	// Storage class swap: immutable.
+	ws := lintOne(changed("PersistentVolumeClaim", pvc("fast", "10Gi"), pvc("slow", "10Gi")))
+	if n, w := countRule(ws, "immutable-field"); n != 1 || !strings.Contains(w.Detail, "spec.storageClassName") {
+		t.Errorf("storageClassName change: want immutable-field, got %d (%q)", n, w.Detail)
+	}
+
+	// Expansion is the allowed mutation: no caution either way.
+	ws = lintOne(changed("PersistentVolumeClaim", pvc("fast", "10Gi"), pvc("fast", "20Gi")))
+	if hasRule(ws, "immutable-field") || hasRule(ws, "pvc-shrink") {
+		t.Errorf("PVC expansion flagged: %+v", ws)
+	}
+
+	// A shrink is rejected by the API server.
+	ws = lintOne(changed("PersistentVolumeClaim", pvc("fast", "20Gi"), pvc("fast", "10Gi")))
+	if n, w := countRule(ws, "pvc-shrink"); n != 1 || !strings.Contains(w.Detail, "20Gi → 10Gi") {
+		t.Errorf("PVC shrink: want pvc-shrink with values, got %d (%q)", n, w.Detail)
+	}
+
+	// Unit-aware: 1Gi → 1024Mi is the same size, not a shrink (and not growth).
+	ws = lintOne(changed("PersistentVolumeClaim", pvc("fast", "1Gi"), pvc("fast", "1024Mi")))
+	if hasRule(ws, "pvc-shrink") {
+		t.Errorf("equal quantities in different units flagged as shrink: %+v", ws)
+	}
+
+	// Unparseable quantities stay silent rather than guessing.
+	ws = lintOne(changed("PersistentVolumeClaim", pvc("fast", "lots"), pvc("fast", "few")))
+	if hasRule(ws, "pvc-shrink") {
+		t.Errorf("unparseable quantities flagged: %+v", ws)
+	}
+}
+
+func TestImmutable_RoleRefAndClusterIP(t *testing.T) {
+	t.Parallel()
+	roleRef := func(name string) map[string]any {
+		return map[string]any{"apiGroup": "rbac.authorization.k8s.io", "kind": "ClusterRole", "name": name}
+	}
+	for _, kind := range []string{"RoleBinding", "ClusterRoleBinding"} {
+		c := Change{
+			Status: "changed", Kind: kind, Name: "x",
+			Old: map[string]any{"roleRef": roleRef("view"), "subjects": []any{"a"}},
+			New: map[string]any{"roleRef": roleRef("edit"), "subjects": []any{"a"}},
+		}
+		if n, w := countRule(lintOne(c), "immutable-field"); n != 1 || !strings.Contains(w.Detail, "roleRef") {
+			t.Errorf("%s roleRef change: want immutable-field, got %d (%q)", kind, n, w.Detail)
+		}
+		// Subjects are mutable.
+		c.New = map[string]any{"roleRef": roleRef("view"), "subjects": []any{"b"}}
+		if hasRule(lintOne(c), "immutable-field") {
+			t.Errorf("%s subjects change flagged", kind)
+		}
+	}
+
+	// Service clusterIP: flagged only when both sides pin one.
+	ws := lintOne(changed("Service",
+		map[string]any{"clusterIP": "10.0.0.1"}, map[string]any{"clusterIP": "10.0.0.2"}))
+	if n, w := countRule(ws, "immutable-field"); n != 1 || !strings.Contains(w.Detail, "spec.clusterIP") {
+		t.Errorf("clusterIP change: want immutable-field, got %d (%q)", n, w.Detail)
+	}
+	ws = lintOne(changed("Service", map[string]any{}, map[string]any{"clusterIP": "10.0.0.2"}))
+	if hasRule(ws, "immutable-field") {
+		t.Errorf("newly-pinned clusterIP (old side server-allocated) flagged: %+v", ws)
+	}
+}
+
+func TestImmutable_AddsAndRemovesAreQuiet(t *testing.T) {
+	t.Parallel()
+	// Adds and removes never in-place-update anything — no immutable warnings,
+	// whatever the manifests contain.
+	spec := map[string]any{"spec": map[string]any{"serviceName": "db"}}
+	for _, c := range []Change{
+		{Status: "added", Kind: "StatefulSet", Name: "x", New: spec},
+		{Status: "removed", Kind: "StatefulSet", Name: "x", Old: spec},
+	} {
+		if hasRule(lintOne(c), "immutable-field") {
+			t.Errorf("%s resource produced an immutable-field warning", c.Status)
+		}
+	}
+}

--- a/internal/diff/lint.go
+++ b/internal/diff/lint.go
@@ -49,7 +49,7 @@ func Lint(changes []Change, images []api.ImageChange) []api.Warning {
 	for _, c := range changes {
 		if c.Status == statusRemoved {
 			switch c.Kind {
-			case "StatefulSet":
+			case kindStatefulSet:
 				add("removed-statefulset", "removed StatefulSet — its PersistentVolumeClaims and data may be deleted", c)
 			case "PersistentVolumeClaim":
 				add("removed-pvc", "removed PersistentVolumeClaim — the bound volume's data may be reclaimed", c)
@@ -77,6 +77,10 @@ func Lint(changes []Change, images []api.ImageChange) []api.Warning {
 		if c.Status == statusAdded && c.Kind == "ClusterRoleBinding" {
 			add("rbac-widened", "new ClusterRoleBinding — grants cluster-wide permissions", c)
 		}
+
+		// Immutable-field rules: a changed resource whose diff touches a field
+		// the API server refuses to update in place (see immutable.go).
+		warnings = append(warnings, immutableFieldWarnings(c)...)
 	}
 
 	// Blast-radius / version signals: an unusually large change set, and major
@@ -216,7 +220,7 @@ func resourceLabel(c Change) string {
 // isWorkload reports whether kind carries a replica count worth flagging.
 func isWorkload(kind string) bool {
 	switch kind {
-	case "Deployment", "StatefulSet", "ReplicaSet", "ReplicationController":
+	case "Deployment", kindStatefulSet, "ReplicaSet", "ReplicationController":
 		return true
 	default:
 		return false
@@ -270,8 +274,8 @@ func hasPrivilegedContainer(m map[string]any) bool {
 	const spec = "spec"
 	for _, base := range [][]string{
 		{spec},
-		{spec, "template", spec},
-		{spec, "jobTemplate", spec, "template", spec},
+		{spec, fieldTemplate, spec},
+		{spec, "jobTemplate", spec, fieldTemplate, spec},
 	} {
 		podSpec, ok := nestedMap(m, base...)
 		if !ok {


### PR DESCRIPTION
## Summary

A changed resource whose diff touches a field the API server refuses to update in place reads like any other `~ changed` hunk in review — but the apply gets rejected (`field is immutable`, or the StatefulSet forbidden-fields error), wedging Flux reconciliation until the object is recreated (or `force` is enabled on the Kustomization/HelmRelease). These changes are exactly the ones a reviewer most needs to catch before merge, and today nothing distinguishes them.

## New lint rules

**`immutable-field`** — one caution per resource, naming the offending field(s):

| Kind | Flagged |
|---|---|
| StatefulSet | any `spec` change outside the API's mutable allowlist (`replicas`, `ordinals`, `template`, `updateStrategy`, `persistentVolumeClaimRetentionPolicy`, `minReadySeconds`) — catches the classic `volumeClaimTemplates` storage bump, plus `serviceName`, `podManagementPolicy`, `selector` |
| Deployment / DaemonSet / ReplicaSet | `spec.selector` |
| Job | `spec.selector`, `spec.template` |
| PersistentVolumeClaim | every `spec` field except the expand-only `resources` and `volumeAttributesClassName` (storage-class swap, accessModes, volumeMode, …) |
| RoleBinding / ClusterRoleBinding | `roleRef` |
| Service | `spec.clusterIP`, only when **both** sides pin one (an unset side is server-allocated and never appears in a rendered diff) |

**`pvc-shrink`** — a PVC storage request that got *smaller*: expansion is the one mutation PVCs allow, and only upward. Quantity-aware via apimachinery (`1Gi → 1024Mi` is not a shrink); unparseable values stay silent rather than guessing.

## Notes

- Field comparison goes through canonical JSON, so the `int` vs `float64` skew two YAML decode paths can produce never reads as a change (regression-tested).
- Adds and removes are exempt by construction — nothing is updated in place.
- Deliberately a short list of the immutability wedges that actually occur in GitOps repos, not a schema-complete validator.
- No UI changes needed — cautions render through the existing warning surfaces (overview, list preview, summary endpoint/markdown, signal badges).
- `k8s.io/apimachinery` promoted indirect → direct (already in the module graph via flate).

## Tests

Seven table/behavior tests covering: the VCT bump, multi-field sorting, the full StatefulSet mutable allowlist staying quiet, selector vs template semantics per workload kind, numeric-type-skew immunity, PVC class swap / expansion / shrink / equal-units / unparseable, roleRef vs subjects, clusterIP both-pinned gating, and add/remove exemption. `go test ./...` green; `golangci-lint run` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)