### PR TITLE
feat(lint): Flux-semantic cautions — suspend awareness and prune semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ front.
    `volumeClaimTemplates` bump, a workload selector edit, a PVC storage-class
    swap or shrink, a `roleRef` change — that read like ordinary diffs but
    wedge the apply with "field is immutable" until the resource is recreated).
+   The lint also reasons about what **Flux will actually do** on merge:
+   changes under a suspended Kustomization/HelmRelease (they won't roll out),
+   a PR flipping `spec.suspend` (resuming applies everything accumulated while
+   parked, at once), and removal semantics under `prune` — a pruning
+   Kustomization really deletes the resource in-cluster, a non-pruning one
+   orphans it, silently left running.
 
     The **image changes** signal lists the `container` and `initContainer` image
     references that changed across _every rendered workload_ — so it captures

--- a/internal/diff/flux.go
+++ b/internal/diff/flux.go
@@ -1,0 +1,171 @@
+package diff
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/home-operations/konflate/internal/api"
+)
+
+// Flux-semantic lint: the rules in this file reason about what Flux will
+// actually do with a change on merge, not just what the change contains.
+// They consume two inputs the generic rules don't have:
+//
+//   - The producing parent's own spec (ParentInfo, looked up by the engine
+//     from the full rendered manifest sets): whether the Kustomization /
+//     HelmRelease is suspended post-merge, and whether a Kustomization
+//     prunes. A diff under a suspended parent won't roll out at all; a
+//     removal under prune: false won't be deleted in-cluster.
+//   - The parent docs themselves when the PR changes them: flipping
+//     spec.suspend freezes or (scarier) unfreezes reconciliation.
+
+// ParentInfo carries the Flux-semantic bits of one producing Kustomization /
+// HelmRelease, keyed in Lint's parents map by the same "Kind ns/name" label
+// Change.Parent uses. The engine looks the doc up in the rendered manifest
+// sets — head side first (the post-merge truth), base side when the PR
+// removes the parent itself. Found=false (the zero value) means the parent
+// doc wasn't located; every rule below then stays quiet rather than guessing.
+type ParentInfo struct {
+	Found           bool
+	IsKustomization bool
+	Suspended       bool // spec.suspend (absent = false)
+	Prune           bool // spec.prune, Kustomizations only (absent = false)
+}
+
+// fluxKind reports whether the change is a Flux Kustomization / HelmRelease
+// document itself (guarded by API group — a non-Flux CRD that happens to be
+// called "Kustomization" must not trip the suspend rules).
+func fluxKind(c Change) bool {
+	if c.Kind != "Kustomization" && c.Kind != "HelmRelease" {
+		return false
+	}
+	for _, m := range []map[string]any{c.New, c.Old} {
+		if m == nil {
+			continue
+		}
+		if v, ok := m["apiVersion"].(string); ok {
+			return strings.Contains(v, "toolkit.fluxcd.io")
+		}
+	}
+	return false
+}
+
+// suspendToggleWarnings flags a PR flipping spec.suspend on a Kustomization /
+// HelmRelease. Suspending freezes reconciliation; resuming is the sharper
+// edge — everything that accumulated while suspended applies at once.
+func suspendToggleWarnings(c Change) []api.Warning {
+	if c.Status != "changed" || !fluxKind(c) {
+		return nil
+	}
+	oldSusp := boolField(c.Old, "spec", "suspend")
+	newSusp := boolField(c.New, "spec", "suspend")
+	switch {
+	case !oldSusp && newSusp:
+		return []api.Warning{{
+			Level: api.LevelCaution, Rule: "suspends", Resource: resourceLabel(c),
+			Detail: "spec.suspend set — reconciliation freezes on merge; later changes will sit unapplied until it is resumed",
+		}}
+	case oldSusp && !newSusp:
+		return []api.Warning{{
+			Level: api.LevelCaution, Rule: "resumes", Resource: resourceLabel(c),
+			Detail: "spec.suspend removed — reconciliation resumes on merge and every change accumulated while suspended applies at once",
+		}}
+	}
+	return nil
+}
+
+// suspendedParentWarnings aggregates the changes whose producing parent is
+// suspended post-merge: Flux will not reconcile any of them, so the diff
+// shown is a diff of nothing-happens. One caution per suspended parent, not
+// one per resource — a parked app shouldn't bury the review in repeats.
+func suspendedParentWarnings(changes []Change, parents map[string]ParentInfo) []api.Warning {
+	counts := map[string]int{}
+	for _, c := range changes {
+		if p := parents[c.Parent]; p.Found && p.Suspended {
+			counts[c.Parent]++
+		}
+	}
+	return aggregateParentWarnings(counts, "suspended-parent", func(parent string, n int) string {
+		return fmt.Sprintf("%d %s under the suspended %s — Flux will not reconcile %s until it is resumed",
+			n, plural(n, "changed resource", "changed resources"), parent, plural(n, "it", "them"))
+	})
+}
+
+// notPrunedWarnings aggregates removals under a Kustomization with
+// prune: false: Flux deletes nothing — the removed resources keep running
+// in-cluster, unmanaged. That silent divergence is the signal; deletions
+// under prune: true are ordinary GitOps (the dangerous kinds among them
+// already carry their own cautions, sharpened by pruneSuffix).
+func notPrunedWarnings(changes []Change, parents map[string]ParentInfo) []api.Warning {
+	counts := map[string]int{}
+	for _, c := range changes {
+		if c.Status != statusRemoved {
+			continue
+		}
+		if p := parents[c.Parent]; p.Found && p.IsKustomization && !p.Prune {
+			counts[c.Parent]++
+		}
+	}
+	return aggregateParentWarnings(counts, "not-pruned", func(parent string, n int) string {
+		return fmt.Sprintf("%d removed %s under %s, which does not prune — Flux will leave %s running in-cluster, unmanaged",
+			n, plural(n, "resource", "resources"), parent, plural(n, "it", "them"))
+	})
+}
+
+// pruneSuffix sharpens a removed-resource caution with what Flux will
+// actually do: under a pruning Kustomization the removal is a real in-cluster
+// deletion on merge; under prune: false it is an orphaning. Empty when the
+// parent is unknown or a HelmRelease (Helm deletes on upgrade either way, so
+// the base wording already holds).
+func pruneSuffix(c Change, parents map[string]ParentInfo) string {
+	p := parents[c.Parent]
+	if !p.Found || !p.IsKustomization {
+		return ""
+	}
+	if p.Prune {
+		return " (the Kustomization prunes: it is deleted in-cluster on merge)"
+	}
+	return " (the Kustomization does not prune: it is orphaned in-cluster, not deleted)"
+}
+
+// aggregateParentWarnings renders one warning per parent from a count map,
+// sorted by parent label so the output is deterministic.
+func aggregateParentWarnings(counts map[string]int, rule string, detail func(parent string, n int) string) []api.Warning {
+	if len(counts) == 0 {
+		return nil
+	}
+	labels := make([]string, 0, len(counts))
+	for l := range counts {
+		labels = append(labels, l)
+	}
+	sort.Strings(labels)
+	out := make([]api.Warning, 0, len(labels))
+	for _, l := range labels {
+		out = append(out, api.Warning{
+			Level: api.LevelCaution, Rule: rule, Resource: l, Detail: detail(l, counts[l]),
+		})
+	}
+	return out
+}
+
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+	return many
+}
+
+// boolField reads a boolean at the given path (false when missing or not a
+// bool — Flux treats an absent suspend/prune as false, so the rules do too).
+func boolField(m map[string]any, keys ...string) bool {
+	if len(keys) == 0 {
+		return false
+	}
+	parent, ok := nestedMap(m, keys[:len(keys)-1]...)
+	if !ok {
+		return false
+	}
+	b, _ := parent[keys[len(keys)-1]].(bool)
+	return b
+}

--- a/internal/diff/flux_test.go
+++ b/internal/diff/flux_test.go
@@ -1,0 +1,178 @@
+package diff
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/home-operations/konflate/internal/api"
+)
+
+// fluxDoc builds a Flux Kustomization/HelmRelease manifest with the given
+// spec, for the suspend-toggle rules that inspect the doc itself.
+func fluxDoc(kind string, spec map[string]any) map[string]any {
+	return map[string]any{
+		"apiVersion": map[string]string{
+			"Kustomization": "kustomize.toolkit.fluxcd.io/v1",
+			"HelmRelease":   "helm.toolkit.fluxcd.io/v2",
+		}[kind],
+		"kind": kind,
+		"spec": spec,
+	}
+}
+
+func TestFlux_SuspendToggles(t *testing.T) {
+	t.Parallel()
+	for _, kind := range []string{"Kustomization", "HelmRelease"} {
+		// false → true: freezes.
+		c := Change{
+			Status: "changed", Kind: kind, Namespace: "flux-system", Name: "apps",
+			Old: fluxDoc(kind, map[string]any{}),
+			New: fluxDoc(kind, map[string]any{"suspend": true}),
+		}
+		if n, w := countRule(Lint([]Change{c}, nil, nil), "suspends"); n != 1 || !strings.Contains(w.Detail, "freezes") {
+			t.Errorf("%s suspend set: want 1 suspends caution, got %d (%q)", kind, n, w.Detail)
+		}
+
+		// true → absent: resumes, the accumulated-changes warning.
+		c.Old, c.New = c.New, c.Old
+		if n, w := countRule(Lint([]Change{c}, nil, nil), "resumes"); n != 1 || !strings.Contains(w.Detail, "accumulated") {
+			t.Errorf("%s suspend removed: want 1 resumes caution, got %d (%q)", kind, n, w.Detail)
+		}
+	}
+
+	// A non-Flux CRD that happens to be called Kustomization must not trip.
+	argo := Change{
+		Status: "changed", Kind: "Kustomization", Name: "x",
+		Old: map[string]any{"apiVersion": "example.io/v1", "kind": "Kustomization", "spec": map[string]any{}},
+		New: map[string]any{"apiVersion": "example.io/v1", "kind": "Kustomization", "spec": map[string]any{"suspend": true}},
+	}
+	ws := Lint([]Change{argo}, nil, nil)
+	if hasRule(ws, "suspends") {
+		t.Errorf("non-Flux Kustomization tripped the suspend rule: %+v", ws)
+	}
+
+	// An unrelated change on a Flux doc (no suspend flip) stays quiet.
+	quiet := Change{
+		Status: "changed", Kind: "HelmRelease", Name: "x",
+		Old: fluxDoc("HelmRelease", map[string]any{"interval": "30m"}),
+		New: fluxDoc("HelmRelease", map[string]any{"interval": "1h"}),
+	}
+	ws = Lint([]Change{quiet}, nil, nil)
+	if hasRule(ws, "suspends") || hasRule(ws, "resumes") {
+		t.Errorf("interval-only change tripped a suspend rule: %+v", ws)
+	}
+}
+
+func TestFlux_SuspendedParentAggregates(t *testing.T) {
+	t.Parallel()
+	parents := map[string]ParentInfo{
+		"Kustomization flux-system/media": {Found: true, IsKustomization: true, Suspended: true, Prune: true},
+		"HelmRelease media/plex":          {Found: true, Suspended: false},
+	}
+	changes := []Change{
+		{Status: "changed", Kind: "Deployment", Namespace: "media", Name: "radarr", Parent: "Kustomization flux-system/media", Old: map[string]any{}, New: map[string]any{}},
+		{Status: "added", Kind: "ConfigMap", Namespace: "media", Name: "cfg", Parent: "Kustomization flux-system/media", New: map[string]any{}},
+		{Status: "changed", Kind: "Deployment", Namespace: "media", Name: "plex", Parent: "HelmRelease media/plex", Old: map[string]any{}, New: map[string]any{}},
+	}
+
+	ws := Lint(changes, nil, parents)
+	n, w := countRule(ws, "suspended-parent")
+	if n != 1 {
+		t.Fatalf("suspended-parent warnings = %d, want 1 (aggregated): %+v", n, ws)
+	}
+	if w.Resource != "Kustomization flux-system/media" || !strings.Contains(w.Detail, "2 changed resources") {
+		t.Errorf("aggregate should name the parent and count 2, got %+v", w)
+	}
+
+	// No parent facts at all (nil map) → silent, never guessing.
+	if hasRule(Lint(changes, nil, nil), "suspended-parent") {
+		t.Error("suspended-parent fired without parent facts")
+	}
+}
+
+func TestFlux_PruneSemanticsOnRemovals(t *testing.T) {
+	t.Parallel()
+	pruning := map[string]ParentInfo{
+		"Kustomization flux-system/db": {Found: true, IsKustomization: true, Prune: true},
+	}
+	notPruning := map[string]ParentInfo{
+		"Kustomization flux-system/db": {Found: true, IsKustomization: true, Prune: false},
+	}
+	removedSts := Change{
+		Status: statusRemoved, Kind: "StatefulSet", Namespace: "default", Name: "postgres",
+		Parent: "Kustomization flux-system/db", Old: map[string]any{},
+	}
+
+	// prune: true — the dangerous-kind caution states the deletion is real.
+	ws := Lint([]Change{removedSts}, nil, pruning)
+	if _, w := countRule(ws, "removed-statefulset"); !strings.Contains(w.Detail, "deleted in-cluster on merge") {
+		t.Errorf("pruning parent: caution should state the deletion, got %q", w.Detail)
+	}
+	if hasRule(ws, "not-pruned") {
+		t.Errorf("pruning parent must not raise not-pruned: %+v", ws)
+	}
+
+	// prune: false — the caution states the orphaning, and the aggregate fires.
+	ws = Lint([]Change{removedSts}, nil, notPruning)
+	if _, w := countRule(ws, "removed-statefulset"); !strings.Contains(w.Detail, "orphaned in-cluster") {
+		t.Errorf("non-pruning parent: caution should state the orphaning, got %q", w.Detail)
+	}
+	if n, w := countRule(ws, "not-pruned"); n != 1 || !strings.Contains(w.Detail, "1 removed resource under") {
+		t.Errorf("non-pruning parent: want 1 not-pruned aggregate, got %d (%q)", n, w.Detail)
+	}
+
+	// Unknown parent — generic wording, no flux suffix, no aggregate.
+	ws = Lint([]Change{removedSts}, nil, nil)
+	if _, w := countRule(ws, "removed-statefulset"); strings.Contains(w.Detail, "Kustomization") {
+		t.Errorf("unknown parent must keep the generic wording, got %q", w.Detail)
+	}
+	if hasRule(ws, "not-pruned") {
+		t.Error("not-pruned fired without parent facts")
+	}
+
+	// HelmRelease parent: Helm deletes on upgrade either way — no suffix, no
+	// aggregate (the orphan semantics are a Kustomization-prune concept).
+	hrParent := map[string]ParentInfo{"HelmRelease default/db": {Found: true}}
+	removedSts.Parent = "HelmRelease default/db"
+	ws = Lint([]Change{removedSts}, nil, hrParent)
+	if _, w := countRule(ws, "removed-statefulset"); strings.Contains(w.Detail, "prune") {
+		t.Errorf("HelmRelease parent must not get prune wording, got %q", w.Detail)
+	}
+	if hasRule(ws, "not-pruned") {
+		t.Error("not-pruned fired for a HelmRelease parent")
+	}
+}
+
+// The aggregate counts only removals — changed/added resources under a
+// non-pruning Kustomization are reconciled normally.
+func TestFlux_NotPrunedCountsOnlyRemovals(t *testing.T) {
+	t.Parallel()
+	parents := map[string]ParentInfo{
+		"Kustomization flux-system/apps": {Found: true, IsKustomization: true, Prune: false},
+	}
+	changes := []Change{
+		{Status: "changed", Kind: "Deployment", Name: "a", Parent: "Kustomization flux-system/apps", Old: map[string]any{}, New: map[string]any{}},
+		{Status: statusRemoved, Kind: "ConfigMap", Name: "b", Parent: "Kustomization flux-system/apps", Old: map[string]any{}},
+		{Status: statusRemoved, Kind: "Service", Name: "c", Parent: "Kustomization flux-system/apps", Old: map[string]any{}},
+	}
+	n, w := countRule(Lint(changes, nil, parents), "not-pruned")
+	if n != 1 || !strings.Contains(w.Detail, "2 removed resources") {
+		t.Errorf("want one aggregate counting the 2 removals, got %d (%q)", n, w.Detail)
+	}
+}
+
+// Belt and braces: the warnings keep the api caution level (the UI keys
+// styling off it).
+func TestFlux_WarningsAreCautions(t *testing.T) {
+	t.Parallel()
+	c := Change{
+		Status: "changed", Kind: "Kustomization", Name: "x",
+		Old: fluxDoc("Kustomization", map[string]any{}),
+		New: fluxDoc("Kustomization", map[string]any{"suspend": true}),
+	}
+	for _, w := range Lint([]Change{c}, nil, nil) {
+		if w.Level != api.LevelCaution {
+			t.Errorf("warning %q level = %q, want caution", w.Rule, w.Level)
+		}
+	}
+}

--- a/internal/diff/immutable_test.go
+++ b/internal/diff/immutable_test.go
@@ -17,7 +17,7 @@ func changed(kind string, oldSpec, newSpec map[string]any) Change {
 	}
 }
 
-func lintOne(c Change) []api.Warning { return Lint([]Change{c}, nil) }
+func lintOne(c Change) []api.Warning { return Lint([]Change{c}, nil, nil) }
 
 func TestImmutable_StatefulSetSpecOutsideAllowlist(t *testing.T) {
 	t.Parallel()

--- a/internal/diff/lint.go
+++ b/internal/diff/lint.go
@@ -38,9 +38,11 @@ const (
 
 // Lint runs the danger-lint rules over the changed resources (and the diff's
 // image changes) and returns the warnings, most-severe first (all dangers
-// before all cautions). Advisory only — konflate never blocks on these; they
-// are a reviewer aid.
-func Lint(changes []Change, images []api.ImageChange) []api.Warning {
+// before all cautions). parents carries the Flux-semantic facts about each
+// producing Kustomization/HelmRelease (suspend/prune — see ParentInfo); nil
+// is fine and simply mutes the parent-aware rules. Advisory only — konflate
+// never blocks on these; they are a reviewer aid.
+func Lint(changes []Change, images []api.ImageChange, parents map[string]ParentInfo) []api.Warning {
 	var warnings []api.Warning
 	add := func(rule, detail string, c Change) {
 		warnings = append(warnings, api.Warning{Level: api.LevelCaution, Rule: rule, Resource: resourceLabel(c), Detail: detail})
@@ -48,19 +50,25 @@ func Lint(changes []Change, images []api.ImageChange) []api.Warning {
 
 	for _, c := range changes {
 		if c.Status == statusRemoved {
+			// pruneSuffix sharpens each removal with what Flux will actually
+			// do — prune (a real deletion) vs orphan — when the parent
+			// Kustomization's spec is known.
 			switch c.Kind {
 			case kindStatefulSet:
-				add("removed-statefulset", "removed StatefulSet — its PersistentVolumeClaims and data may be deleted", c)
+				add("removed-statefulset", "removed StatefulSet — its PersistentVolumeClaims and data may be deleted"+pruneSuffix(c, parents), c)
 			case "PersistentVolumeClaim":
-				add("removed-pvc", "removed PersistentVolumeClaim — the bound volume's data may be reclaimed", c)
+				add("removed-pvc", "removed PersistentVolumeClaim — the bound volume's data may be reclaimed"+pruneSuffix(c, parents), c)
 			case "Namespace":
-				add("removed-namespace", "removed Namespace — deletes every resource inside it", c)
+				add("removed-namespace", "removed Namespace — deletes every resource inside it"+pruneSuffix(c, parents), c)
 			case "CustomResourceDefinition":
-				add("removed-crd", "removed CustomResourceDefinition — deletes all of its custom resources", c)
+				add("removed-crd", "removed CustomResourceDefinition — deletes all of its custom resources"+pruneSuffix(c, parents), c)
 			case "NetworkPolicy":
-				add("removed-networkpolicy", "removed NetworkPolicy — traffic it previously denied may now be allowed", c)
+				add("removed-networkpolicy", "removed NetworkPolicy — traffic it previously denied may now be allowed"+pruneSuffix(c, parents), c)
 			}
 		}
+
+		// Flux suspend toggles on the Kustomization/HelmRelease doc itself.
+		warnings = append(warnings, suspendToggleWarnings(c)...)
 
 		// Post-image rules (added or changed): inspect the New manifest.
 		if c.New != nil {
@@ -82,6 +90,11 @@ func Lint(changes []Change, images []api.ImageChange) []api.Warning {
 		// the API server refuses to update in place (see immutable.go).
 		warnings = append(warnings, immutableFieldWarnings(c)...)
 	}
+
+	// Flux-semantic aggregates: changes parked under a suspended parent, and
+	// removals a non-pruning Kustomization will orphan rather than delete.
+	warnings = append(warnings, suspendedParentWarnings(changes, parents)...)
+	warnings = append(warnings, notPrunedWarnings(changes, parents)...)
 
 	// Blast-radius / version signals: an unusually large change set, and major
 	// (semver) chart or container-image bumps.

--- a/internal/diff/lint_test.go
+++ b/internal/diff/lint_test.go
@@ -168,7 +168,7 @@ func TestLint(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := Lint(tt.changes, nil)
+			got := Lint(tt.changes, nil, nil)
 
 			if len(got) != len(tt.want) {
 				t.Fatalf("Lint() = %d warnings, want %d\n got: %+v\nwant: %+v", len(got), len(tt.want), got, tt.want)
@@ -198,12 +198,12 @@ func TestLint_LargeChangeSet(t *testing.T) {
 			Old:    map[string]any{}, New: map[string]any{},
 		})
 	}
-	if !hasRule(Lint(many, nil), "large-changeset") {
+	if !hasRule(Lint(many, nil, nil), "large-changeset") {
 		t.Errorf("%d apps should trip the large-changeset caution", largeParentCount)
 	}
 	// A one-app change does not.
 	few := []Change{{Status: "changed", Kind: "ConfigMap", Name: "c", Parent: "HelmRelease app", Old: map[string]any{}, New: map[string]any{}}}
-	if hasRule(Lint(few, nil), "large-changeset") {
+	if hasRule(Lint(few, nil, nil), "large-changeset") {
 		t.Error("a one-app change must not be flagged as large")
 	}
 }
@@ -214,7 +214,7 @@ func TestLint_MajorImageBump(t *testing.T) {
 		{Name: "ghcr.io/app", From: "v1.9.0", To: "v2.0.0"}, // major → caution
 		{Name: "ghcr.io/lib", From: "1.2.3", To: "1.3.0"},   // minor → none
 	}
-	n, w := countRule(Lint(nil, images), "major-image-bump")
+	n, w := countRule(Lint(nil, images, nil), "major-image-bump")
 	if n != 1 {
 		t.Fatalf("major-image-bump count = %d, want 1", n)
 	}
@@ -232,7 +232,7 @@ func TestLint_MajorChartBump(t *testing.T) {
 		// A minor chart bump → none.
 		{Status: "changed", Kind: "ConfigMap", Name: "c", Parent: "HelmRelease other", OldChart: "other-1.2.0", NewChart: "other-1.3.0", Old: map[string]any{}, New: map[string]any{}},
 	}
-	n, w := countRule(Lint(changes, nil), "major-chart-bump")
+	n, w := countRule(Lint(changes, nil, nil), "major-chart-bump")
 	if n != 1 {
 		t.Fatalf("major-chart-bump count = %d, want 1 (deduped by chart)", n)
 	}

--- a/internal/diff/render.go
+++ b/internal/diff/render.go
@@ -31,6 +31,10 @@ type RenderInput struct {
 	// the rendered set and counted in DiffResult.Truncated; the summary and
 	// impact still reflect the full change set. <=0 means no cap.
 	MaxResources int
+	// Parents carries the Flux-semantic facts (suspend/prune) about each
+	// producing Kustomization/HelmRelease, keyed by the Change.Parent label —
+	// see ParentInfo. Optional; nil mutes the parent-aware lint rules.
+	Parents map[string]ParentInfo
 }
 
 // Row and cell kinds, matching the api string-literal unions.
@@ -87,7 +91,7 @@ func Render(in RenderInput) (api.DiffResult, error) {
 		Impact:    Summarize(changes),
 		Images:    in.Images,
 		Failures:  in.Failures,
-		Warnings:  Lint(changes, in.Images),
+		Warnings:  Lint(changes, in.Images, in.Parents),
 	}
 
 	// Summary reflects the true totals across every (real) change, even when the

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -164,6 +164,9 @@ func (e *flateEngine) Diff(ctx context.Context, pr api.PR) (api.DiffResult, erro
 		Images:       imageChanges(changes),
 		Failures:     failures,
 		MaxResources: e.maxDiffResources,
+		// Flux-semantic parent facts (suspend/prune) for the lint rules,
+		// looked up across the full rendered sets — see parentInfos.
+		Parents: parentInfos(base.Result.Manifests, head.Result.Manifests),
 	})
 }
 

--- a/internal/engine/flux.go
+++ b/internal/engine/flux.go
@@ -1,0 +1,53 @@
+package engine
+
+import (
+	"strings"
+
+	"github.com/home-operations/flate/pkg/manifest"
+
+	"github.com/home-operations/konflate/internal/diff"
+)
+
+// parentInfos scans the full rendered manifest sets for the Flux Kustomization
+// and HelmRelease documents and returns their suspend/prune facts, keyed by the
+// same "Kind ns/name" label the diff changes carry as Parent. The head side is
+// the post-merge truth and wins; the base side fills in parents the PR removes
+// (so a removal's prune semantics still resolve). The docs are scanned from the
+// manifest VALUES — a Kustomization/HelmRelease is itself a rendered resource
+// of whatever produced it — so the index covers every parent the cluster
+// declares, changed by this PR or not.
+func parentInfos(base, head map[manifest.NamedResource][]map[string]any) map[string]diff.ParentInfo {
+	out := map[string]diff.ParentInfo{}
+	// Base first, head second: same key ⇒ the head-side doc overwrites, making
+	// the post-merge spec the one the rules see.
+	for _, side := range []map[manifest.NamedResource][]map[string]any{base, head} {
+		for _, docs := range side {
+			for _, doc := range docs {
+				kind, _ := doc["kind"].(string)
+				if kind != "Kustomization" && kind != "HelmRelease" {
+					continue
+				}
+				apiVersion, _ := doc["apiVersion"].(string)
+				if !strings.Contains(apiVersion, "toolkit.fluxcd.io") {
+					continue
+				}
+				meta, _ := doc["metadata"].(map[string]any)
+				name, _ := meta["name"].(string)
+				if name == "" {
+					continue
+				}
+				ns, _ := meta["namespace"].(string)
+				spec, _ := doc["spec"].(map[string]any)
+				suspended, _ := spec["suspend"].(bool)
+				prune, _ := spec["prune"].(bool)
+				out[parentLabel(manifest.NamedResource{Kind: kind, Namespace: ns, Name: name})] = diff.ParentInfo{
+					Found:           true,
+					IsKustomization: kind == "Kustomization",
+					Suspended:       suspended,
+					Prune:           prune,
+				}
+			}
+		}
+	}
+	return out
+}

--- a/internal/engine/flux_test.go
+++ b/internal/engine/flux_test.go
@@ -1,0 +1,65 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// TestParentInfos covers the Flux parent index the lint rules consume: docs
+// are found across both manifest sets, the head side wins for parents present
+// on both (the post-merge truth), the base side fills in removed parents, and
+// non-Flux lookalikes are excluded.
+func TestParentInfos(t *testing.T) {
+	t.Parallel()
+	ks := func(name string, suspend, prune bool, apiVersion string) map[string]any {
+		return map[string]any{
+			"apiVersion": apiVersion,
+			"kind":       "Kustomization",
+			"metadata":   map[string]any{"name": name, "namespace": "flux-system"},
+			"spec":       map[string]any{"suspend": suspend, "prune": prune},
+		}
+	}
+	hr := func(name string, suspend bool) map[string]any {
+		return map[string]any{
+			"apiVersion": "helm.toolkit.fluxcd.io/v2",
+			"kind":       "HelmRelease",
+			"metadata":   map[string]any{"name": name, "namespace": "media"},
+			"spec":       map[string]any{"suspend": suspend},
+		}
+	}
+	parent := manifest.NamedResource{Kind: "Kustomization", Namespace: "flux-system", Name: "root"}
+
+	base := map[manifest.NamedResource][]map[string]any{
+		parent: {
+			ks("apps", false, true, "kustomize.toolkit.fluxcd.io/v1"),  // suspend flips on head
+			ks("gone", false, false, "kustomize.toolkit.fluxcd.io/v1"), // removed by the PR: base fills in
+			hr("plex", false),
+		},
+	}
+	head := map[manifest.NamedResource][]map[string]any{
+		parent: {
+			ks("apps", true, true, "kustomize.toolkit.fluxcd.io/v1"), // head wins: suspended post-merge
+			hr("plex", false),
+			ks("argo-lookalike", true, true, "example.io/v1"), // wrong API group: excluded
+		},
+	}
+
+	got := parentInfos(base, head)
+
+	apps := got["Kustomization flux-system/apps"]
+	if !apps.Found || !apps.IsKustomization || !apps.Suspended || !apps.Prune {
+		t.Errorf("apps: head side (suspended, pruning) should win, got %+v", apps)
+	}
+	gone := got["Kustomization flux-system/gone"]
+	if !gone.Found || gone.Prune {
+		t.Errorf("gone: removed parent should resolve from base (prune false), got %+v", gone)
+	}
+	plex := got["HelmRelease media/plex"]
+	if !plex.Found || plex.IsKustomization || plex.Suspended {
+		t.Errorf("plex: HelmRelease facts wrong, got %+v", plex)
+	}
+	if _, ok := got["Kustomization flux-system/argo-lookalike"]; ok {
+		t.Error("non-Flux Kustomization lookalike must be excluded")
+	}
+}


### PR DESCRIPTION
## Summary

The danger lint reasoned about what a change *contains*; these rules reason about what **Flux will actually do with it on merge**. Both consume a new input: the producing Kustomization/HelmRelease's own spec, which the engine looks up across the full rendered manifest sets (a KS/HR is itself a rendered resource of whatever produced it) — head side first as the post-merge truth, base side filling in parents the PR removes. `Lint` receives it as a `ParentInfo` map keyed by the existing `Change.Parent` label; unknown parents mute every rule rather than guessing.

## A — Suspend awareness

| Rule | Fires when | Why it matters |
|---|---|---|
| `suspended-parent` | changes whose producing parent is suspended post-merge | the diff is a diff of *nothing-happens* — Flux won't reconcile any of it until resumed. One **aggregated** caution per parent (`"3 changed resources under the suspended Kustomization flux-system/media — …"`), never one per resource. |
| `suspends` | a PR sets `spec.suspend` on a KS/HR | reconciliation freezes on merge; later changes sit unapplied. |
| `resumes` | a PR removes `spec.suspend` | the sharper edge: everything accumulated while parked applies **at once**. |

The toggle rules are guarded by API group, so a non-Flux CRD that happens to be called `Kustomization` can't trip them.

## B — Prune semantics on removals

- The existing `removed-statefulset` / `removed-pvc` / `removed-namespace` / `removed-crd` / `removed-networkpolicy` cautions now state the actual consequence when the parent's spec is known: under `prune: true` — *"deleted in-cluster on merge"* (a real deletion); under `prune: false` — *"orphaned in-cluster, not deleted"* (silently left running, unmanaged). Opposite outcomes that previously read identically.
- New `not-pruned` aggregate: one caution per non-pruning Kustomization counting **all** its removed resources — the orphaning applies to every removal, not just the dangerous kinds.
- HelmRelease parents are exempt from prune wording: Helm deletes on upgrade either way, so the base wording already holds.

## Notes

- Pure konflate — no flate changes needed; the engine already holds both full manifest sets.
- No UI work: everything flows through the existing caution surfaces (overview, list preview, summary endpoint/markdown, signal badges).
- README's danger-lint bullet extended with the Flux-semantics line.

## Tests

- Rule tests: both toggles on both kinds, the non-Flux lookalike guard, interval-only quiet, per-parent aggregation (2 resources → one caution), prune-true vs prune-false vs unknown-parent vs HelmRelease wording, removals-only counting for `not-pruned`, and caution-level invariance.
- Engine test: `parentInfos` head-wins / base-fills-removed / lookalike-excluded.
- `go test ./...` green; `golangci-lint run` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)