### PR TITLE
feat(ui): find-in-diff search ('/' on the review)

### DIFF
--- a/internal/web/src/App.svelte
+++ b/internal/web/src/App.svelte
@@ -140,7 +140,7 @@
           <dt><kbd>u</kbd> or <kbd>Esc</kbd></dt>
           <dd>back to the list</dd>
           <dt><kbd>/</kbd></dt>
-          <dd>filter the list</dd>
+          <dd>filter the list · find in the diff</dd>
           <dt><kbd>Ctrl</kbd>/<kbd>⌘</kbd> <kbd>k</kbd></dt>
           <dd>search pull requests</dd>
           <dt><kbd>?</kbd></dt>

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -1290,7 +1290,9 @@ button.sum-pill:hover {
   min-height: 0;
 }
 .diff-main {
-  /* Column wrapper so the mobile switcher bar can sit above the scrolling pane. */
+  /* Column wrapper so the mobile switcher bar can sit above the scrolling pane.
+     position: relative anchors the floating find-in-diff bar (.diff-search). */
+  position: relative;
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -1472,6 +1474,53 @@ button.sum-pill:hover {
 }
 .leaf-counts .del {
   margin-left: 4px;
+}
+
+/* Floating find-in-diff bar ('/'): overlays the top-right of the diff pane,
+   above the sticky section headers. Searches the diff data, so lazy-mounted
+   sections the browser's Ctrl+F can't see are still found. */
+.diff-search {
+  position: absolute;
+  top: 8px;
+  right: 16px;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 4px 14px rgb(0 0 0 / 0.25);
+  color: var(--muted);
+}
+.diff-search input {
+  width: 200px;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+}
+.search-count {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+/* The jumped-to row: a brief accent flash so the eye lands on the hit. The
+   class is added by search.svelte.ts and removed after the animation. */
+tr.search-hit > td {
+  animation: search-hit-flash 1.6s ease-out;
+}
+@keyframes search-hit-flash {
+  0%,
+  60% {
+    background-color: color-mix(in srgb, var(--accent) 22%, transparent);
+  }
+  100% {
+    background-color: transparent;
+  }
 }
 
 /* ---- diff view ------------------------------------------------------- */

--- a/internal/web/src/lib/Diff.svelte
+++ b/internal/web/src/lib/Diff.svelte
@@ -131,7 +131,9 @@
                 </tr>
               {/if}
             {:else}
-              <tr class="row-{row.kind ?? 'ctx'}">
+              <!-- data-old/data-new let the diff search (search.svelte.ts)
+                   locate a hit's row in whichever view mode is mounted. -->
+              <tr class="row-{row.kind ?? 'ctx'}" data-old={row.oldNo} data-new={row.newNo}>
                 <td class="gutter num">{row.oldNo || ''}</td>
                 <td class="gutter num">{row.newNo || ''}</td>
                 <td class="gutter sign">{row.kind === 'add' ? '+' : row.kind === 'del' ? '-' : ''}</td>
@@ -174,7 +176,7 @@
                 </tr>
               {/if}
             {:else}
-              <tr>
+              <tr data-old={row.left.no} data-new={row.right.no}>
                 <td class="gutter num">{row.left.no || ''}</td>
                 <td class="code {cellClass(row.left)}"
                   >{#if row.left.kind !== 'blank'}{@html row.left.html ?? ''}{/if}</td

--- a/internal/web/src/lib/DiffSearch.svelte
+++ b/internal/web/src/lib/DiffSearch.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  // The floating find-in-diff bar (opened with '/' on the review screen — see
+  // keyboard.svelte.ts). Searches the diff data rather than the DOM, so
+  // lazy-mounted sections that defeat the browser's Ctrl+F are still found;
+  // Enter / Shift+Enter (or the arrows) step through hits and jump.
+  import Icon from './Icon.svelte';
+  import { search, setQuery, step, closeSearch } from './search.svelte';
+  import { mdiChevronDown, mdiChevronUp, mdiClose, mdiMagnify } from './icons';
+
+  function onKeydown(e: KeyboardEvent): void {
+    switch (e.key) {
+      case 'Enter':
+        step(e.shiftKey ? -1 : 1);
+        break;
+      case 'Escape':
+        closeSearch();
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  // Autofocus the input when the bar mounts ({#if search.open} in Diffs).
+  function focusOnMount(node: HTMLInputElement) {
+    node.focus();
+  }
+
+  const counter = $derived(
+    search.hits.length === 0
+      ? search.q.trim().length >= 2
+        ? 'no hits'
+        : ''
+      : search.cur >= 0
+        ? `${search.cur + 1}/${search.hits.length}`
+        : `${search.hits.length} ${search.hits.length === 1 ? 'hit' : 'hits'}`,
+  );
+</script>
+
+<div class="diff-search" role="search" aria-label="Find in diff">
+  <Icon path={mdiMagnify} size={14} />
+  <input
+    type="text"
+    placeholder="Find in diff…"
+    value={search.q}
+    oninput={(e) => setQuery(e.currentTarget.value)}
+    onkeydown={onKeydown}
+    use:focusOnMount
+    aria-label="Find in diff"
+  />
+  <span class="search-count" aria-live="polite">{counter}</span>
+  <button
+    class="btn btn-icon"
+    onclick={() => step(-1)}
+    disabled={search.hits.length === 0}
+    title="Previous hit (Shift+Enter)"
+    aria-label="Previous hit"
+  >
+    <Icon path={mdiChevronUp} size={14} />
+  </button>
+  <button
+    class="btn btn-icon"
+    onclick={() => step(1)}
+    disabled={search.hits.length === 0}
+    title="Next hit (Enter)"
+    aria-label="Next hit"
+  >
+    <Icon path={mdiChevronDown} size={14} />
+  </button>
+  <button class="btn btn-icon" onclick={closeSearch} title="Close (Esc)" aria-label="Close search">
+    <Icon path={mdiClose} size={14} />
+  </button>
+</div>

--- a/internal/web/src/lib/Diffs.svelte
+++ b/internal/web/src/lib/Diffs.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { router, replace } from './router.svelte';
   import { store, adjacentResource, selectables } from './store.svelte';
+  import { search, closeSearch } from './search.svelte';
+  import DiffSearch from './DiffSearch.svelte';
   import Tree from './Tree.svelte';
   import Diff from './Diff.svelte';
   import Overview from './Overview.svelte';
@@ -179,6 +181,10 @@
     };
   });
 
+  // Close the search when the review unmounts (back to the list, or the next
+  // PR remounting Diffs) so a stale query never carries across.
+  $effect(() => closeSearch);
+
   // Action on each resource <section>: register it (so an observer rebuild can
   // re-observe it) and observe it now if the observer already exists.
   function lazy(node: HTMLElement) {
@@ -196,6 +202,9 @@
 <div class="diffs">
   <aside class="rail"><Tree /></aside>
   <div class="diff-main">
+    {#if search.open}
+      <DiffSearch />
+    {/if}
     <!-- The tree rail is hidden on narrow screens; this bar is the navigator
          there, jumping between Summary + every resource. On mobile it's the one
          bar pinned while the header + diff scroll past (see CSS / scroller). -->

--- a/internal/web/src/lib/keyboard.svelte.ts
+++ b/internal/web/src/lib/keyboard.svelte.ts
@@ -2,6 +2,7 @@
 // modifier keys, so it never fights the browser or the filter box.
 import { router } from './router.svelte';
 import { adjacentPR, adjacentResource, goList, openSel } from './store.svelte';
+import { search, openSearch, closeSearch } from './search.svelte';
 
 // Two overlays: the shortcuts help (toggled by '?' or the topbar button) and the
 // command palette (Cmd/Ctrl+K). They are mutually exclusive, and opening either
@@ -77,6 +78,20 @@ export function initKeyboard(): void {
         document.querySelector<HTMLInputElement>('.pr-search')?.focus();
         e.preventDefault();
       }
+      return;
+    }
+
+    // On the review, '/' opens the find-in-diff bar (the lazy-mounted tables
+    // defeat the browser's own Ctrl+F); Escape closes it before falling back
+    // to "leave the review".
+    if (e.key === '/') {
+      openSearch();
+      e.preventDefault();
+      return;
+    }
+    if (search.open && e.key === 'Escape') {
+      closeSearch();
+      e.preventDefault();
       return;
     }
 

--- a/internal/web/src/lib/search.svelte.ts
+++ b/internal/web/src/lib/search.svelte.ts
@@ -1,0 +1,110 @@
+// In-review diff search. The diff tables are lazy-mounted (only sections near
+// the viewport hold a real <table>) and content-visibility skips off-screen
+// rendering, so the browser's Ctrl+F cannot find text in sections you haven't
+// scrolled to. This searches the diff *data* instead — every resource's rows,
+// mounted or not — and jumps to the match: navigating to the resource mounts
+// its table, then the matching row is scrolled into view and flashed.
+import { router } from './router.svelte';
+import { store, openSel } from './store.svelte';
+
+// One searchable diff line: the resource it lives in plus the line numbers the
+// rendered rows carry as data attributes (data-old / data-new in both the
+// unified and split tables), so a hit can be located in whichever view mode is
+// active.
+interface Entry {
+  res: string;
+  oldNo?: number;
+  newNo?: number;
+  text: string;
+}
+
+export const search = $state({
+  open: false,
+  q: '',
+  hits: [] as Entry[],
+  // cur indexes hits once a jump happened; -1 = typed but not yet stepped.
+  cur: -1,
+});
+
+// The flat text index, rebuilt only when the diff identity changes. Folded
+// context rows are skipped — they are collapsed unchanged lines; the diff's
+// own add/del/ctx rows are what review search is for.
+let index: Entry[] = [];
+let indexKey = '';
+
+function buildIndex(): void {
+  const d = store.diff;
+  const key = d ? `${d.prNumber}@${d.headSha}` : '';
+  if (key === indexKey) return;
+  indexKey = key;
+  index = [];
+  const parser = new DOMParser();
+  for (const res of d?.resources ?? []) {
+    for (const row of res.unified) {
+      if (row.hunk || row.folded || !row.html) continue;
+      const text = parser.parseFromString(row.html, 'text/html').body.textContent ?? '';
+      if (text.trim() === '') continue;
+      index.push({ res: res.id, oldNo: row.oldNo, newNo: row.newNo, text });
+    }
+  }
+}
+
+export function openSearch(): void {
+  buildIndex();
+  search.open = true;
+}
+
+export function closeSearch(): void {
+  search.open = false;
+  search.q = '';
+  search.hits = [];
+  search.cur = -1;
+}
+
+// setQuery recomputes the hit list live (the bar shows the count); stepping is
+// what jumps. Sub-2-char queries match nothing — one letter hits every line.
+export function setQuery(q: string): void {
+  search.q = q;
+  search.cur = -1;
+  const needle = q.trim().toLowerCase();
+  if (needle.length < 2) {
+    search.hits = [];
+    return;
+  }
+  search.hits = index.filter((e) => e.text.toLowerCase().includes(needle));
+}
+
+// step advances through the hits (dir ±1) and jumps to the new current one.
+// The first step after a query lands on the first hit.
+export function step(dir: 1 | -1): void {
+  const n = search.hits.length;
+  if (n === 0) return;
+  search.cur = search.cur < 0 ? (dir === 1 ? 0 : n - 1) : (search.cur + dir + n) % n;
+  jumpTo(search.hits[search.cur]);
+}
+
+// jumpTo navigates to the hit's resource section (the existing navigation
+// mounts the lazy table and scrolls the section in), then locates the matching
+// row by its line-number data attributes — retrying across frames because the
+// table mounts a tick after the route changes — and centres + flashes it.
+function jumpTo(hit: Entry): void {
+  const r = router.route;
+  if (r.name !== 'review') return;
+  openSel(r.pr, hit.res);
+
+  const selector =
+    `[data-sel="${CSS.escape(hit.res)}"] ` +
+    (hit.newNo ? `tr[data-new="${hit.newNo}"]` : `tr[data-old="${hit.oldNo}"]`);
+  const deadline = performance.now() + 1500;
+  const locate = (): void => {
+    const row = document.querySelector<HTMLElement>(selector);
+    if (!row) {
+      if (performance.now() < deadline) requestAnimationFrame(locate);
+      return;
+    }
+    row.scrollIntoView({ block: 'center' });
+    row.classList.add('search-hit');
+    setTimeout(() => row.classList.remove('search-hit'), 1600);
+  };
+  requestAnimationFrame(locate);
+}

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -1135,3 +1135,46 @@ test('review chrome: rail Summary and section headers form one level bar (regres
   });
   expect(stuck).toBeLessThanOrEqual(0);
 });
+
+test("'/' finds text across lazy-mounted diff sections and jumps to hits", async ({ page }) => {
+  await stubApi(page);
+  await page.goto('/#/pr/142');
+  await page.locator('.res-header').first().waitFor();
+
+  // '/' opens the find bar with the input focused.
+  await page.keyboard.press('/');
+  const bar = page.locator('.diff-search');
+  await expect(bar).toBeVisible();
+  await expect(bar.locator('input')).toBeFocused();
+
+  // Typing computes the hit count live (searching the diff DATA — the browser's
+  // Ctrl+F can't see lazy-mounted sections) without jumping yet.
+  await bar.locator('input').fill('apiVersion');
+  await expect(bar.locator('.search-count')).toHaveText('2 hits');
+  await expect(page).toHaveURL(/#\/pr\/142$/);
+
+  // Enter steps through the hits, navigating to each hit's resource and
+  // flashing the matched row.
+  await page.keyboard.press('Enter');
+  await expect(page).toHaveURL(/#\/pr\/142\/r0$/);
+  await expect(bar.locator('.search-count')).toHaveText('1/2');
+  await expect(page.locator('[data-sel="r0"] tr.search-hit')).toBeVisible();
+  await page.keyboard.press('Enter');
+  await expect(page).toHaveURL(/#\/pr\/142\/r1$/);
+  await expect(bar.locator('.search-count')).toHaveText('2/2');
+
+  // A term that lives only in the LAST resource's diff still hits and jumps —
+  // the whole point versus Ctrl+F.
+  await bar.locator('input').fill('statefulset');
+  await expect(bar.locator('.search-count')).toHaveText('1 hit');
+  await page.keyboard.press('Enter');
+  await expect(page).toHaveURL(/#\/pr\/142\/r2$/);
+  await expect(page.locator('[data-sel="r2"] tr.search-hit')).toBeVisible();
+
+  // Escape closes the bar; a second Escape (outside the input) leaves the
+  // review as before.
+  await page.keyboard.press('Escape');
+  await expect(bar).toHaveCount(0);
+  await page.keyboard.press('Escape');
+  await expect(page).toHaveURL(/#\/$|\/$/);
+});


### PR DESCRIPTION
## Summary

The diff tables are lazy-mounted (only sections near the viewport hold a real `<table>`) and `content-visibility` skips off-screen rendering — which means the browser's **Ctrl+F can't find text in sections you haven't scrolled to**. The better the lazy-mount performs, the less searchable the review gets.

This adds an in-app find that searches the diff **data** instead of the DOM, so every resource's rows are searchable whether mounted or not.

## How it works

- **`/`** on the review opens a floating find bar (top-right of the diff pane, autofocused). Typing shows a live hit count across all resources; nothing jumps while you type.
- **Enter / Shift+Enter** (or the bar's arrows) step through hits with an `n/m` counter. Each jump navigates to the hit's resource — the existing navigation mounts the lazy table — then locates the exact row via new `data-old`/`data-new` line-number attributes (carried by **both** the unified and split tables, so jumps land in either view mode), centres it, and flashes it with an accent wash.
- **Escape** closes the bar; a second Escape leaves the review as before. `/` on the list still focuses the filter (unchanged); the shortcuts help now reads "filter the list · find in the diff".
- The text index is built once per diff identity (PR + head SHA) by stripping the server-rendered row HTML through `DOMParser` (inert document — nothing executes or fetches). Folded context rows (collapsed unchanged lines) are skipped; sub-2-character queries match nothing.

## Tests

One end-to-end spec covers: open + autofocus, live count without jumping, stepping across resources (URL, flashed row, `1/2 → 2/2` counter), a term that lives **only in the last resource's diff** (the case Ctrl+F loses), and the Escape close-then-leave ladder. `svelte-check` 0 errors; all 64 Playwright tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)