### PR TITLE
feat(chart): availability knobs (PDB, priorityClass, grace, startup probe)

### DIFF
--- a/charts/konflate/README.md
+++ b/charts/konflate/README.md
@@ -115,8 +115,12 @@ Kubernetes: `>=1.25.0-0`
 | persistence.size | string | `"5Gi"` | PVC size. |
 | persistence.storageClass | string | `""` | StorageClass for the created PVC. |
 | podAnnotations | object | `{}` | Annotations added to the pod. |
+| podDisruptionBudget.enabled | bool | `false` | Create a PodDisruptionBudget. ⚠️ With a single replica, the default `minAvailable: 1` makes a node drain block until you delete the pod yourself; set `maxUnavailable: 1` instead to let drains proceed. Off by default. |
+| podDisruptionBudget.maxUnavailable | string | `""` | Maximum pods that may be unavailable; takes precedence over `minAvailable` when set. |
+| podDisruptionBudget.minAvailable | int | `1` | Minimum pods that must stay available. Used unless `maxUnavailable` is set. |
 | podLabels | object | `{}` | Labels added to the pod. |
 | podSecurityContext | object | `{"fsGroup":65532,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod-level securityContext (runs as non-root uid/gid 65532 with the RuntimeDefault seccomp profile). |
+| priorityClassName | string | `""` | PriorityClass for the pod, so konflate is less likely to be preempted/evicted under node pressure. Empty uses the cluster default. |
 | readinessProbe | object | `{"httpGet":{"path":"/readyz","port":"http"},"initialDelaySeconds":5,"periodSeconds":10}` | Readiness probe. |
 | replicaCount | int | `1` | Replica count; konflate is single-instance, so 0 or 1 only (a value >1 is rejected at render time). |
 | resources | object | `{"limits":{"memory":"1Gi"},"requests":{"cpu":"50m","memory":"256Mi"}}` | Pod resource requests/limits. The memory limit is the hard ceiling: it drives GOMEMLIMIT (90%) so the GC reclaims before the kernel OOM-kills a runaway render. Default bounds memory out of the box; raise it for very large clusters. |
@@ -134,6 +138,8 @@ Kubernetes: `>=1.25.0-0`
 | serviceAccount.automount | bool | `false` | Automount the ServiceAccount API token (off by default: konflate talks to forges, not the cluster API). |
 | serviceAccount.create | bool | `true` | Create a ServiceAccount. |
 | serviceAccount.name | string | `""` | ServiceAccount name; generated from the release name if empty. |
+| startupProbe | object | `{}` | Startup probe (optional). Gates liveness/readiness while konflate starts — useful when a large persisted store (see `persistence`) makes the cold start slow, since it loads before serving. Empty disables it. |
+| terminationGracePeriodSeconds | int | `30` | Grace period for a clean shutdown. konflate drains in-flight renders and closes the HTTP/websocket servers on SIGTERM (it caps its own shutdown near 15s), so the default is ample; raise it only if you expect longer drains. |
 | tests.image.pullPolicy | string | `"IfNotPresent"` | `helm test` image pull policy. |
 | tests.image.repository | string | `"mirror.gcr.io/busybox"` | `helm test` pod image; needs a shell with wget (konflate's own image is distroless). |
 | tests.image.tag | string | `"1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d"` | `helm test` image, pinned as `tag@sha256:digest` so Renovate bumps the tag and its digest together. |

--- a/charts/konflate/README.md
+++ b/charts/konflate/README.md
@@ -116,8 +116,8 @@ Kubernetes: `>=1.25.0-0`
 | persistence.storageClass | string | `""` | StorageClass for the created PVC. |
 | podAnnotations | object | `{}` | Annotations added to the pod. |
 | podDisruptionBudget.enabled | bool | `false` | Create a PodDisruptionBudget. ⚠️ With a single replica, the default `minAvailable: 1` makes a node drain block until you delete the pod yourself; set `maxUnavailable: 1` instead to let drains proceed. Off by default. |
-| podDisruptionBudget.maxUnavailable | string | `""` | Maximum pods that may be unavailable; takes precedence over `minAvailable` when set. |
-| podDisruptionBudget.minAvailable | int | `1` | Minimum pods that must stay available. Used unless `maxUnavailable` is set. |
+| podDisruptionBudget.maxUnavailable | string | `""` | Maximum pods that may be unavailable, as a count or percentage; takes precedence over `minAvailable` when set. @schema type: [integer, string] @schema |
+| podDisruptionBudget.minAvailable | int | `1` | Minimum pods that must stay available, as a count or percentage. Used unless `maxUnavailable` is set. @schema type: [integer, string] @schema |
 | podLabels | object | `{}` | Labels added to the pod. |
 | podSecurityContext | object | `{"fsGroup":65532,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod-level securityContext (runs as non-root uid/gid 65532 with the RuntimeDefault seccomp profile). |
 | priorityClassName | string | `""` | PriorityClass for the pod, so konflate is less likely to be preempted/evicted under node pressure. Empty uses the cluster default. |

--- a/charts/konflate/templates/deployment.tpl
+++ b/charts/konflate/templates/deployment.tpl
@@ -48,6 +48,10 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "konflate.serviceAccountName" . | quote }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ tpl . $ | quote }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       securityContext:
         {{- tpl (toYaml .Values.podSecurityContext) $ | nindent 8 }}
       containers:
@@ -182,6 +186,10 @@ spec:
             - name: metrics
               containerPort: 9090
               protocol: TCP
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
           livenessProbe:
             {{- tpl (toYaml .Values.livenessProbe) $ | nindent 12 }}
           readinessProbe:

--- a/charts/konflate/templates/pdb.tpl
+++ b/charts/konflate/templates/pdb.tpl
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "konflate.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "konflate.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "konflate.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/konflate/tests/deployment_test.yaml
+++ b/charts/konflate/tests/deployment_test.yaml
@@ -87,6 +87,36 @@ tests:
           path: spec.template.spec.containers[0].resources.limits.memory
           value: 1Gi
 
+  - it: defaults the grace period and omits priorityClassName / startupProbe
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 30
+      - notExists:
+          path: spec.template.spec.priorityClassName
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe
+
+  - it: sets priorityClassName, grace, and a startup probe when configured
+    set:
+      priorityClassName: high-priority
+      terminationGracePeriodSeconds: 60
+      startupProbe:
+        httpGet:
+          path: /readyz
+          port: http
+        failureThreshold: 30
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: high-priority
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 60
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 30
+
   - it: omits KONFLATE_PR_FILTER_EXPR when prFilterExpr is empty (default applied in-binary)
     asserts:
       - notContains:

--- a/charts/konflate/tests/pdb_test.yaml
+++ b/charts/konflate/tests/pdb_test.yaml
@@ -1,0 +1,38 @@
+suite: poddisruptionbudget
+templates:
+  - pdb.tpl
+set:
+  config.repo: github://owner/repo
+tests:
+  - it: renders no PDB by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a PDB with minAvailable when enabled
+    set:
+      podDisruptionBudget.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-konflate
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - notExists:
+          path: spec.maxUnavailable
+
+  - it: prefers maxUnavailable when it is set
+    set:
+      podDisruptionBudget.enabled: true
+      podDisruptionBudget.maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable

--- a/charts/konflate/values.schema.json
+++ b/charts/konflate/values.schema.json
@@ -632,15 +632,23 @@
         },
         "maxUnavailable": {
           "default": "",
-          "description": "Maximum pods that may be unavailable; takes precedence over `minAvailable` when set.",
+          "description": "Maximum pods that may be unavailable, as a count or percentage; takes precedence over `minAvailable` when set.",
+          "required": [],
           "title": "maxUnavailable",
-          "type": "string"
+          "type": [
+            "integer",
+            "string"
+          ]
         },
         "minAvailable": {
           "default": 1,
-          "description": "Minimum pods that must stay available. Used unless `maxUnavailable` is set.",
+          "description": "Minimum pods that must stay available, as a count or percentage. Used unless `maxUnavailable` is set.",
+          "required": [],
           "title": "minAvailable",
-          "type": "integer"
+          "type": [
+            "integer",
+            "string"
+          ]
         }
       },
       "required": [],

--- a/charts/konflate/values.schema.json
+++ b/charts/konflate/values.schema.json
@@ -621,6 +621,32 @@
       "title": "podAnnotations",
       "type": "object"
     },
+    "podDisruptionBudget": {
+      "description": "konflate runs a single replica (in-memory state; see replicaCount), so this guards only against *voluntary* disruption — node drains, autoscaler scale-down.",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Create a PodDisruptionBudget. ⚠️ With a single replica, the default `minAvailable: 1` makes a node drain block until you delete the pod yourself; set `maxUnavailable: 1` instead to let drains proceed. Off by default.",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "maxUnavailable": {
+          "default": "",
+          "description": "Maximum pods that may be unavailable; takes precedence over `minAvailable` when set.",
+          "title": "maxUnavailable",
+          "type": "string"
+        },
+        "minAvailable": {
+          "default": 1,
+          "description": "Minimum pods that must stay available. Used unless `maxUnavailable` is set.",
+          "title": "minAvailable",
+          "type": "integer"
+        }
+      },
+      "required": [],
+      "title": "podDisruptionBudget",
+      "type": "object"
+    },
     "podLabels": {
       "description": "Labels added to the pod.",
       "required": [],
@@ -666,6 +692,12 @@
       "required": [],
       "title": "podSecurityContext",
       "type": "object"
+    },
+    "priorityClassName": {
+      "default": "",
+      "description": "PriorityClass for the pod, so konflate is less likely to be preempted/evicted under node pressure. Empty uses the cluster default.",
+      "title": "priorityClassName",
+      "type": "string"
     },
     "readinessProbe": {
       "description": "Readiness probe.",
@@ -881,6 +913,18 @@
       "required": [],
       "title": "serviceAccount",
       "type": "object"
+    },
+    "startupProbe": {
+      "description": "Startup probe (optional). Gates liveness/readiness while konflate starts — useful when a large persisted store (see `persistence`) makes the cold start slow, since it loads before serving. Empty disables it.",
+      "required": [],
+      "title": "startupProbe",
+      "type": "object"
+    },
+    "terminationGracePeriodSeconds": {
+      "default": 30,
+      "description": "Grace period for a clean shutdown. konflate drains in-flight renders and closes the HTTP/websocket servers on SIGTERM (it caps its own shutdown near 15s), so the default is ample; raise it only if you expect longer drains.",
+      "title": "terminationGracePeriodSeconds",
+      "type": "integer"
     },
     "tests": {
       "description": "Config for the chart's `helm test` hook — a one-shot pod that curls the Service's /readyz to prove the release serves. Used only by `helm test`, never the workload.",

--- a/charts/konflate/values.yaml
+++ b/charts/konflate/values.yaml
@@ -383,9 +383,15 @@ priorityClassName: ""
 podDisruptionBudget:
   # -- Create a PodDisruptionBudget. ⚠️ With a single replica, the default `minAvailable: 1` makes a node drain block until you delete the pod yourself; set `maxUnavailable: 1` instead to let drains proceed. Off by default.
   enabled: false
-  # -- Minimum pods that must stay available. Used unless `maxUnavailable` is set.
+  # -- Minimum pods that must stay available, as a count or percentage. Used unless `maxUnavailable` is set.
+  # @schema
+  # type: [integer, string]
+  # @schema
   minAvailable: 1
-  # -- Maximum pods that may be unavailable; takes precedence over `minAvailable` when set.
+  # -- Maximum pods that may be unavailable, as a count or percentage; takes precedence over `minAvailable` when set.
+  # @schema
+  # type: [integer, string]
+  # @schema
   maxUnavailable: ""
 
 # -- Additional volumes on the Deployment.

--- a/charts/konflate/values.yaml
+++ b/charts/konflate/values.yaml
@@ -340,6 +340,16 @@ readinessProbe:
     port: http
   initialDelaySeconds: 5
   periodSeconds: 10
+# -- Startup probe (optional). Gates liveness/readiness while konflate starts — useful when a large persisted store (see `persistence`) makes the cold start slow, since it loads before serving. Empty disables it.
+startupProbe: {}
+#  httpGet:
+#    path: /readyz
+#    port: http
+#  periodSeconds: 5
+#  failureThreshold: 30
+
+# -- Grace period for a clean shutdown. konflate drains in-flight renders and closes the HTTP/websocket servers on SIGTERM (it caps its own shutdown near 15s), so the default is ample; raise it only if you expect longer drains.
+terminationGracePeriodSeconds: 30
 
 monitoring:
   serviceMonitor:
@@ -366,6 +376,17 @@ nodeSelector: {}
 tolerations: []
 # -- Affinity rules for pod scheduling.
 affinity: {}
+# -- PriorityClass for the pod, so konflate is less likely to be preempted/evicted under node pressure. Empty uses the cluster default.
+priorityClassName: ""
+
+# konflate runs a single replica (in-memory state; see replicaCount), so this guards only against *voluntary* disruption — node drains, autoscaler scale-down.
+podDisruptionBudget:
+  # -- Create a PodDisruptionBudget. ⚠️ With a single replica, the default `minAvailable: 1` makes a node drain block until you delete the pod yourself; set `maxUnavailable: 1` instead to let drains proceed. Off by default.
+  enabled: false
+  # -- Minimum pods that must stay available. Used unless `maxUnavailable` is set.
+  minAvailable: 1
+  # -- Maximum pods that may be unavailable; takes precedence over `minAvailable` when set.
+  maxUnavailable: ""
 
 # -- Additional volumes on the Deployment.
 volumes: []


### PR DESCRIPTION
The Tier-1 availability levers from the HA discussion. konflate is single-instance by design (in-memory authoritative state, RWO cache volume, in-process locks), so "HA" here is fast, lossless recovery — these knobs help with that without any re-architecture. **All default to today's behaviour.**

## Added (chart only)

- **`podDisruptionBudget`** (off by default) — guards *voluntary* disruption (node drains, autoscaler scale-down). `minAvailable` defaults to `1`; `maxUnavailable` takes precedence when set. ⚠️ Documented caveat: with a single replica, `minAvailable: 1` makes a drain block until you delete the pod yourself — set `maxUnavailable: 1` if you'd rather let drains proceed.
- **`priorityClassName`** — keep konflate from being preempted/evicted under node pressure.
- **`terminationGracePeriodSeconds`** (default `30`) — konflate already drains in-flight renders and closes its servers on SIGTERM, capping its own shutdown near 15s, so the default is ample; exposed for longer drains.
- **`startupProbe`** (optional) — gate liveness/readiness while a large persisted store loads on a cold start (konflate loads it before serving).

Liveness/readiness were already configurable values, so they're untouched. The biggest recovery lever — `persistence` (reload diffs/mirror/shelf instead of cold re-render) — already exists; pair these with it on a fast RWO storage class.

## Testing

- New `pdb` helm-unittest suite: absent by default, `minAvailable` when enabled, `maxUnavailable` override wins.
- Deployment suite: default grace + no priorityClass/startupProbe, and all three wired when set.
- Regenerated chart README + `values.schema.json`; `helm lint`, `helm unittest` (54/54), `helm template` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
