### PR TITLE
fix(images): merge rename-split add/remove pairs into one transition

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -340,6 +340,71 @@ func TestImageChanges_SameRepoMultipleTags(t *testing.T) {
 	}
 }
 
+// TestImageChanges_RenameMergesTransition: a chart restructure removes the old
+// resource (pure removal of the image) and adds a differently-named one (pure
+// addition). The two halves must reconcile into the single real version bump the
+// cluster undergoes, not read as one image vanishing and another appearing.
+func TestImageChanges_RenameMergesTransition(t *testing.T) {
+	t.Parallel()
+	changes := []diff.Change{
+		{Status: "removed", Kind: "Deployment", Namespace: "rook", Name: "old-provisioner",
+			Old: deploy("rook", "old-provisioner", "quay.io/cephcsi/cephcsi:v3.16.2"), New: nil},
+		{Status: "added", Kind: "Deployment", Namespace: "rook", Name: "new-provisioner",
+			Old: nil, New: deploy("rook", "new-provisioner", "quay.io/cephcsi/cephcsi:v3.17.0")},
+	}
+	got := imageChanges(changes)
+	if len(got) != 1 {
+		t.Fatalf("got %d image changes, want 1 merged transition: %+v", len(got), got)
+	}
+	c := got[0]
+	if c.Name != "quay.io/cephcsi/cephcsi" || c.From != "v3.16.2" || c.To != "v3.17.0" {
+		t.Errorf("got %+v, want cephcsi v3.16.2→v3.17.0 (the real bump)", c)
+	}
+	if len(c.Refs) != 2 {
+		t.Errorf("merged refs should union both resources, got %v", c.Refs)
+	}
+}
+
+// TestImageChanges_RelocationDropped: an image at the same version on both sides,
+// split across a rename, is a pure relocation — the running image is unchanged,
+// so it must not appear in the Image changes list at all.
+func TestImageChanges_RelocationDropped(t *testing.T) {
+	t.Parallel()
+	changes := []diff.Change{
+		{Status: "removed", Kind: "Deployment", Namespace: "rook", Name: "old",
+			Old: deploy("rook", "old", "registry.k8s.io/sig-storage/csi-resizer:v2.1.0"), New: nil},
+		{Status: "added", Kind: "Deployment", Namespace: "rook", Name: "new",
+			Old: nil, New: deploy("rook", "new", "registry.k8s.io/sig-storage/csi-resizer:v2.1.0")},
+	}
+	if got := imageChanges(changes); len(got) != 0 {
+		t.Fatalf("a same-version relocation is not an image change, got %+v", got)
+	}
+}
+
+// TestImageChanges_AmbiguousNotMerged: two removals and one addition of the same
+// repo are ambiguous to pair, so they stay discrete — reconciliation must not
+// fabricate a transition, mirroring TestImageChanges_SameRepoMultipleTags.
+func TestImageChanges_AmbiguousNotMerged(t *testing.T) {
+	t.Parallel()
+	changes := []diff.Change{
+		{Status: "removed", Kind: "Deployment", Namespace: "a", Name: "r1",
+			Old: deploy("a", "r1", "reg/x:1.0"), New: nil},
+		{Status: "removed", Kind: "Deployment", Namespace: "a", Name: "r2",
+			Old: deploy("a", "r2", "reg/x:1.1"), New: nil},
+		{Status: "added", Kind: "Deployment", Namespace: "a", Name: "n1",
+			Old: nil, New: deploy("a", "n1", "reg/x:2.0")},
+	}
+	got := imageChanges(changes)
+	if len(got) != 3 {
+		t.Fatalf("ambiguous repo must stay discrete, got %d: %+v", len(got), got)
+	}
+	for _, c := range got {
+		if c.From != "" && c.To != "" {
+			t.Errorf("no merged transition expected for an ambiguous repo, got %+v", c)
+		}
+	}
+}
+
 // splitImageRef's behavior now lives in flate's image.Split (tested in
 // flate); konflate's collectImages composes image.Extract + image.Split,
 // exercised end to end by TestImageChanges above.

--- a/internal/engine/images.go
+++ b/internal/engine/images.go
@@ -58,9 +58,92 @@ func imageChanges(changes []diff.Change) []api.ImageChange {
 		slices.Sort(refs)
 		out = append(out, api.ImageChange{Name: a.name, From: a.from, To: a.to, Refs: refs})
 	}
+	out = reconcileRelocations(out)
 	slices.SortFunc(out, func(a, b api.ImageChange) int {
 		return cmp.Or(cmp.Compare(a.Name, b.Name), cmp.Compare(a.From, b.From), cmp.Compare(a.To, b.To))
 	})
+	return out
+}
+
+// reconcileRelocations folds the artificial add/remove split that a resource
+// rename produces back into the one real image transition. When a PR moves an
+// image to a differently-named resource (a chart restructure), the old resource
+// (removed) reports the image as a pure removal (To == "") and the new resource
+// (added) reports it as a pure addition (From == ""); per-resource diffing can't
+// see the two are the same image. This pass pairs a lone pure removal with a lone
+// pure addition of the same repository into one from→to move, unioning the
+// resources that reference it.
+//
+// Only the unambiguous one-removal-one-addition case is merged — mirroring
+// repoTransitions' refusal to pair when several versions are in play, so a
+// transition no container underwent is never invented. A merged move whose
+// versions are equal is a pure relocation: the image itself is unchanged, so it
+// is dropped — the Image changes list reports version deltas, not where a
+// resource moved (the resource diff already shows that), the same reason record
+// skips a no-op move.
+func reconcileRelocations(in []api.ImageChange) []api.ImageChange {
+	type repoIdx struct{ adds, removes []int }
+	byRepo := map[string]*repoIdx{}
+	idx := func(name string) *repoIdx {
+		if byRepo[name] == nil {
+			byRepo[name] = &repoIdx{}
+		}
+		return byRepo[name]
+	}
+	for i, ic := range in {
+		switch {
+		case ic.From == "" && ic.To != "":
+			r := idx(ic.Name)
+			r.adds = append(r.adds, i)
+		case ic.To == "" && ic.From != "":
+			r := idx(ic.Name)
+			r.removes = append(r.removes, i)
+		}
+	}
+
+	dropped := make([]bool, len(in))
+	var merged []api.ImageChange
+	for _, r := range byRepo {
+		if len(r.adds) != 1 || len(r.removes) != 1 {
+			continue // ambiguous (or one-sided) — leave the entries discrete
+		}
+		add, rem := in[r.adds[0]], in[r.removes[0]]
+		dropped[r.adds[0]] = true
+		dropped[r.removes[0]] = true
+		if rem.From == add.To {
+			continue // same version on both sides: a relocation, not a change
+		}
+		merged = append(merged, api.ImageChange{
+			Name: add.Name, From: rem.From, To: add.To, Refs: mergeRefs(rem.Refs, add.Refs),
+		})
+	}
+
+	out := make([]api.ImageChange, 0, len(in))
+	for i, ic := range in {
+		if !dropped[i] {
+			out = append(out, ic)
+		}
+	}
+	return append(out, merged...)
+}
+
+// mergeRefs unions two already-sorted reference lists into one sorted, deduped list.
+func mergeRefs(a, b []string) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	out := make([]string, 0, len(a)+len(b))
+	add := func(s string) {
+		if _, ok := seen[s]; !ok {
+			seen[s] = struct{}{}
+			out = append(out, s)
+		}
+	}
+	for _, s := range a {
+		add(s)
+	}
+	for _, s := range b {
+		add(s)
+	}
+	slices.Sort(out)
 	return out
 }
 


### PR DESCRIPTION
## Problem

Image changes are computed per resource. When a PR moves an image to a differently-named resource — a chart restructure, like the rook-ceph CSI layout in [`#/pr/10973`](https://konflate.turbo.ac/#/pr/10973) — the old resource (removed) reports the image as a pure removal and the new resource (added) reports it as a pure addition. Per-resource diffing can't tell they're the same image, so the reviewer sees one image listed as **both vanishing and appearing**.

On that rook-ceph PR it produced 17 image entries, several of them noise: `csi-resizer v2.1.0` shown twice (added on one path, removed on another, same version), `cephcsi` shown as `∅→v3.17.0` and `v3.16.2→∅` separately rather than the real `v3.16.2 → v3.17.0`.

## Fix

A cross-resource reconciliation pass (`reconcileRelocations` in `internal/engine/images.go`):

- Pair a **lone** pure removal with a **lone** pure addition of the same repository into the single `from → to` move it actually underwent, unioning the resources that reference it.
- Only the unambiguous one-removal / one-addition case merges — mirroring the existing `repoTransitions` rule (and `TestImageChanges_SameRepoMultipleTags`), so a transition no container underwent is never fabricated. Two-removals-one-addition stays discrete.
- A merged pair whose versions are **equal** is a pure relocation: the running image is unchanged, so it's dropped from the list. The resource diff already shows the move; the Image changes list is for version deltas. (Same reason `record` already skips a no-op move within a resource.)

Net effect on `#/pr/10973`: **17 raw entries → 7 real image changes** (4 merged bumps, 3 same-version relocations dropped).

## Decision worth a look

I **drop** same-version relocations rather than showing them. If you'd rather see them flagged as `moved (unchanged)` so the move is still visible in the image list, that's a one-line change — say the word.

## Scope

This corrects the image list and trims its length; it does **not** touch the 23 MB payload (that's dominated by removed-resource bodies + `chromaCss`, a separate change). UI is unchanged — the existing `from → to` rendering just gets correct, deduped data.

## Verification

`go build`, `go test ./...`, and `golangci-lint` (0 issues) all pass. New tests: rename merges to one transition (refs unioned), same-version relocation dropped, ambiguous repo stays discrete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
