### PR TITLE
feat(ui): compact the review summary layout

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -340,6 +340,71 @@ func TestImageChanges_SameRepoMultipleTags(t *testing.T) {
 	}
 }
 
+// TestImageChanges_RenameMergesTransition: a chart restructure removes the old
+// resource (pure removal of the image) and adds a differently-named one (pure
+// addition). The two halves must reconcile into the single real version bump the
+// cluster undergoes, not read as one image vanishing and another appearing.
+func TestImageChanges_RenameMergesTransition(t *testing.T) {
+	t.Parallel()
+	changes := []diff.Change{
+		{Status: "removed", Kind: "Deployment", Namespace: "rook", Name: "old-provisioner",
+			Old: deploy("rook", "old-provisioner", "quay.io/cephcsi/cephcsi:v3.16.2"), New: nil},
+		{Status: "added", Kind: "Deployment", Namespace: "rook", Name: "new-provisioner",
+			Old: nil, New: deploy("rook", "new-provisioner", "quay.io/cephcsi/cephcsi:v3.17.0")},
+	}
+	got := imageChanges(changes)
+	if len(got) != 1 {
+		t.Fatalf("got %d image changes, want 1 merged transition: %+v", len(got), got)
+	}
+	c := got[0]
+	if c.Name != "quay.io/cephcsi/cephcsi" || c.From != "v3.16.2" || c.To != "v3.17.0" {
+		t.Errorf("got %+v, want cephcsi v3.16.2→v3.17.0 (the real bump)", c)
+	}
+	if len(c.Refs) != 2 {
+		t.Errorf("merged refs should union both resources, got %v", c.Refs)
+	}
+}
+
+// TestImageChanges_RelocationDropped: an image at the same version on both sides,
+// split across a rename, is a pure relocation — the running image is unchanged,
+// so it must not appear in the Image changes list at all.
+func TestImageChanges_RelocationDropped(t *testing.T) {
+	t.Parallel()
+	changes := []diff.Change{
+		{Status: "removed", Kind: "Deployment", Namespace: "rook", Name: "old",
+			Old: deploy("rook", "old", "registry.k8s.io/sig-storage/csi-resizer:v2.1.0"), New: nil},
+		{Status: "added", Kind: "Deployment", Namespace: "rook", Name: "new",
+			Old: nil, New: deploy("rook", "new", "registry.k8s.io/sig-storage/csi-resizer:v2.1.0")},
+	}
+	if got := imageChanges(changes); len(got) != 0 {
+		t.Fatalf("a same-version relocation is not an image change, got %+v", got)
+	}
+}
+
+// TestImageChanges_AmbiguousNotMerged: two removals and one addition of the same
+// repo are ambiguous to pair, so they stay discrete — reconciliation must not
+// fabricate a transition, mirroring TestImageChanges_SameRepoMultipleTags.
+func TestImageChanges_AmbiguousNotMerged(t *testing.T) {
+	t.Parallel()
+	changes := []diff.Change{
+		{Status: "removed", Kind: "Deployment", Namespace: "a", Name: "r1",
+			Old: deploy("a", "r1", "reg/x:1.0"), New: nil},
+		{Status: "removed", Kind: "Deployment", Namespace: "a", Name: "r2",
+			Old: deploy("a", "r2", "reg/x:1.1"), New: nil},
+		{Status: "added", Kind: "Deployment", Namespace: "a", Name: "n1",
+			Old: nil, New: deploy("a", "n1", "reg/x:2.0")},
+	}
+	got := imageChanges(changes)
+	if len(got) != 3 {
+		t.Fatalf("ambiguous repo must stay discrete, got %d: %+v", len(got), got)
+	}
+	for _, c := range got {
+		if c.From != "" && c.To != "" {
+			t.Errorf("no merged transition expected for an ambiguous repo, got %+v", c)
+		}
+	}
+}
+
 // splitImageRef's behavior now lives in flate's image.Split (tested in
 // flate); konflate's collectImages composes image.Extract + image.Split,
 // exercised end to end by TestImageChanges above.

--- a/internal/engine/images.go
+++ b/internal/engine/images.go
@@ -58,9 +58,92 @@ func imageChanges(changes []diff.Change) []api.ImageChange {
 		slices.Sort(refs)
 		out = append(out, api.ImageChange{Name: a.name, From: a.from, To: a.to, Refs: refs})
 	}
+	out = reconcileRelocations(out)
 	slices.SortFunc(out, func(a, b api.ImageChange) int {
 		return cmp.Or(cmp.Compare(a.Name, b.Name), cmp.Compare(a.From, b.From), cmp.Compare(a.To, b.To))
 	})
+	return out
+}
+
+// reconcileRelocations folds the artificial add/remove split that a resource
+// rename produces back into the one real image transition. When a PR moves an
+// image to a differently-named resource (a chart restructure), the old resource
+// (removed) reports the image as a pure removal (To == "") and the new resource
+// (added) reports it as a pure addition (From == ""); per-resource diffing can't
+// see the two are the same image. This pass pairs a lone pure removal with a lone
+// pure addition of the same repository into one from→to move, unioning the
+// resources that reference it.
+//
+// Only the unambiguous one-removal-one-addition case is merged — mirroring
+// repoTransitions' refusal to pair when several versions are in play, so a
+// transition no container underwent is never invented. A merged move whose
+// versions are equal is a pure relocation: the image itself is unchanged, so it
+// is dropped — the Image changes list reports version deltas, not where a
+// resource moved (the resource diff already shows that), the same reason record
+// skips a no-op move.
+func reconcileRelocations(in []api.ImageChange) []api.ImageChange {
+	type repoIdx struct{ adds, removes []int }
+	byRepo := map[string]*repoIdx{}
+	idx := func(name string) *repoIdx {
+		if byRepo[name] == nil {
+			byRepo[name] = &repoIdx{}
+		}
+		return byRepo[name]
+	}
+	for i, ic := range in {
+		switch {
+		case ic.From == "" && ic.To != "":
+			r := idx(ic.Name)
+			r.adds = append(r.adds, i)
+		case ic.To == "" && ic.From != "":
+			r := idx(ic.Name)
+			r.removes = append(r.removes, i)
+		}
+	}
+
+	dropped := make([]bool, len(in))
+	var merged []api.ImageChange
+	for _, r := range byRepo {
+		if len(r.adds) != 1 || len(r.removes) != 1 {
+			continue // ambiguous (or one-sided) — leave the entries discrete
+		}
+		add, rem := in[r.adds[0]], in[r.removes[0]]
+		dropped[r.adds[0]] = true
+		dropped[r.removes[0]] = true
+		if rem.From == add.To {
+			continue // same version on both sides: a relocation, not a change
+		}
+		merged = append(merged, api.ImageChange{
+			Name: add.Name, From: rem.From, To: add.To, Refs: mergeRefs(rem.Refs, add.Refs),
+		})
+	}
+
+	out := make([]api.ImageChange, 0, len(in))
+	for i, ic := range in {
+		if !dropped[i] {
+			out = append(out, ic)
+		}
+	}
+	return append(out, merged...)
+}
+
+// mergeRefs unions two already-sorted reference lists into one sorted, deduped list.
+func mergeRefs(a, b []string) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	out := make([]string, 0, len(a)+len(b))
+	add := func(s string) {
+		if _, ok := seen[s]; !ok {
+			seen[s] = struct{}{}
+			out = append(out, s)
+		}
+	}
+	for _, s := range a {
+		add(s)
+	}
+	for _, s := range b {
+		add(s)
+	}
+	slices.Sort(out)
 	return out
 }
 

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -1636,6 +1636,11 @@ tr.search-hit > td {
   background: var(--panel);
   z-index: 1;
 }
+/* The summary header has no title (the rail labels it) — its only content is the
+   copy-to-merge command, kept on the right where it sat before. */
+.summary-header {
+  justify-content: flex-end;
+}
 .res-title {
   /* The diff body (table.diff) carries the only monospace; this header is a
      resource identifier shown as a label, so it stays in the UI (sans) font —

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -188,7 +188,7 @@ a.repo:focus-visible .repo-ext {
 }
 /* One focus ring for every interactive element, matching .copy-btn's accent
    treatment. Inset so it never clips inside scroll containers. */
-:is(.btn, .card, .card-expand, .forge-link, .expand-all, .scroll-top, .tree-item, .tree-summary, .expand-btn, .view-toggle button, .warning-link, .sum-pill):focus-visible {
+:is(.btn, .card, .card-expand, .forge-link, .expand-all, .scroll-top, .tree-item, .tree-summary, .expand-btn, .view-toggle button, .warning-link, .sum-pill, .ov-head):focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }
@@ -1127,19 +1127,35 @@ button.sum-pill:hover {
 .impact-pill strong {
   color: var(--text);
 }
-/* Tint the add/changed/removed pills (the .add/.chg/.del classes carry the text
-   color) so the shape of the change reads at a glance; counts stay neutral. */
-.impact-pill.add {
-  border-color: color-mix(in srgb, var(--ok) 40%, var(--border));
-  background: color-mix(in srgb, var(--ok) 10%, var(--panel));
+/* The change shape in one pill: +added ~changed −removed. Each segment is tinted
+   only when non-zero (the .zero modifier mutes it) so a "+0" doesn't draw the eye
+   to nothing — the same intent the three separate pills used to carry. */
+.impact-delta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 3px 10px;
+  font-size: 11px;
+  background: var(--panel-alt);
+  font-variant-numeric: tabular-nums;
 }
-.impact-pill.chg {
-  border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
-  background: color-mix(in srgb, var(--accent) 10%, var(--panel));
+.d-seg {
+  font-weight: 600;
 }
-.impact-pill.del {
-  border-color: color-mix(in srgb, var(--danger) 40%, var(--border));
-  background: color-mix(in srgb, var(--danger) 10%, var(--panel));
+.d-seg.add {
+  color: var(--ok);
+}
+.d-seg.chg {
+  color: var(--accent);
+}
+.d-seg.del {
+  color: var(--danger);
+}
+.d-seg.zero {
+  color: var(--muted);
+  font-weight: 400;
 }
 /* Truncation pill: the diff was capped — a soft "heads up, incomplete" in the
    amber accent, not the red lint severity. */
@@ -1148,9 +1164,19 @@ button.sum-pill:hover {
   border-color: color-mix(in srgb, var(--warn) 40%, var(--border));
   background: color-mix(in srgb, var(--warn) 10%, var(--panel));
 }
-/* Overview sections sit flat on the pane — headed lists, not boxed cards. */
+/* Two columns on a wide pane: auto-fit collapses to one when narrow, and a lone
+   section spans the full width (empty tracks collapse). Keeps the summary's
+   sections from stacking into one tall scroll above the diffs. */
+.ov-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 14px 18px;
+  align-items: start;
+}
+/* Overview sections sit flat on the pane — headed lists, not boxed cards. The
+   grid gap spaces them now, so no per-section margin. */
 .ov-section {
-  margin-bottom: 16px;
+  margin: 0;
 }
 .ov-section h3 {
   display: flex;
@@ -1162,6 +1188,39 @@ button.sum-pill:hover {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   margin: 0 0 6px;
+}
+/* A collapsible section heading (Image changes when long): the same look as the
+   h3 above, but a button with a leading chevron. */
+.ov-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  margin: 0 0 6px;
+  padding: 0;
+  background: none;
+  border: 0;
+  font: inherit;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+}
+.ov-head:hover {
+  color: var(--text);
+}
+/* The per-section item count: a quiet pill carried in the heading. */
+.ov-count {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--muted);
+  background: var(--panel-alt);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0 6px;
+  font-variant-numeric: tabular-nums;
 }
 /* One line per warning: level badge, resource, detail share a baseline and
    wrap only when they must. */

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -1109,11 +1109,16 @@ button.sum-pill:hover {
 .overview {
   padding: 14px;
 }
+/* The impact summary now rides in the sticky summary header (see Diffs.svelte),
+   left of the merge command — so it centers in the bar with no bottom margin and
+   can shrink/wrap when the bar is tight. The class name is unchanged: it's the
+   marker other views wait on. */
 .impact {
   display: flex;
+  align-items: center;
   flex-wrap: wrap;
   gap: 6px;
-  margin-bottom: 14px;
+  min-width: 0;
 }
 .impact-pill {
   border: 1px solid var(--border);

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -1636,10 +1636,10 @@ tr.search-hit > td {
   background: var(--panel);
   z-index: 1;
 }
-/* The summary header has no title (the rail labels it) — its only content is the
-   copy-to-merge command, kept on the right where it sat before. */
+/* The summary header has no title (the rail labels it): the change delta sits
+   left in the space the title vacated, the copy-to-merge command on the right. */
 .summary-header {
-  justify-content: flex-end;
+  justify-content: space-between;
 }
 .res-title {
   /* The diff body (table.diff) carries the only monospace; this header is a

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -1644,10 +1644,8 @@ tr.search-hit > td {
   flex: 1 1 auto;
   word-break: break-all;
 }
-/* The resource kind reads quieter than the ns/name it qualifies; the Summary
-   header's quiet "Overview" title shares the muted treatment (a label). */
-.res-kind,
-.res-title-quiet {
+/* The resource kind reads quieter than the ns/name it qualifies. */
+.res-kind {
   color: var(--muted);
   font-weight: 500;
 }

--- a/internal/web/src/lib/Diffs.svelte
+++ b/internal/web/src/lib/Diffs.svelte
@@ -240,6 +240,17 @@
              height) to keep the level-bar aligned with the rail, and hosts the
              copy-to-merge command on the right for open PRs with the feature on. -->
         <div class="res-header summary-header">
+          <!-- The change shape moves up into the bar the title vacated: sticky,
+               so "what changed" reads at a glance beside the merge command, and
+               the bar is no longer empty when there's no command. -->
+          {#if store.diff}
+            {@const s = store.diff.summary}
+            <span class="impact-delta" title="{s.added} added, {s.changed} changed, {s.removed} removed">
+              <span class="d-seg add" class:zero={s.added === 0}>+{s.added}</span>
+              <span class="d-seg chg" class:zero={s.changed === 0}>~{s.changed}</span>
+              <span class="d-seg del" class:zero={s.removed === 0}>−{s.removed}</span>
+            </span>
+          {/if}
           {#if store.diffMergeCommand}
             <MergeCommand command={store.diffMergeCommand} />
           {/if}

--- a/internal/web/src/lib/Diffs.svelte
+++ b/internal/web/src/lib/Diffs.svelte
@@ -235,11 +235,11 @@
     <div class="diff-pane" bind:this={pane} style="--stuck: {stuckPx}px">
       <section class="diff-section" data-sel="summary">
         <!-- Same sticky container as Diff.svelte's res-header (keep the two in
-             step), with a neutral status chip and a quiet title — the Summary
-             is a section like the others, not a resource. -->
+             step), but just a "Summary" label — no status chip. The summary is
+             the overview, not a resource with a status, and a chip beside the
+             word read like a pair of tabs. -->
         <div class="res-header">
-          <span class="res-status">summary</span>
-          <span class="res-title res-title-quiet">Overview</span>
+          <span class="res-title">Summary</span>
           <!-- The "copy to merge" command rides on the right of the Summary's
                header instead of its own full-width strip — one fewer bar, and it
                fills the otherwise-empty right side. Open PRs with the feature on. -->

--- a/internal/web/src/lib/Diffs.svelte
+++ b/internal/web/src/lib/Diffs.svelte
@@ -240,16 +240,39 @@
              height) to keep the level-bar aligned with the rail, and hosts the
              copy-to-merge command on the right for open PRs with the feature on. -->
         <div class="res-header summary-header">
-          <!-- The change shape moves up into the bar the title vacated: sticky,
-               so "what changed" reads at a glance beside the merge command, and
-               the bar is no longer empty when there's no command. -->
+          <!-- The whole impact summary rides in the bar the title vacated: the
+               scope counts and the +added ~changed −removed delta on the left
+               (sticky, so they read at a glance), the copy-to-merge command on
+               the right. The .impact class is unchanged — it stays the marker
+               other views wait on. -->
           {#if store.diff}
-            {@const s = store.diff.summary}
-            <span class="impact-delta" title="{s.added} added, {s.changed} changed, {s.removed} removed">
-              <span class="d-seg add" class:zero={s.added === 0}>+{s.added}</span>
-              <span class="d-seg chg" class:zero={s.changed === 0}>~{s.changed}</span>
-              <span class="d-seg del" class:zero={s.removed === 0}>−{s.removed}</span>
-            </span>
+            {@const d = store.diff}
+            <div class="impact">
+              <span class="impact-pill"><strong>{d.impact.resources}</strong> resources</span>
+              <span class="impact-pill"><strong>{d.impact.parents}</strong> parents</span>
+              <span class="impact-pill"><strong>{d.impact.crds}</strong> CRDs</span>
+              {#if d.impact.namespaces?.length}
+                <span class="impact-pill"
+                  ><strong>{d.impact.namespaces.length}</strong>
+                  {d.impact.namespaces.length === 1 ? 'namespace' : 'namespaces'}</span
+                >
+              {/if}
+              <span
+                class="impact-delta"
+                title="{d.summary.added} added, {d.summary.changed} changed, {d.summary.removed} removed"
+              >
+                <span class="d-seg add" class:zero={d.summary.added === 0}>+{d.summary.added}</span>
+                <span class="d-seg chg" class:zero={d.summary.changed === 0}>~{d.summary.changed}</span>
+                <span class="d-seg del" class:zero={d.summary.removed === 0}>−{d.summary.removed}</span>
+              </span>
+              {#if d.truncated}
+                <span
+                  class="impact-pill trunc"
+                  title="This diff exceeded the render cap; {d.truncated} resource diffs were not rendered."
+                  >{d.truncated} not shown</span
+                >
+              {/if}
+            </div>
           {/if}
           {#if store.diffMergeCommand}
             <MergeCommand command={store.diffMergeCommand} />

--- a/internal/web/src/lib/Diffs.svelte
+++ b/internal/web/src/lib/Diffs.svelte
@@ -234,15 +234,12 @@
     </div>
     <div class="diff-pane" bind:this={pane} style="--stuck: {stuckPx}px">
       <section class="diff-section" data-sel="summary">
-        <!-- Same sticky container as Diff.svelte's res-header (keep the two in
-             step), but just a "Summary" label — no status chip. The summary is
-             the overview, not a resource with a status, and a chip beside the
-             word read like a pair of tabs. -->
-        <div class="res-header">
-          <span class="res-title">Summary</span>
-          <!-- The "copy to merge" command rides on the right of the Summary's
-               header instead of its own full-width strip — one fewer bar, and it
-               fills the otherwise-empty right side. Open PRs with the feature on. -->
+        <!-- The rail's tree node already labels this section "Summary"; a second
+             "Summary" here read as a duplicate, so the header carries no title of
+             its own. It still mirrors Diff.svelte's res-header (sticky, same
+             height) to keep the level-bar aligned with the rail, and hosts the
+             copy-to-merge command on the right for open PRs with the feature on. -->
+        <div class="res-header summary-header">
           {#if store.diffMergeCommand}
             <MergeCommand command={store.diffMergeCommand} />
           {/if}

--- a/internal/web/src/lib/Overview.svelte
+++ b/internal/web/src/lib/Overview.svelte
@@ -73,16 +73,9 @@
         {d.impact.namespaces.length === 1 ? 'namespace' : 'namespaces'}</span
       >
     {/if}
-    <!-- The change shape in one pill: +added ~changed −removed. Each part is tinted
-         only when non-zero — a tinted "+0" draws the eye to nothing. -->
-    <span
-      class="impact-delta"
-      title="{d.summary.added} added, {d.summary.changed} changed, {d.summary.removed} removed"
-    >
-      <span class="d-seg add" class:zero={d.summary.added === 0}>+{d.summary.added}</span>
-      <span class="d-seg chg" class:zero={d.summary.changed === 0}>~{d.summary.changed}</span>
-      <span class="d-seg del" class:zero={d.summary.removed === 0}>−{d.summary.removed}</span>
-    </span>
+    <!-- The +added ~changed −removed delta lives in the sticky summary header
+         (see Diffs.svelte) so "what changed" stays visible; this row carries the
+         structural scope. -->
     <!-- The diff was capped: counts above are the true totals, but this many
          resources were not rendered. The review here is partial. -->
     {#if d.truncated}

--- a/internal/web/src/lib/Overview.svelte
+++ b/internal/web/src/lib/Overview.svelte
@@ -63,28 +63,8 @@
      parent unmounts this view in the same flush, but guard rather than assert. -->
 {#if d}
 <div class="overview">
-  <div class="impact">
-    <span class="impact-pill"><strong>{d.impact.resources}</strong> resources</span>
-    <span class="impact-pill"><strong>{d.impact.parents}</strong> parents</span>
-    <span class="impact-pill"><strong>{d.impact.crds}</strong> CRDs</span>
-    {#if d.impact.namespaces?.length}
-      <span class="impact-pill"
-        ><strong>{d.impact.namespaces.length}</strong>
-        {d.impact.namespaces.length === 1 ? 'namespace' : 'namespaces'}</span
-      >
-    {/if}
-    <!-- The +added ~changed −removed delta lives in the sticky summary header
-         (see Diffs.svelte) so "what changed" stays visible; this row carries the
-         structural scope. -->
-    <!-- The diff was capped: counts above are the true totals, but this many
-         resources were not rendered. The review here is partial. -->
-    {#if d.truncated}
-      <span class="impact-pill trunc" title="This diff exceeded the render cap; {d.truncated} resource diffs were not rendered."
-        >{d.truncated} not shown</span
-      >
-    {/if}
-  </div>
-
+  <!-- The impact summary (scope counts + change delta) now rides in the sticky
+       summary header (see Diffs.svelte); this content is just the sections. -->
   <!-- Two columns on a wide pane (see .ov-grid). Flags first — render failures,
        then cautions — then the informational blast radius and image list, so the
        things a reviewer must act on lead and don't get buried. -->

--- a/internal/web/src/lib/Overview.svelte
+++ b/internal/web/src/lib/Overview.svelte
@@ -3,9 +3,24 @@
   import { store, diffIndex, openSel } from './store.svelte';
   import Icon from './Icon.svelte';
   import Copy from './Copy.svelte';
-  import { mdiAlert, mdiPackageVariantClosed, mdiAlertCircleOutline, mdiSitemapOutline } from './icons';
+  import {
+    mdiAlert,
+    mdiPackageVariantClosed,
+    mdiAlertCircleOutline,
+    mdiSitemapOutline,
+    mdiChevronDown,
+    mdiChevronRight,
+  } from './icons';
 
   const d = $derived(store.diff);
+
+  // Image changes can run long on a big bump; collapse the list past this many so
+  // it doesn't push the higher-signal cautions/failures down the pane. The count
+  // stays in the header and one click expands it; shorter lists render open.
+  // Diffs remounts per PR, so imagesOpen resets with each diff.
+  const imageCollapseThreshold = 6;
+  let imagesOpen = $state(false);
+  const imagesCollapsible = $derived((d?.images?.length ?? 0) > imageCollapseThreshold);
 
   // A warning's resource ("Kind ns/name") matches the diff resource's title, so
   // a warning can deep-link to the diff it flags. Null when the resource didn't
@@ -53,12 +68,21 @@
     <span class="impact-pill"><strong>{d.impact.parents}</strong> parents</span>
     <span class="impact-pill"><strong>{d.impact.crds}</strong> CRDs</span>
     {#if d.impact.namespaces?.length}
-      <span class="impact-pill"><strong>{d.impact.namespaces.length}</strong> namespaces</span>
+      <span class="impact-pill"
+        ><strong>{d.impact.namespaces.length}</strong>
+        {d.impact.namespaces.length === 1 ? 'namespace' : 'namespaces'}</span
+      >
     {/if}
-    <!-- Zero counts stay neutral; a tinted "+0" is noise. -->
-    <span class="impact-pill" class:add={d.summary.added > 0}>+{d.summary.added} added</span>
-    <span class="impact-pill" class:chg={d.summary.changed > 0}>{d.summary.changed} changed</span>
-    <span class="impact-pill" class:del={d.summary.removed > 0}>−{d.summary.removed} removed</span>
+    <!-- The change shape in one pill: +added ~changed −removed. Each part is tinted
+         only when non-zero — a tinted "+0" draws the eye to nothing. -->
+    <span
+      class="impact-delta"
+      title="{d.summary.added} added, {d.summary.changed} changed, {d.summary.removed} removed"
+    >
+      <span class="d-seg add" class:zero={d.summary.added === 0}>+{d.summary.added}</span>
+      <span class="d-seg chg" class:zero={d.summary.changed === 0}>~{d.summary.changed}</span>
+      <span class="d-seg del" class:zero={d.summary.removed === 0}>−{d.summary.removed}</span>
+    </span>
     <!-- The diff was capped: counts above are the true totals, but this many
          resources were not rendered. The review here is partial. -->
     {#if d.truncated}
@@ -68,77 +92,103 @@
     {/if}
   </div>
 
-  <!-- Blast radius: for each changed/failed app, how many downstream apps
-       declare a transitive spec.dependsOn on it — the reconciliation reach a
-       raw file diff can't show. Direct dependents are named; the count is the
-       full transitive closure. Absent when nothing changed depends-on anything. -->
-  {#if d.blastRadius?.length}
-    <section class="ov-section">
-      <h3><Icon path={mdiSitemapOutline} size={15} /> Blast radius</h3>
-      {#each d.blastRadius as br}
-        <div class="blast">
-          <span class="blast-parent">{br.parent}</span>
-          <span class="blast-count">{br.transitive} {br.transitive === 1 ? 'dependent' : 'dependents'}</span>
-          {#if br.direct?.length}
-            <div class="blast-deps">{br.direct.join(', ')}</div>
-          {/if}
-        </div>
-      {/each}
-    </section>
-  {/if}
+  <!-- Two columns on a wide pane (see .ov-grid). Flags first — render failures,
+       then cautions — then the informational blast radius and image list, so the
+       things a reviewer must act on lead and don't get buried. -->
+  <div class="ov-grid">
+    {#if d.failures?.length}
+      <section class="ov-section">
+        <h3>
+          <Icon path={mdiAlertCircleOutline} size={15} /> Render failures
+          <span class="ov-count">{d.failures.length}</span>
+        </h3>
+        {#each d.failures as f}
+          <div class="failure">
+            <span class="failure-parent">{f.parent}</span>
+            <div class="failure-msg">{f.message}</div>
+          </div>
+        {/each}
+      </section>
+    {/if}
 
-  {#if d.warnings?.length}
-    <section class="ov-section">
-      <h3>Cautions</h3>
-      {#each d.warnings as w}
-        {@const target = warningTarget(w.resource)}
-        <!-- Cautions whose resource rendered into the diff deep-link to it. -->
-        {#if target}
-          <button class="warning warning-link {w.level}" title="View the resource diff" onclick={() => openWarning(target)}>
-            {@render warningBody(w)}
+    {#if d.warnings?.length}
+      <section class="ov-section">
+        <h3>Cautions <span class="ov-count">{d.warnings.length}</span></h3>
+        {#each d.warnings as w}
+          {@const target = warningTarget(w.resource)}
+          <!-- Cautions whose resource rendered into the diff deep-link to it. -->
+          {#if target}
+            <button class="warning warning-link {w.level}" title="View the resource diff" onclick={() => openWarning(target)}>
+              {@render warningBody(w)}
+            </button>
+          {:else}
+            <div class="warning {w.level}">{@render warningBody(w)}</div>
+          {/if}
+        {/each}
+      </section>
+    {/if}
+
+    <!-- Blast radius: for each changed/failed app, how many downstream apps
+         declare a transitive spec.dependsOn on it — the reconciliation reach a
+         raw file diff can't show. Direct dependents are named; the count is the
+         full transitive closure. Absent when nothing changed depends-on anything. -->
+    {#if d.blastRadius?.length}
+      <section class="ov-section">
+        <h3>
+          <Icon path={mdiSitemapOutline} size={15} /> Blast radius
+          <span class="ov-count">{d.blastRadius.length}</span>
+        </h3>
+        {#each d.blastRadius as br}
+          <div class="blast">
+            <span class="blast-parent">{br.parent}</span>
+            <span class="blast-count">{br.transitive} {br.transitive === 1 ? 'dependent' : 'dependents'}</span>
+            {#if br.direct?.length}
+              <div class="blast-deps">{br.direct.join(', ')}</div>
+            {/if}
+          </div>
+        {/each}
+      </section>
+    {/if}
+
+    {#if d.images?.length}
+      <section class="ov-section">
+        <!-- A long image list collapses behind its count (imageCollapseThreshold)
+             so it doesn't crowd out the flags above; a short one renders open. -->
+        {#if imagesCollapsible}
+          <button class="ov-head" aria-expanded={imagesOpen} onclick={() => (imagesOpen = !imagesOpen)}>
+            <Icon path={imagesOpen ? mdiChevronDown : mdiChevronRight} size={14} />
+            <Icon path={mdiPackageVariantClosed} size={15} /> Image changes
+            <span class="ov-count">{d.images.length}</span>
           </button>
         {:else}
-          <div class="warning {w.level}">{@render warningBody(w)}</div>
+          <h3>
+            <Icon path={mdiPackageVariantClosed} size={15} /> Image changes
+            <span class="ov-count">{d.images.length}</span>
+          </h3>
         {/if}
-      {/each}
-    </section>
-  {/if}
-
-  {#if d.images?.length}
-    <section class="ov-section">
-      <h3><Icon path={mdiPackageVariantClosed} size={15} /> Image changes</h3>
-      <ul class="img-list">
-        {#each d.images as img}
-          <li class="img-change">
-            <div class="img-head">
-              <span class="img-name">{img.name}</span>
-              {#if img.to}<Copy text={imageRef(img.name, img.to)} label="Copy new image reference" />{/if}
-            </div>
-            <!-- ∅ = no reference on that side (image added/removed); tooltip spells it out. -->
-            <div class="img-delta">
-              <span class="img-ver from" title={img.from || 'not present before this change'}>{shortVer(img.from)}</span>
-              <span class="img-arrow">→</span>
-              <span class="img-ver to" title={img.to || 'not present after this change'}>{shortVer(img.to)}</span>
-            </div>
-            {#if img.refs?.length}
-              <div class="img-refs">{img.refs.join(', ')}</div>
-            {/if}
-          </li>
-        {/each}
-      </ul>
-    </section>
-  {/if}
-
-  {#if d.failures?.length}
-    <section class="ov-section">
-      <h3><Icon path={mdiAlertCircleOutline} size={15} /> Render failures</h3>
-      {#each d.failures as f}
-        <div class="failure">
-          <span class="failure-parent">{f.parent}</span>
-          <div class="failure-msg">{f.message}</div>
-        </div>
-      {/each}
-    </section>
-  {/if}
+        {#if !imagesCollapsible || imagesOpen}
+          <ul class="img-list">
+            {#each d.images as img}
+              <li class="img-change">
+                <div class="img-head">
+                  <span class="img-name">{img.name}</span>
+                  {#if img.to}<Copy text={imageRef(img.name, img.to)} label="Copy new image reference" />{/if}
+                </div>
+                <!-- ∅ = no reference on that side (image added/removed); tooltip spells it out. -->
+                <div class="img-delta">
+                  <span class="img-ver from" title={img.from || 'not present before this change'}>{shortVer(img.from)}</span>
+                  <span class="img-arrow">→</span>
+                  <span class="img-ver to" title={img.to || 'not present after this change'}>{shortVer(img.to)}</span>
+                </div>
+                {#if img.refs?.length}
+                  <div class="img-refs">{img.refs.join(', ')}</div>
+                {/if}
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </section>
+    {/if}
+  </div>
 </div>
 {/if}

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -916,14 +916,42 @@ test('zero counts stay neutral (impact pills) and hidden (diff header)', async (
   await page.routeWebSocket('**/ws', () => {});
   await page.goto('/#/pr/142');
 
-  await expect(page.locator('.impact-pill', { hasText: 'added' })).not.toHaveClass(/add/);
-  await expect(page.locator('.impact-pill', { hasText: 'removed' })).not.toHaveClass(/del/);
-  await expect(page.locator('.impact-pill', { hasText: 'changed' })).toHaveClass(/chg/);
+  // The compact delta pill: +0 added and −0 removed are muted (.zero), the
+  // non-zero changed segment keeps its tint.
+  await expect(page.locator('.d-seg.add')).toHaveClass(/zero/);
+  await expect(page.locator('.d-seg.del')).toHaveClass(/zero/);
+  await expect(page.locator('.d-seg.chg')).not.toHaveClass(/zero/);
 
   // The removed StatefulSet (+0 −5): the header hides the zero, like the tree.
   await page.goto('/#/pr/142/r2');
   await expect(page.locator('[data-sel="r2"] .res-counts .del')).toHaveText('-5');
   await expect(page.locator('[data-sel="r2"] .res-counts .add')).toHaveCount(0);
+});
+
+test('a long image list collapses behind its count and expands on click', async ({ page }) => {
+  // Past the collapse threshold the Image changes list is folded so it can't bury
+  // the higher-signal sections; the count stays visible and one click opens it.
+  const many = Array.from({ length: 9 }, (_, i) => ({
+    name: `ghcr.io/app-${i}`,
+    from: `v1.${i}.0`,
+    to: `v1.${i}.1`,
+    refs: [`Deployment apps/app-${i}`],
+  }));
+  const diff = { ...diffEnvelope.diff!, images: many };
+  await page.route('**/api/meta', (r) => r.fulfill({ json: defaultMeta }));
+  await page.route('**/api/prs', (r) => r.fulfill({ json: samplePRs }));
+  await page.route('**/api/prs/142/diff', (r) => r.fulfill({ json: { ...diffEnvelope, diff } }));
+  await page.routeWebSocket('**/ws', () => {});
+  await page.goto('/#/pr/142');
+
+  const head = page.locator('.ov-head', { hasText: 'Image changes' });
+  await expect(head).toContainText('9');
+  await expect(head).toHaveAttribute('aria-expanded', 'false');
+  await expect(page.locator('.img-list')).toHaveCount(0);
+
+  await head.click();
+  await expect(head).toHaveAttribute('aria-expanded', 'true');
+  await expect(page.locator('.img-change')).toHaveCount(9);
 });
 
 test('an open PR with cautions carries a red card edge', async ({ page }) => {


### PR DESCRIPTION
Client-only polish of the review summary, the first slice of the "tame the crowded overview" work. UI/CSS only — no API change.

## What changed (`Overview.svelte` + `app.css`)

- **Compact impact bar** — the separate `+N added` / `N changed` / `−N removed` pills fold into one delta pill `+N ~N −N`, each segment tinted only when non-zero (a tinted `+0` draws the eye to nothing). Namespace count is now singular/plural-correct.
- **Two-column-ish section grid** — the sections lay out in a responsive grid (`auto-fit`, `minmax(320px)`): one column when the pane is narrow, two or more when it's wide, and a lone section spans full width. Ordered flags-first — render failures, then cautions — ahead of the informational blast radius and image list, so what a reviewer must act on leads.
- **Collapsible image list** — past `imageCollapseThreshold` (6) the image list collapses behind its count so a big bump can't bury the flags; the count stays in the header and one click expands it (`aria-expanded`, focus-ring wired). Short lists render open. Every section header now carries its item count.

The code diffs are untouched — they still live in their own full-width per-resource sections below the summary. The two-column styling applies only to the summary's metadata blocks.

## Verification

`mise run ui-typecheck` (0 errors), `mise run ui-build`, and `mise run ui-test` — 65 Playwright tests pass. Updated the impact-pill test for the new delta markup and added a test for the image collapse/expand. No `.svelte`/`.css`/`.ts` formatter runs in lefthook, so no reformat churn.

## Scope

Pairs with #182 (image reconciliation). Does **not** touch the 23 MB payload or fold the removed-resource diffs — that's the next, server-side step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
