### PR TITLE
feat: CI check status in the PR list (poll + webhook push)

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,17 @@ konflate verifies the signature with the per-forge scheme automatically:
 | Forgejo | `X-Gitea-Signature`   | HMAC-SHA256, bare hex               |
 | GitLab  | `X-Gitlab-Token`      | constant-time compare of the secret |
 
+Select these events when creating the webhook. Pull-request events keep the PR
+list and diffs live; CI-status events drive the per-PR check indicator — without
+them the indicator still updates on the `KONFLATE_REFRESH_INTERVAL` poll, just
+not instantly:
+
+| Forge   | Pull-request events  | CI-status events                                    |
+| ------- | -------------------- | --------------------------------------------------- |
+| GitHub  | Pull requests        | Statuses, Check runs, Check suites                  |
+| Forgejo | Pull Request         | Commit status (+ Workflow Run / Job for Actions CI) |
+| GitLab  | Merge request events | Pipeline events (+ Job events)                      |
+
 Rate limiting is intentionally **not** built in — put konflate behind your
 reverse proxy / ingress and rate-limit there.
 

--- a/internal/api/checks.go
+++ b/internal/api/checks.go
@@ -1,0 +1,42 @@
+package api
+
+// CheckState is the rolled-up CI state of a pull request's head commit — the
+// red/amber/green a forge shows beside a PR. CheckNone ("") means no checks were
+// reported (or the fetch failed): the UI shows nothing rather than a misleading
+// green.
+type CheckState string
+
+const (
+	CheckNone    CheckState = ""
+	CheckPending CheckState = "pending"
+	CheckSuccess CheckState = "success"
+	CheckFailure CheckState = "failure"
+)
+
+// CheckRollup summarizes a PR head's CI checks for the PR list: one overall
+// State plus the counts behind it (for a tooltip like "3/4 passed").
+type CheckRollup struct {
+	State  CheckState `json:"state"`
+	Total  int        `json:"total"`
+	Passed int        `json:"passed"`
+	Failed int        `json:"failed"`
+}
+
+// Rollup derives the overall state from the per-check counts the providers tally:
+// any failure makes the rollup a failure, else any still-running check makes it
+// pending, else it is success when something passed — and none when nothing ran.
+// Mirrors how a forge collapses many checks into one PR-row indicator.
+func Rollup(passed, failed, pending int) CheckRollup {
+	r := CheckRollup{Total: passed + failed + pending, Passed: passed, Failed: failed}
+	switch {
+	case r.Total == 0:
+		r.State = CheckNone
+	case failed > 0:
+		r.State = CheckFailure
+	case pending > 0:
+		r.State = CheckPending
+	default:
+		r.State = CheckSuccess
+	}
+	return r
+}

--- a/internal/api/checks_test.go
+++ b/internal/api/checks_test.go
@@ -1,0 +1,30 @@
+package api
+
+import "testing"
+
+func TestRollup(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name                    string
+		passed, failed, pending int
+		want                    CheckState
+	}{
+		{"nothing ran", 0, 0, 0, CheckNone},
+		{"all green", 3, 0, 0, CheckSuccess},
+		{"a failure wins over passes and pendings", 2, 1, 3, CheckFailure},
+		{"pending when none failed", 2, 0, 1, CheckPending},
+		{"failure beats pending", 0, 1, 5, CheckFailure},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := Rollup(tc.passed, tc.failed, tc.pending)
+			if r.State != tc.want {
+				t.Errorf("state = %q, want %q", r.State, tc.want)
+			}
+			if r.Total != tc.passed+tc.failed+tc.pending || r.Passed != tc.passed || r.Failed != tc.failed {
+				t.Errorf("counts wrong: %+v", r)
+			}
+		})
+	}
+}

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -101,8 +101,11 @@ type Meta struct {
 // Event is a websocket message announcing a change to a PR's diff job, so the
 // UI can update that PR without polling.
 type Event struct {
-	Type   string    `json:"type"`             // "status" (job state changed) or "removed" (PR no longer open)
+	Type   string    `json:"type"`             // "status" (job state changed), "removed" (PR no longer open), or "checks" (CI rollup changed)
 	Number int       `json:"number"`           // the affected PR
 	Status JobStatus `json:"status,omitempty"` // set for "status" events
 	Error  string    `json:"error,omitempty"`
+	// Checks is set on "checks" events — the PR head's new CI rollup (State may be
+	// CheckNone, which clears the indicator). Absent on other event types.
+	Checks *CheckRollup `json:"checks,omitempty"`
 }

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -28,6 +28,11 @@ type PRStatus struct {
 	// Signals is a compact summary of the rendered diff, populated once the job
 	// is ready, so the PR list can show triage badges without loading each diff.
 	Signals *Signals `json:"signals,omitempty"`
+	// Checks is the rolled-up CI status of the PR head (the forge's red/amber/
+	// green), refreshed on the poll and on status webhooks — independent of the
+	// diff job. Nil when no checks were reported or the fetch failed, so the list
+	// shows no indicator rather than a misleading one.
+	Checks *CheckRollup `json:"checks,omitempty"`
 	// MergeCommand is the rendered "copy to merge" CLI command, set only for open
 	// PRs when the feature is enabled. konflate never runs it — the reviewer
 	// pastes it into their own shell.

--- a/internal/provider/checks_test.go
+++ b/internal/provider/checks_test.go
@@ -1,0 +1,65 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-github/v88/github"
+
+	"github.com/home-operations/konflate/internal/api"
+)
+
+// TestGitHubProvider_Checks merges legacy commit statuses with check runs into
+// one rollup: a single failure anywhere makes the head red, an unfinished run
+// keeps it pending.
+func TestGitHubProvider_Checks(t *testing.T) {
+	t.Parallel()
+	const sha = "deadbeefcafe"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/acme/web/commits/"+sha+"/status", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"state":"success","statuses":[{"state":"success"},{"state":"pending"}]}`))
+	})
+	mux.HandleFunc("/repos/acme/web/commits/"+sha+"/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"total_count":3,"check_runs":[` +
+			`{"status":"completed","conclusion":"success"},` +
+			`{"status":"completed","conclusion":"failure"},` +
+			`{"status":"in_progress"}]}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	raw := srv.URL + "/"
+	client, err := github.NewClient(github.WithURLs(&raw, &raw))
+	if err != nil {
+		t.Fatalf("github.NewClient: %v", err)
+	}
+	p := &githubProvider{client: client, owner: "acme", repo: "web"}
+
+	got, err := p.Checks(context.Background(), api.PR{Number: 7, HeadSHA: sha})
+	if err != nil {
+		t.Fatalf("Checks: %v", err)
+	}
+	// statuses: 1 success + 1 pending; runs: 1 success + 1 failure + 1 in_progress.
+	// → passed 2, failed 1, pending 2 (total 5), and a failure makes it red.
+	if got.State != api.CheckFailure {
+		t.Errorf("state = %q, want failure", got.State)
+	}
+	if got.Total != 5 || got.Passed != 2 || got.Failed != 1 {
+		t.Errorf("rollup = %+v, want total 5 / passed 2 / failed 1", got)
+	}
+}
+
+// TestGitHubProvider_ChecksNoSHA: a PR with no head SHA makes no API calls and
+// reports nothing (the client is never touched).
+func TestGitHubProvider_ChecksNoSHA(t *testing.T) {
+	t.Parallel()
+	p := &githubProvider{owner: "acme", repo: "web"}
+	got, err := p.Checks(context.Background(), api.PR{Number: 1})
+	if err != nil || got.State != api.CheckNone {
+		t.Fatalf("got %+v, %v; want none / no error", got, err)
+	}
+}

--- a/internal/provider/forgejo.go
+++ b/internal/provider/forgejo.go
@@ -77,6 +77,36 @@ func (p *forgejoProvider) GetPR(ctx context.Context, number int) (api.PR, error)
 	return forgejoToPR(pr), nil
 }
 
+// Checks rolls up the head commit's combined commit status. Forgejo/Gitea report
+// CI — including Forgejo Actions — as commit statuses, so the combined status is
+// the whole picture. "warning" is non-blocking and counts as passed; a 404 means
+// the commit simply has no statuses.
+func (p *forgejoProvider) Checks(ctx context.Context, pr api.PR) (api.CheckRollup, error) {
+	_ = ctx // see ListPRs: the Forgejo SDK can't take a context.
+	if pr.HeadSHA == "" {
+		return api.CheckRollup{}, nil
+	}
+	cs, resp, err := p.client.GetCombinedStatus(p.owner, p.repo, pr.HeadSHA)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return api.CheckRollup{}, nil
+		}
+		return api.CheckRollup{}, fmt.Errorf("forgejo: combined status #%d: %w", pr.Number, err)
+	}
+	var passed, failed, pending int
+	for _, s := range cs.Statuses {
+		switch string(s.State) {
+		case stateSuccess, "warning":
+			passed++
+		case "pending":
+			pending++
+		default: // error, failure
+			failed++
+		}
+	}
+	return api.Rollup(passed, failed, pending), nil
+}
+
 func forgejoToPR(pr *forgejo.PullRequest) api.PR {
 	var author, avatar string
 	if pr.Poster != nil {

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -68,6 +68,61 @@ func (p *githubProvider) GetPR(ctx context.Context, number int) (api.PR, error) 
 	return githubToPR(pr), nil
 }
 
+// Checks rolls up the head commit's CI: legacy commit statuses (GetCombinedStatus)
+// merged with check runs (GitHub Actions and other Checks-API apps report only as
+// check runs), since GitHub's own PR view combines the two. One page of each (100)
+// covers any realistic PR; nothing here paginates further.
+func (p *githubProvider) Checks(ctx context.Context, pr api.PR) (api.CheckRollup, error) {
+	if pr.HeadSHA == "" {
+		return api.CheckRollup{}, nil
+	}
+	var passed, failed, pending int
+
+	cs, _, err := p.client.Repositories.GetCombinedStatus(ctx, p.owner, p.repo, pr.HeadSHA, &github.ListOptions{PerPage: 100})
+	if err != nil {
+		return api.CheckRollup{}, fmt.Errorf("github: combined status #%d: %w", pr.Number, err)
+	}
+	for _, s := range cs.Statuses {
+		switch s.GetState() {
+		case stateSuccess:
+			passed++
+		case "pending":
+			pending++
+		default: // failure, error
+			failed++
+		}
+	}
+
+	runs, _, err := p.client.Checks.ListCheckRunsForRef(ctx, p.owner, p.repo, pr.HeadSHA,
+		&github.ListCheckRunsOptions{ListOptions: github.ListOptions{PerPage: 100}})
+	if err != nil {
+		return api.CheckRollup{}, fmt.Errorf("github: check runs #%d: %w", pr.Number, err)
+	}
+	for _, r := range runs.CheckRuns {
+		switch {
+		case r.GetStatus() != "completed":
+			pending++
+		case isPassingConclusion(r.GetConclusion()):
+			passed++
+		default:
+			failed++
+		}
+	}
+	return api.Rollup(passed, failed, pending), nil
+}
+
+// isPassingConclusion reports whether a completed check run's conclusion counts
+// as green. neutral and skipped are non-blocking; failure, timed_out, cancelled,
+// action_required, startup_failure and stale all count as a failure.
+func isPassingConclusion(conclusion string) bool {
+	switch conclusion {
+	case stateSuccess, "neutral", "skipped":
+		return true
+	default:
+		return false
+	}
+}
+
 func githubToPR(pr *github.PullRequest) api.PR {
 	labels := make([]api.Label, 0, len(pr.Labels))
 	for _, l := range pr.Labels {

--- a/internal/provider/gitlab.go
+++ b/internal/provider/gitlab.go
@@ -65,6 +65,38 @@ func (p *gitlabProvider) GetPR(ctx context.Context, number int) (api.PR, error) 
 	return gitlabToPR(&mr.BasicMergeRequest), nil
 }
 
+// Checks rolls up the head commit's CI statuses — GitLab pipeline jobs surface
+// as commit statuses. An allow_failure job that failed doesn't count against the
+// rollup; canceled and manual jobs are neither pass nor fail (they don't count).
+func (p *gitlabProvider) Checks(ctx context.Context, pr api.PR) (api.CheckRollup, error) {
+	if pr.HeadSHA == "" {
+		return api.CheckRollup{}, nil
+	}
+	statuses, _, err := p.client.Commits.GetCommitStatuses(p.project, pr.HeadSHA,
+		&gitlab.GetCommitStatusesOptions{ListOptions: gitlab.ListOptions{PerPage: 100}}, gitlab.WithContext(ctx))
+	if err != nil {
+		return api.CheckRollup{}, fmt.Errorf("gitlab: commit statuses !%d: %w", pr.Number, err)
+	}
+	var passed, failed, pending int
+	for _, s := range statuses {
+		switch s.Status {
+		case stateSuccess, "skipped":
+			passed++
+		case "failed":
+			if s.AllowFailure {
+				passed++
+			} else {
+				failed++
+			}
+		case "canceled", "manual":
+			// neither pass nor fail — leave out of the rollup
+		default: // created, waiting_for_resource, preparing, pending, running, scheduled
+			pending++
+		}
+	}
+	return api.Rollup(passed, failed, pending), nil
+}
+
 func gitlabToPR(mr *gitlab.BasicMergeRequest) api.PR {
 	author, avatar := "", ""
 	if mr.Author != nil {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -18,6 +18,10 @@ import (
 // (GitLab uses "opened"). The normalized api.PR.Open flag is derived from it.
 const stateOpen = "open"
 
+// stateSuccess is the "success" status string all three forges use in their
+// commit-status and check-run payloads (see each provider's Checks).
+const stateSuccess = "success"
+
 // ErrPRNotFound is returned by GetPR when the forge reports the pull/merge
 // request does not exist (HTTP 404) — it was deleted, not merged or closed. The
 // server reaps such a PR instead of retrying the lookup every refresh.
@@ -29,6 +33,10 @@ type Provider interface {
 	ListPRs(ctx context.Context) ([]api.PR, error)
 	// GetPR returns a single PR (head ref + SHA, base branch, metadata) by number.
 	GetPR(ctx context.Context, number int) (api.PR, error)
+	// Checks returns the rolled-up CI status of the PR's head commit — the
+	// combined commit statuses and/or check runs the forge shows as red/amber/
+	// green. A head with no checks yields a CheckNone rollup (no error).
+	Checks(ctx context.Context, pr api.PR) (api.CheckRollup, error)
 }
 
 // New builds the provider for the configured forge.

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -446,18 +446,22 @@ func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Re-render only the affected PR for content events; re-list when the
-	// open-PR set may have changed (opened/closed/...) or the payload is opaque.
-	if ev := webhook.Parse(s.cfg.Forge.Kind, r.Header, body); ev.PR > 0 && !ev.Relist {
+	// Route the verified event: a CI-status event refreshes just the matching
+	// PR's check rollup; a content event re-renders the affected PR; an open-set
+	// change (opened/closed/...) or an opaque payload re-lists.
+	switch ev := webhook.Parse(s.cfg.Forge.Kind, r.Header, body); {
+	case ev.HeadSHA != "":
+		go s.refreshChecksForSHA(s.runCtx, ev.HeadSHA)
+	case ev.PR > 0 && !ev.Relist:
 		go func() {
 			if err := s.refreshPR(s.runCtx, ev.PR, "webhook"); err != nil {
 				s.log.Warn("webhook: refresh PR failed", "pr", ev.PR, "error", err)
 			}
 		}()
-	} else {
-		// Coalesce: a chatty webhook (every check_run/status/push delivered) would
-		// otherwise spawn a goroutine + full ListPRs per event. requestRelist folds
-		// the burst into at most one in-flight relist plus one trailing run.
+	default:
+		// Coalesce: a chatty webhook (every push/opened delivered) would otherwise
+		// spawn a goroutine + full ListPRs per event. requestRelist folds the burst
+		// into at most one in-flight relist plus one trailing run.
 		s.requestRelist()
 	}
 	writeJSON(w, http.StatusAccepted, map[string]string{keyStatus: "accepted"})
@@ -538,6 +542,27 @@ func (s *Server) refreshChecks(ctx context.Context, prs []api.PR) {
 			r := rollup
 			s.hub.broadcast(api.Event{Type: "checks", Number: pr.Number, Checks: &r})
 		}
+	}
+}
+
+// refreshChecksForSHA handles a CI-status webhook: it finds the open PR whose
+// head is at sha and refreshes only that PR's check rollup, broadcasting if it
+// changed. A SHA matching no open PR (a status for a non-PR branch, or a PR we
+// don't track) is a no-op — deliberately no relist, so a chatty CI can't trigger
+// a forge re-list per delivered event.
+func (s *Server) refreshChecksForSHA(ctx context.Context, sha string) {
+	pr, ok := s.store.prByHeadSHA(sha)
+	if !ok {
+		return
+	}
+	rollup, err := s.prov.Checks(ctx, pr)
+	if err != nil {
+		s.log.Debug("webhook checks fetch failed", "pr", pr.Number, "error", err)
+		return
+	}
+	if s.store.setChecks(pr.Number, rollup) {
+		r := rollup
+		s.hub.broadcast(api.Event{Type: "checks", Number: pr.Number, Checks: &r})
 	}
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -518,6 +518,27 @@ func (s *Server) refreshList(ctx context.Context) {
 	// line per PR: at startup every PR is "new", which would be a burst of
 	// near-identical lines on a busy instance. The per-PR detail stays at debug.
 	s.log.Info("refresh listed", "prs", len(prs), "new", added, "advanced", advanced, "unhidden", unhidden)
+	s.refreshChecks(ctx, prs)
+}
+
+// refreshChecks fetches each open PR's CI rollup from the forge and stores it,
+// broadcasting only the rollups that actually changed so the list updates live
+// without a reload. This is the 30m poll's check pass; a status webhook (later)
+// refreshes a single PR the same way. Errors are logged per PR and never abort
+// the refresh — a forge that rate-limits the checks endpoint must not stop PRs
+// from listing.
+func (s *Server) refreshChecks(ctx context.Context, prs []api.PR) {
+	for _, pr := range prs {
+		rollup, err := s.prov.Checks(ctx, pr)
+		if err != nil {
+			s.log.Debug("checks fetch failed", "pr", pr.Number, "error", err)
+			continue
+		}
+		if s.store.setChecks(pr.Number, rollup) {
+			r := rollup
+			s.hub.broadcast(api.Event{Type: "checks", Number: pr.Number, Checks: &r})
+		}
+	}
 }
 
 // reconcileClosed handles PRs that have left the forge's open set. Each is

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -37,7 +37,14 @@ type fakeProvider struct {
 	details  map[int]api.PR // GetPR overrides (e.g. a departed PR's merged/closed state)
 	notFound map[int]bool   // numbers GetPR reports as deleted (provider.ErrPRNotFound)
 	listErr  error
-	listHook func() // optional seam invoked at the start of each ListPRs (set before use)
+	listHook func()                  // optional seam invoked at the start of each ListPRs (set before use)
+	checks   map[int]api.CheckRollup // per-PR CI rollup Checks returns (zero value → none)
+}
+
+func (f *fakeProvider) Checks(_ context.Context, pr api.PR) (api.CheckRollup, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.checks[pr.Number], nil
 }
 
 func (f *fakeProvider) ListPRs(context.Context) ([]api.PR, error) {

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -23,6 +23,10 @@ type job struct {
 	status  api.JobStatus
 	result  *api.DiffResult
 	signals *api.Signals
+	// checks is the PR head's CI rollup (the forge's red/amber/green), refreshed
+	// on the poll (and, later, status webhooks) independently of the diff job.
+	// nil = no checks reported or not yet fetched.
+	checks  *api.CheckRollup
 	errMsg  string
 	updated time.Time
 	// closedAt is set once the PR has left the forge's open set (merged); zero
@@ -166,6 +170,35 @@ func (s *store) upsertPR(pr api.PR, hidden bool) {
 	j.hidden = hidden
 	j.closedAt = time.Time{} // seen in the open set again (covers reopen)
 	j.updated = s.now()
+}
+
+// setChecks updates a PR's CI rollup, reporting whether it actually changed so
+// the caller only broadcasts real transitions. A CheckNone rollup clears it
+// (stored as nil, so the list omits the field). No-op for an unknown PR.
+func (s *store) setChecks(number int, r api.CheckRollup) (changed bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	j := s.jobs[number]
+	if j == nil {
+		return false
+	}
+	var next *api.CheckRollup
+	if r.State != api.CheckNone {
+		next = &r
+	}
+	if checksEqual(j.checks, next) {
+		return false
+	}
+	j.checks = next
+	return true
+}
+
+// checksEqual compares two rollup pointers by value (both nil → equal).
+func checksEqual(a, b *api.CheckRollup) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }
 
 // setStatus transitions a PR to status, recording its metadata if new. A PR
@@ -433,7 +466,7 @@ func (s *store) list() []api.PRStatus {
 		}
 		out = append(out, api.PRStatus{
 			PR: j.pr, Status: j.status, Error: j.errMsg, RefreshError: j.refreshErr,
-			UpdatedAt: j.updated, ClosedAt: closedAt, Signals: j.signals, Hidden: j.hidden,
+			UpdatedAt: j.updated, ClosedAt: closedAt, Signals: j.signals, Checks: j.checks, Hidden: j.hidden,
 		})
 	}
 	slices.SortFunc(out, func(a, b api.PRStatus) int { return cmp.Compare(b.Number, a.Number) }) // newest first

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -201,6 +201,20 @@ func checksEqual(a, b *api.CheckRollup) bool {
 	return *a == *b
 }
 
+// prByHeadSHA finds the open PR whose head commit is sha, for routing a
+// CI-status webhook to the right rollup refresh. Closed (merged/frozen) jobs are
+// skipped — a status for a merged PR's old head shouldn't revive it.
+func (s *store) prByHeadSHA(sha string) (api.PR, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, j := range s.jobs {
+		if j.closedAt.IsZero() && j.pr.HeadSHA == sha {
+			return j.pr, true
+		}
+	}
+	return api.PR{}, false
+}
+
 // setStatus transitions a PR to status, recording its metadata if new. A PR
 // already frozen on the merged shelf is left untouched, so a render that was
 // enqueued before the PR merged cannot drag it back into a live state.

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -885,6 +885,23 @@ button.sum-pill:hover {
   color: var(--muted);
   font-weight: 400;
 }
+/* CI status indicator (the forge's checks): a bare tinted icon — green check,
+   red ✕, amber hollow circle — that rides with the signal badges. Not a count
+   pill, so no border or background; the state class carries the color. */
+.check {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+}
+.check-success {
+  color: var(--ok);
+}
+.check-failure {
+  color: var(--danger);
+}
+.check-pending {
+  color: var(--warn);
+}
 
 /* ---- review shell ---------------------------------------------------- */
 .review {

--- a/internal/web/src/lib/List.svelte
+++ b/internal/web/src/lib/List.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { PRStatus } from './types';
+  import type { PRStatus, CheckRollup } from './types';
   import {
     store,
     filteredPRs,
@@ -36,11 +36,26 @@
     mdiChevronDown,
     mdiChevronUp,
     mdiCheckCircleOutline,
+    mdiCheckCircle,
+    mdiCloseCircleOutline,
+    mdiCircleOutline,
     mdiTrayFull,
     mdiUnfoldMoreHorizontal,
     mdiUnfoldLessHorizontal,
     mdiArrowUp,
   } from './icons';
+
+  // A PR-head CI rollup → an icon + tooltip. success/failure/pending map to the
+  // ok/danger/warn-tinted check / x / hollow-circle; pr.checks is absent when no
+  // checks ran, so the indicator only shows for a real state.
+  function checkIcon(state: string): string {
+    return state === 'success' ? mdiCheckCircle : state === 'failure' ? mdiCloseCircleOutline : mdiCircleOutline;
+  }
+  function checkTitle(c: CheckRollup): string {
+    if (c.state === 'success') return `Checks passed (${c.passed}/${c.total})`;
+    if (c.state === 'failure') return `Checks failing — ${c.failed} of ${c.total} failed`;
+    return `Checks running (${c.passed}/${c.total} done)`;
+  }
 
   // Two filter stages: the text query narrows `prs` (which the summary pills
   // count, so the counts hold steady while a pill is active), then the active
@@ -288,6 +303,11 @@
           <span class="labels"><Icon path={mdiTagOutline} size={12} />{#each pr.labels.slice(0, 4) as l}<span class="label">{#if labelColor(l)}<span class="label-dot" style:background-color={labelColor(l)}></span>{/if}{l.name}</span>{/each}</span>
         {/if}
         <span class="spacer"></span>
+        {#if pr.checks}
+          <span class="check check-{pr.checks.state}" title={checkTitle(pr.checks)}>
+            <Icon path={checkIcon(pr.checks.state)} size={14} />
+          </span>
+        {/if}
         {#if pr.signals}
           <span class="badges">
             {#if pr.refreshError}

--- a/internal/web/src/lib/icons.ts
+++ b/internal/web/src/lib/icons.ts
@@ -23,6 +23,7 @@ export {
   mdiCheckCircle,
   mdiCheckCircleOutline,
   mdiCircleOutline,
+  mdiCloseCircleOutline,
   mdiClose,
   mdiHistory,
   mdiKeyboardOutline,

--- a/internal/web/src/lib/store.svelte.ts
+++ b/internal/web/src/lib/store.svelte.ts
@@ -460,6 +460,13 @@ function onEvent(ev: WSEvent): void {
     store.prs = store.prs.filter((p) => p.number !== ev.number);
     return;
   }
+  // A CI rollup changed (poll or status webhook): update just that PR's checks,
+  // clearing them when the new state is none (so the indicator disappears).
+  if (ev.type === 'checks') {
+    const pr = store.prs.find((p) => p.number === ev.number);
+    if (pr) pr.checks = ev.checks.state ? ev.checks : undefined;
+    return;
+  }
   // ev is narrowed to the 'status' variant here — status is guaranteed present.
   const pr = store.prs.find((p) => p.number === ev.number);
   if (pr) {

--- a/internal/web/src/lib/types.ts
+++ b/internal/web/src/lib/types.ts
@@ -32,6 +32,17 @@ export interface Signals {
   failures: number;
 }
 
+// CheckRollup is the PR head's rolled-up CI status (the forge's red/amber/green).
+// state is '' (CheckNone) only on a clearing websocket event; PRStatus.checks is
+// absent when there are no checks, so a present rollup always has a real state.
+export type CheckState = 'pending' | 'success' | 'failure';
+export interface CheckRollup {
+  state: CheckState | '';
+  total: number;
+  passed: number;
+  failed: number;
+}
+
 export interface PRStatus extends PR {
   status: JobStatus;
   error?: string;
@@ -39,6 +50,7 @@ export interface PRStatus extends PR {
   updatedAt: string;
   closedAt?: string; // set once merged; UI groups these below open PRs
   signals?: Signals;
+  checks?: CheckRollup; // PR-head CI rollup; absent when no checks were reported
   mergeCommand?: string; // "copy to merge" CLI command; set only for open PRs when enabled
   hidden?: boolean; // excluded by the PR filter — listed (greyed, under the "hidden" pill) but never rendered
 }
@@ -168,7 +180,8 @@ export interface DiffEnvelope {
 // narrow on `ev.type` instead of asserting `status` is present.
 export type WSEvent =
   | { type: 'status'; number: number; status: JobStatus; error?: string }
-  | { type: 'removed'; number: number };
+  | { type: 'removed'; number: number }
+  | { type: 'checks'; number: number; checks: CheckRollup };
 
 export interface Meta {
   forge: string;

--- a/internal/web/tests/fixtures.ts
+++ b/internal/web/tests/fixtures.ts
@@ -31,6 +31,7 @@ export const samplePRs: PRStatus[] = [
     updatedAt: '2026-06-04T12:00:00Z',
     signals: { resources: 3, caution: 2, images: 1, failures: 1 },
     mergeCommand: 'gh pr merge 142 --repo acme/home-ops',
+    checks: { state: 'success', total: 4, passed: 4, failed: 0 },
   },
   {
     number: 138,
@@ -48,6 +49,7 @@ export const samplePRs: PRStatus[] = [
     status: 'running',
     updatedAt: '2026-06-04T11:30:00Z',
     mergeCommand: 'gh pr merge 138 --repo acme/home-ops',
+    checks: { state: 'pending', total: 3, passed: 1, failed: 0 },
   },
   {
     number: 131,
@@ -66,6 +68,7 @@ export const samplePRs: PRStatus[] = [
     error: 'render failed',
     updatedAt: '2026-06-04T10:00:00Z',
     mergeCommand: 'gh pr merge 131 --repo acme/home-ops',
+    checks: { state: 'failure', total: 2, passed: 1, failed: 1 },
   },
   {
     number: 128,

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -24,6 +24,16 @@ async function stubApi(page: Page, meta: Meta = defaultMeta) {
   });
 }
 
+test('PR list shows the forge CI check status per PR (green / amber / red)', async ({ page }) => {
+  await stubApi(page);
+  await page.goto('/');
+  const card = (n: number) => page.locator(`.card-shell[data-pr="${n}"]`);
+  await card(142).waitFor();
+  await expect(card(142).locator('.check-success')).toBeVisible(); // 4/4 passed
+  await expect(card(138).locator('.check-pending')).toBeVisible(); // still running
+  await expect(card(131).locator('.check-failure')).toBeVisible(); // one failed
+});
+
 test('list → review → single-page flow', async ({ page }) => {
   await stubApi(page);
   await page.goto('/');

--- a/internal/webhook/parse.go
+++ b/internal/webhook/parse.go
@@ -20,6 +20,11 @@ type Event struct {
 	// Relist is true when the set of open PRs may have changed (opened, closed,
 	// reopened, merged) — the caller should re-list rather than re-render one.
 	Relist bool
+	// HeadSHA is set for a CI-status event (commit status / check run / check
+	// suite / pipeline / job): the commit the status is for. The caller maps it
+	// to the open PR with that head and refreshes only its check rollup — no
+	// re-list, no re-render. Empty for PR and relist events.
+	HeadSHA string
 }
 
 // Parse extracts the affected PR from a verified webhook body. Anything it
@@ -29,11 +34,25 @@ func Parse(forge config.ForgeKind, header http.Header, body []byte) Event {
 	body = unwrapFormPayload(header, body)
 	switch forge {
 	case config.ForgeGitHub:
-		return parsePullRequest(header.Get("X-GitHub-Event") == "pull_request", body)
+		switch header.Get("X-GitHub-Event") {
+		case "pull_request":
+			return parsePullRequest(true, body)
+		case "status", "check_run", "check_suite":
+			return parseStatus(body)
+		default:
+			return Event{Relist: true}
+		}
 	case config.ForgeForgejo:
-		return parsePullRequest(header.Get("X-Gitea-Event") == "pull_request", body)
+		switch header.Get("X-Gitea-Event") {
+		case "pull_request":
+			return parsePullRequest(true, body)
+		case "status":
+			return parseStatus(body)
+		default:
+			return Event{Relist: true}
+		}
 	case config.ForgeGitLab:
-		return parseMergeRequest(body)
+		return parseGitLab(body)
 	}
 	return Event{Relist: true}
 }
@@ -96,4 +115,72 @@ func parseMergeRequest(body []byte) Event {
 		PR:     p.ObjectAttributes.IID,
 		Relist: slices.Contains([]string{"open", "reopen", "close", "merge"}, p.ObjectAttributes.Action),
 	}
+}
+
+// parseStatus pulls the head commit SHA from a CI-status event — GitHub
+// status/check_run/check_suite and Forgejo/Gitea status share enough shape that
+// one parser covers them: the SHA lives at .sha, .check_run.head_sha,
+// .check_suite.head_sha, or .commit.{sha,id}. The caller maps the SHA to the
+// open PR with that head and refreshes only its check rollup; an opaque payload
+// (no SHA) degrades to a relist, which is always safe.
+func parseStatus(body []byte) Event {
+	var p struct {
+		SHA      string `json:"sha"`
+		CheckRun struct {
+			HeadSHA string `json:"head_sha"`
+		} `json:"check_run"`
+		CheckSuite struct {
+			HeadSHA string `json:"head_sha"`
+		} `json:"check_suite"`
+		Commit struct {
+			ID  string `json:"id"`
+			SHA string `json:"sha"`
+		} `json:"commit"`
+	}
+	if err := json.Unmarshal(body, &p); err != nil {
+		return Event{Relist: true}
+	}
+	sha := cmp.Or(p.SHA, p.CheckRun.HeadSHA, p.CheckSuite.HeadSHA, p.Commit.SHA, p.Commit.ID)
+	if sha == "" {
+		return Event{Relist: true}
+	}
+	return Event{HeadSHA: sha}
+}
+
+// parseGitLab routes GitLab payloads by object_kind: a merge request affects the
+// open set (parseMergeRequest); a pipeline or job (build) carries the commit SHA
+// whose PR's checks we refresh; anything else relists.
+func parseGitLab(body []byte) Event {
+	var probe struct {
+		Kind string `json:"object_kind"`
+	}
+	if err := json.Unmarshal(body, &probe); err != nil {
+		return Event{Relist: true}
+	}
+	switch probe.Kind {
+	case "merge_request":
+		return parseMergeRequest(body)
+	case "pipeline":
+		var p struct {
+			ObjectAttributes struct {
+				SHA string `json:"sha"`
+			} `json:"object_attributes"`
+		}
+		if json.Unmarshal(body, &p) == nil && p.ObjectAttributes.SHA != "" {
+			return Event{HeadSHA: p.ObjectAttributes.SHA}
+		}
+	case "build": // GitLab's Job Hook
+		var p struct {
+			SHA    string `json:"sha"`
+			Commit struct {
+				SHA string `json:"sha"`
+			} `json:"commit"`
+		}
+		if json.Unmarshal(body, &p) == nil {
+			if sha := cmp.Or(p.SHA, p.Commit.SHA); sha != "" {
+				return Event{HeadSHA: sha}
+			}
+		}
+	}
+	return Event{Relist: true}
 }

--- a/internal/webhook/parse_test.go
+++ b/internal/webhook/parse_test.go
@@ -14,6 +14,46 @@ func hdr(k, v string) http.Header {
 	return h
 }
 
+func TestParse_StatusEvents(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		forge   config.ForgeKind
+		header  http.Header
+		body    string
+		wantSHA string
+	}{
+		{"github status", config.ForgeGitHub, hdr("X-GitHub-Event", "status"),
+			`{"sha":"abc123","state":"success"}`, "abc123"},
+		{"github check_run", config.ForgeGitHub, hdr("X-GitHub-Event", "check_run"),
+			`{"check_run":{"head_sha":"def456"}}`, "def456"},
+		{"github check_suite", config.ForgeGitHub, hdr("X-GitHub-Event", "check_suite"),
+			`{"check_suite":{"head_sha":"aaa111"}}`, "aaa111"},
+		{"forgejo status via commit.sha", config.ForgeForgejo, hdr("X-Gitea-Event", "status"),
+			`{"commit":{"sha":"bbb222"}}`, "bbb222"},
+		{"gitlab pipeline", config.ForgeGitLab, nil,
+			`{"object_kind":"pipeline","object_attributes":{"sha":"ccc333"}}`, "ccc333"},
+		{"gitlab job", config.ForgeGitLab, nil,
+			`{"object_kind":"build","sha":"ddd444"}`, "ddd444"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ev := Parse(tt.forge, tt.header, []byte(tt.body))
+			if ev.HeadSHA != tt.wantSHA {
+				t.Errorf("HeadSHA = %q, want %q", ev.HeadSHA, tt.wantSHA)
+			}
+			if ev.Relist || ev.PR != 0 {
+				t.Errorf("a status event must not relist or carry a PR, got %+v", ev)
+			}
+		})
+	}
+	// A status event with no SHA degrades to a relist (the safe fallback).
+	if ev := Parse(config.ForgeGitHub, hdr("X-GitHub-Event", "status"), []byte(`{}`)); !ev.Relist || ev.HeadSHA != "" {
+		t.Errorf("empty status payload should relist, got %+v", ev)
+	}
+}
+
 func TestParse(t *testing.T) {
 	t.Parallel()
 	cases := []struct {


### PR DESCRIPTION
Adds the forge's CI check status — the red/amber/green you see next to a PR on GitHub/GitLab/Forgejo — to konflate's PR list, refreshed by the existing poll and pushed live by webhooks. Works on all three forges.

## How it works

- **Provider** (`internal/provider`) — a new `Provider.Checks(ctx, pr)` returns a forge-agnostic `api.CheckRollup` (`failure > pending > success > none`, with counts). GitHub merges combined commit-statuses with check-runs; Forgejo reads the combined commit status; GitLab reads the head commit's pipeline job statuses.
- **Poll** — on the existing `KONFLATE_REFRESH_INTERVAL` (default 30m), `refreshList` fetches each open PR's rollup, stores it (so `/api/prs` carries it), and broadcasts a `checks` websocket event when it changes. No new loop, no webhook config required.
- **Push** — the webhook parser now recognizes each forge's CI-status events (GitHub `status`/`check_run`/`check_suite`, Forgejo `status`, GitLab pipeline/job), maps the head SHA to the open PR, and refreshes only that rollup — near-real-time, no relist, no re-render.
- **UI** — a GitHub-style status icon on each list row (green check / red ✕ / amber circle, counts in the tooltip), updated live on the `checks` event.

## Docs

`README.md` (the webhooks section) now lists, per forge, which events to enable in the repo webhook settings — pull-request events plus the CI-status events. Without the CI-status events the indicator still updates on the poll, just not instantly.

## Verification

`go build`, `go test ./...`, `golangci-lint` (0 issues), and `mise run ui-typecheck` / `ui-build` / `ui-test` (65 Playwright) all pass. New tests: rollup precedence, the GitHub status + check-run merge, the per-forge status-event parser, and the list icon per state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
