### PR TITLE
feat(writeback): retry transient forge writes with backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,13 @@ least one of the feature toggles:
 Set `KONFLATE_PUBLIC_URL` as well so the status and comment link back to the
 review; without it they're still posted, just without a link.
 
+Write-back is **best-effort**: each write runs off the render path, a transient
+forge failure (a 5xx, a blip, a brief outage) is retried a few times with
+backoff, and any write that still fails is re-attempted on the PR's next render —
+konflate logs it but never blocks or fails a render on it. Both writes are
+idempotent (the status is overwritten; the comment is found by its marker and
+edited), so a retry can't double-post.
+
 **This does not make konflate writable from the outside.** Its HTTP surface
 stays read-only — no request, authenticated or not, can trigger a write. The
 status and comment are posted only by konflate's own render loop, using a

--- a/internal/server/comment.go
+++ b/internal/server/comment.go
@@ -65,8 +65,9 @@ func newCommentTemplate(cfg *config.Config, log *slog.Logger) *template.Template
 func (s *Server) commentBody(env api.DiffEnvelope) string {
 	reviewURL := s.reviewURL(env.PR.Number)
 	admonitions := s.cfg.Forge.Kind == config.ForgeGitHub
+	defaultBody := func() string { return summaryMarkdown(env, reviewURL, admonitions) }
 	if s.commentTmpl == nil {
-		return summaryMarkdown(env, reviewURL, admonitions)
+		return defaultBody()
 	}
 	data := commentTemplateData{
 		PR:        env.PR,
@@ -79,7 +80,7 @@ func (s *Server) commentBody(env api.DiffEnvelope) string {
 	if err := s.commentTmpl.Execute(&b, data); err != nil {
 		s.log.Warn("custom PR comment template failed; using the default comment body",
 			"pr", env.PR.Number, "error", err)
-		return summaryMarkdown(env, reviewURL, admonitions)
+		return defaultBody()
 	}
 	return ensureMarker(env.PR.Number, b.String())
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -105,10 +105,17 @@ func New(cfg *config.Config, prov provider.Provider, eng Engine, ui fs.FS, log *
 // statusContext is the name konflate's commit status appears under on the PR.
 const statusContext = "konflate"
 
-// forgeWriteTimeout bounds a single forge write (a status or a comment) so a slow
-// or hung forge can't park a write-back goroutine until shutdown — these run
-// fire-and-forget off the render path. Generous: each is a small API call.
-const forgeWriteTimeout = 30 * time.Second
+// Write-back tuning. forgeWriteTimeout is the overall budget for one write
+// (across all attempts) so a slow or hung forge can't park a fire-and-forget
+// goroutine until shutdown. A brief forge outage is retried a few times with
+// exponential backoff rather than dropped — both writes are idempotent
+// (SetStatus overwrites; UpsertComment edits its own comment), so a retry after a
+// partial failure can't double-post. Beyond that the next render retries anyway.
+const (
+	forgeWriteTimeout  = 30 * time.Second // budget for one write-back, all attempts
+	forgeWriteAttempts = 3                // tries before giving up
+	forgeWriteBackoff  = time.Second      // base backoff, doubled each retry (1s, 2s, …)
+)
 
 // reportOutcome is the queue's terminal-outcome hook: it writes konflate's result
 // back to the forge — a commit status and/or a summary comment, per the enabled
@@ -126,16 +133,47 @@ func (s *Server) reportOutcome(pr api.PR, st api.JobStatus, sig *api.Signals, er
 }
 
 // writeBack runs one forge write off the render path: on its own goroutine,
-// bounded by forgeWriteTimeout, logging (never failing) on error so a write-back
-// problem never blocks or fails a render.
+// retried with backoff and bounded by forgeWriteTimeout, logging (never failing)
+// on giving up so a write-back problem never blocks or fails a render.
 func (s *Server) writeBack(kind string, number int, fn func(ctx context.Context) error) {
 	go func() {
 		ctx, cancel := context.WithTimeout(s.runCtx, forgeWriteTimeout)
 		defer cancel()
-		if err := fn(ctx); err != nil {
-			s.log.Warn("write-back failed", "kind", kind, "pr", number, "error", err)
+		err := retryWrite(ctx, forgeWriteAttempts, forgeWriteBackoff, func() error { return fn(ctx) })
+		if err != nil {
+			s.log.Warn("write-back failed", "kind", kind, "pr", number, "attempts", forgeWriteAttempts, "error", err)
 		}
 	}()
+}
+
+// retryWrite runs fn up to attempts times, returning as soon as it succeeds and
+// backing off exponentially (base, 2·base, …) between tries. The backoff respects
+// ctx — a cancelled or expired ctx stops further tries and returns fn's last
+// error. It retries any error: both write-backs are idempotent, and classifying
+// transient vs permanent across three forge SDKs would couple this to their error
+// types for little gain (a permanent error just wastes a couple of bounded tries).
+func retryWrite(ctx context.Context, attempts int, base time.Duration, fn func() error) error {
+	var err error
+	for attempt := 1; ; attempt++ {
+		if err = fn(); err == nil || attempt >= attempts {
+			return err
+		}
+		if !sleepCtx(ctx, base<<(attempt-1)) {
+			return err // ctx done during backoff — give up with the last error
+		}
+	}
+}
+
+// sleepCtx sleeps for d, or returns false early if ctx is done first.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
 }
 
 // postStatus writes konflate's commit status for a terminal render outcome.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -134,13 +134,15 @@ func (s *Server) reportOutcome(pr api.PR, st api.JobStatus, sig *api.Signals, er
 
 // writeBack runs one forge write off the render path: on its own goroutine,
 // retried with backoff and bounded by forgeWriteTimeout, logging (never failing)
-// on giving up so a write-back problem never blocks or fails a render.
+// on giving up so a write-back problem never blocks or fails a render. A write
+// cut short by shutdown (runCtx cancelled) is draining, not a failure, so it
+// isn't warned — matching the render queue's handling of context.Canceled.
 func (s *Server) writeBack(kind string, number int, fn func(ctx context.Context) error) {
 	go func() {
 		ctx, cancel := context.WithTimeout(s.runCtx, forgeWriteTimeout)
 		defer cancel()
-		err := retryWrite(ctx, forgeWriteAttempts, forgeWriteBackoff, func() error { return fn(ctx) })
-		if err != nil {
+		if err := retryWrite(ctx, forgeWriteAttempts, forgeWriteBackoff, func() error { return fn(ctx) }); err != nil &&
+			!errors.Is(ctx.Err(), context.Canceled) {
 			s.log.Warn("write-back failed", "kind", kind, "pr", number, "attempts", forgeWriteAttempts, "error", err)
 		}
 	}()

--- a/internal/server/writeback_test.go
+++ b/internal/server/writeback_test.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRetryWrite(t *testing.T) {
+	t.Parallel()
+
+	t.Run("succeeds on the first try", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		err := retryWrite(context.Background(), 3, time.Millisecond, func() error { calls++; return nil })
+		if err != nil || calls != 1 {
+			t.Fatalf("calls=%d err=%v; want 1 call, no error", calls, err)
+		}
+	})
+
+	t.Run("retries a transient failure then succeeds", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		err := retryWrite(context.Background(), 3, time.Millisecond, func() error {
+			calls++
+			if calls < 3 {
+				return errors.New("forge unavailable")
+			}
+			return nil
+		})
+		if err != nil || calls != 3 {
+			t.Fatalf("calls=%d err=%v; want 3 calls, no error", calls, err)
+		}
+	})
+
+	t.Run("gives up after the attempt cap, returning the last error", func(t *testing.T) {
+		t.Parallel()
+		want := errors.New("solar flare")
+		calls := 0
+		err := retryWrite(context.Background(), 3, time.Millisecond, func() error { calls++; return want })
+		if calls != 3 || !errors.Is(err, want) {
+			t.Fatalf("calls=%d err=%v; want 3 calls and the last error %v", calls, err, want)
+		}
+	})
+
+	t.Run("stops retrying once the context is done", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // already cancelled: the first try runs, the backoff bails
+		calls := 0
+		err := retryWrite(ctx, 5, time.Hour, func() error { calls++; return errors.New("down") })
+		if calls != 1 || err == nil {
+			t.Fatalf("calls=%d err=%v; want a single try and an error (no long sleep)", calls, err)
+		}
+	})
+}


### PR DESCRIPTION
A resilience + cleanliness pass over the merged write-back features (#186/#187).

## Retries (the main change)

Write-back was fire-and-forget: a transient forge failure — a 5xx, a network blip, a brief outage ("solar flare") — was logged at warn and **dropped**, recovered only when the PR next rendered (a webhook/push, or up to the refresh interval, default 30m, away).

Now `writeBack` retries with exponential backoff (3 attempts, 1s → 2s), bounded by the existing `forgeWriteTimeout`, before giving up — and the next render still re-attempts as a backstop. It covers **both** the commit status and the PR comment (both go through `writeBack`).

Safe because both writes are **idempotent**: `SetStatus` overwrites, and `UpsertComment` finds its own comment by the marker and edits it — so a retry after a partial failure can't double-post. `retryWrite` is forge-agnostic (it wraps the `func(ctx) error` all three writers already return) and respects `ctx` during backoff, so shutdown still drains promptly.

It retries on any error rather than classifying transient vs permanent: both ops are idempotent and the attempt count + backoff are bounded, so a permanent error just wastes a couple of cheap tries — and not coupling `writeBack` to three SDKs' error types keeps it clean.

## Also

Small DRY tidy: `commentBody` computed the default summary in two branches (no-template path + render-error fallback) — factored into a `defaultBody` closure.

## Tests

`retryWrite`: first-try success, retry-then-succeed, give-up-at-cap (returns the last error), and bail-without-sleeping on a cancelled context. `go test ./...`, `go vet`, `golangci-lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
