### PR TITLE
feat(writeback): verify the write credential at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,12 @@ konflate logs it but never blocks or fails a render on it. Both writes are
 idempotent (the status is overwritten; the comment is found by its marker and
 edited), so a retry can't double-post.
 
+konflate **checks the write credential once at startup**. A permanent rejection
+(a 401/403/404 — a bad token, missing permission, or a wrong GitHub App
+installation / unreachable repo) disables write-back with a single clear log line
+rather than warning on every render; a transient failure leaves it enabled to
+recover on a later render.
+
 **This does not make konflate writable from the outside.** Its HTTP surface
 stays read-only — no request, authenticated or not, can trigger a write. The
 status and comment are posted only by konflate's own render loop, using a

--- a/internal/provider/writer.go
+++ b/internal/provider/writer.go
@@ -238,9 +238,9 @@ func (w *githubWriter) Verify(ctx context.Context) error {
 	}
 	// A GitHub App mints its installation token on this first call; if that mint
 	// fails the github.Response is nil and the status is on the ghinstallation error.
-	var he *ghinstallation.HTTPError
-	if status == 0 && errors.As(err, &he) && he.Response != nil {
-		status = he.Response.StatusCode
+	var instErr *ghinstallation.HTTPError
+	if status == 0 && errors.As(err, &instErr) && instErr.Response != nil {
+		status = instErr.Response.StatusCode
 	}
 	return rejectedIf(status, fmt.Errorf("github: verify %s/%s: %w", w.owner, w.repo, err))
 }

--- a/internal/provider/writer.go
+++ b/internal/provider/writer.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -45,6 +46,29 @@ type Writer interface {
 	// UpsertComment posts body as a PR comment, or edits konflate's existing
 	// comment in place — the one whose body contains marker — if there is one.
 	UpsertComment(ctx context.Context, pr api.PR, marker, body string) error
+	// Verify checks the credential can reach the repo, exercising the full auth
+	// path (for a GitHub App, minting the installation token). It returns nil on
+	// success, an ErrWriteAuthRejected-wrapped error for a permanent 401/403/404,
+	// or a plain (transient) error otherwise.
+	Verify(ctx context.Context) error
+}
+
+// ErrWriteAuthRejected marks a write-back credential the forge rejected in a way
+// that won't fix itself — a 401/403/404 (bad token, missing permission, a wrong
+// GitHub App installation, or an unreachable repo), as opposed to a transient 5xx
+// or network error. The server disables write-back on it and keeps trying on
+// transient failures.
+var ErrWriteAuthRejected = errors.New("provider: write-back credential rejected")
+
+// rejectedIf wraps err as ErrWriteAuthRejected for a permanent auth status
+// (401/403/404); any other status (or 0/unknown) stays a plain transient error.
+func rejectedIf(status int, err error) error {
+	switch status {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+		return fmt.Errorf("%w (HTTP %d): %w", ErrWriteAuthRejected, status, err)
+	default:
+		return err
+	}
 }
 
 // NewWriter builds the forge Writer from the configured write credential, or a
@@ -203,6 +227,24 @@ func (w *githubWriter) UpsertComment(ctx context.Context, pr api.PR, marker, bod
 	return nil
 }
 
+func (w *githubWriter) Verify(ctx context.Context) error {
+	_, resp, err := w.client.Repositories.Get(ctx, w.owner, w.repo)
+	if err == nil {
+		return nil
+	}
+	status := 0
+	if resp != nil {
+		status = resp.StatusCode
+	}
+	// A GitHub App mints its installation token on this first call; if that mint
+	// fails the github.Response is nil and the status is on the ghinstallation error.
+	var he *ghinstallation.HTTPError
+	if status == 0 && errors.As(err, &he) && he.Response != nil {
+		status = he.Response.StatusCode
+	}
+	return rejectedIf(status, fmt.Errorf("github: verify %s/%s: %w", w.owner, w.repo, err))
+}
+
 // --- Forgejo ---
 
 type forgejoWriter struct {
@@ -266,6 +308,18 @@ func (w *forgejoWriter) UpsertComment(_ context.Context, pr api.PR, marker, body
 	return nil
 }
 
+func (w *forgejoWriter) Verify(_ context.Context) error {
+	_, resp, err := w.client.GetRepo(w.owner, w.repo)
+	if err == nil {
+		return nil
+	}
+	status := 0
+	if resp != nil {
+		status = resp.StatusCode
+	}
+	return rejectedIf(status, fmt.Errorf("forgejo: verify %s/%s: %w", w.owner, w.repo, err))
+}
+
 // --- GitLab ---
 
 type gitlabWriter struct {
@@ -325,6 +379,18 @@ func (w *gitlabWriter) UpsertComment(ctx context.Context, pr api.PR, marker, bod
 		return fmt.Errorf("gitlab: create note !%d: %w", pr.Number, err)
 	}
 	return nil
+}
+
+func (w *gitlabWriter) Verify(ctx context.Context) error {
+	_, resp, err := w.client.Projects.GetProject(w.project, nil, gitlab.WithContext(ctx))
+	if err == nil {
+		return nil
+	}
+	status := 0
+	if resp != nil {
+		status = resp.StatusCode
+	}
+	return rejectedIf(status, fmt.Errorf("gitlab: verify %s: %w", w.project, err))
 }
 
 // gitlabBuildState maps konflate's state to GitLab's pipeline build state

--- a/internal/provider/writer_test.go
+++ b/internal/provider/writer_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -415,5 +416,102 @@ func TestGitlabBuildState(t *testing.T) {
 		if got := gitlabBuildState(in); got != want {
 			t.Errorf("gitlabBuildState(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+// statusServer answers every request with the given HTTP status and an empty JSON
+// body — enough to exercise each writer's Verify (a repo/project GET).
+func statusServer(t *testing.T, status int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestRejectedIf(t *testing.T) {
+	t.Parallel()
+	base := errors.New("boom")
+	for _, s := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound} {
+		if err := rejectedIf(s, base); !errors.Is(err, ErrWriteAuthRejected) || !errors.Is(err, base) {
+			t.Errorf("status %d: want ErrWriteAuthRejected wrapping the cause, got %v", s, err)
+		}
+	}
+	for _, s := range []int{0, 200, 429, 500, 503} {
+		if err := rejectedIf(s, base); errors.Is(err, ErrWriteAuthRejected) || !errors.Is(err, base) {
+			t.Errorf("status %d: want a plain (transient) error, got %v", s, err)
+		}
+	}
+}
+
+// verifyCases is the shared status→result table for every forge's Verify.
+var verifyCases = []struct {
+	name             string
+	status           int
+	wantErr, wantRej bool
+}{
+	{"ok", http.StatusOK, false, false},
+	{"not found", http.StatusNotFound, true, true},
+	{"forbidden", http.StatusForbidden, true, true},
+	{"server error", http.StatusInternalServerError, true, false},
+}
+
+func checkVerify(t *testing.T, err error, wantErr, wantRej bool) {
+	t.Helper()
+	if wantErr != (err != nil) {
+		t.Fatalf("err = %v, wantErr = %v", err, wantErr)
+	}
+	if got := errors.Is(err, ErrWriteAuthRejected); got != wantRej {
+		t.Errorf("ErrWriteAuthRejected = %v, want %v (err = %v)", got, wantRej, err)
+	}
+}
+
+func TestGitHubWriter_Verify(t *testing.T) {
+	t.Parallel()
+	for _, tc := range verifyCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := statusServer(t, tc.status)
+			wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web"}
+			checkVerify(t, wr.Verify(context.Background()), tc.wantErr, tc.wantRej)
+		})
+	}
+}
+
+func TestGitlabWriter_Verify(t *testing.T) {
+	t.Parallel()
+	for _, tc := range verifyCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := statusServer(t, tc.status)
+			client, err := gitlab.NewClient("tok", gitlab.WithBaseURL(srv.URL))
+			if err != nil {
+				t.Fatalf("gitlab.NewClient: %v", err)
+			}
+			wr := &gitlabWriter{client: client, project: "acme/web"}
+			checkVerify(t, wr.Verify(context.Background()), tc.wantErr, tc.wantRej)
+		})
+	}
+}
+
+func TestForgejoWriter_Verify(t *testing.T) {
+	t.Parallel()
+	for _, tc := range verifyCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := statusServer(t, tc.status)
+			client, err := forgejo.NewClient(srv.URL,
+				forgejo.SetForgejoVersion(forgejo.Version()), forgejo.SetToken("tok"))
+			if err != nil {
+				t.Fatalf("forgejo.NewClient: %v", err)
+			}
+			wr := &forgejoWriter{client: client, owner: "acme", repo: "web"}
+			checkVerify(t, wr.Verify(context.Background()), tc.wantErr, tc.wantRej)
+		})
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -115,7 +115,29 @@ const (
 	forgeWriteTimeout  = 30 * time.Second // budget for one write-back, all attempts
 	forgeWriteAttempts = 3                // tries before giving up
 	forgeWriteBackoff  = time.Second      // base backoff, doubled each retry (1s, 2s, …)
+	forgeVerifyTimeout = 10 * time.Second // startup credential check; don't block boot longer
 )
+
+// verifyWriteBack checks the write credential reaches the forge before any render
+// posts. A permanent rejection (401/403/404 — bad token, missing permission, a
+// wrong GitHub App installation, or an unreachable repo) disables write-back with
+// a single error; a transient failure is logged and write-back left on to recover.
+// Called once from Run before the queue starts, so flipping s.writer is race-free.
+func (s *Server) verifyWriteBack(ctx context.Context) {
+	vctx, cancel := context.WithTimeout(ctx, forgeVerifyTimeout)
+	defer cancel()
+	switch err := s.writer.Verify(vctx); {
+	case err == nil:
+		s.log.Info("write-back credential verified")
+	case errors.Is(err, provider.ErrWriteAuthRejected):
+		s.log.Error("write-back disabled: the forge rejected the write credential — "+
+			"check the write token / GitHub App (client id, key, installation) and that it can write to this repo",
+			"error", err)
+		s.writer = nil
+	default:
+		s.log.Warn("could not verify the write-back credential; leaving it enabled to retry on renders", "error", err)
+	}
+}
 
 // reportOutcome is the queue's terminal-outcome hook: it writes konflate's result
 // back to the forge — a commit status and/or a summary comment, per the enabled
@@ -330,11 +352,20 @@ func (s *Server) Run(ctx context.Context) error {
 	g, gctx := errgroup.WithContext(ctx)
 	s.runCtx = gctx
 
-	// Wire write-back into the queue only when something is enabled and a Writer
-	// was built; otherwise report stays nil and the queue skips it — konflate
+	// Verify the write credential once, before any render can post: a permanent
+	// rejection disables write-back with one clear log line instead of a per-render
+	// warning storm; a transient failure leaves it enabled to recover on a render.
+	// Runs before the queue/goroutines start, so flipping s.writer is race-free.
+	wantWriteBack := s.cfg.StatusChecksEnabled() || s.cfg.PRCommentsEnabled()
+	if s.writer != nil && wantWriteBack {
+		s.verifyWriteBack(gctx)
+	}
+
+	// Wire write-back into the queue only when something is enabled and a Writer is
+	// still configured; otherwise report stays nil and the queue skips it — konflate
 	// posts nothing to the forge (the read-only default).
 	var report reportFunc
-	if s.writer != nil && (s.cfg.StatusChecksEnabled() || s.cfg.PRCommentsEnabled()) {
+	if s.writer != nil && wantWriteBack {
 		report = s.reportOutcome
 	}
 	s.queue = newQueue(

--- a/internal/server/writeback_test.go
+++ b/internal/server/writeback_test.go
@@ -3,9 +3,44 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/home-operations/konflate/internal/api"
+	"github.com/home-operations/konflate/internal/config"
+	"github.com/home-operations/konflate/internal/provider"
 )
+
+// stubWriter is a provider.Writer whose Verify returns a configurable error.
+type stubWriter struct{ verifyErr error }
+
+func (stubWriter) SetStatus(context.Context, api.PR, provider.Status) error    { return nil }
+func (stubWriter) UpsertComment(context.Context, api.PR, string, string) error { return nil }
+func (s stubWriter) Verify(context.Context) error                              { return s.verifyErr }
+
+func TestVerifyWriteBack(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name         string
+		verifyErr    error
+		wantDisabled bool
+	}{
+		{"verified stays enabled", nil, false},
+		{"permanent rejection disables", fmt.Errorf("verify: %w", provider.ErrWriteAuthRejected), true},
+		{"transient failure stays enabled", errors.New("503 service unavailable"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := &Server{cfg: &config.Config{}, log: discardLog(), writer: stubWriter{verifyErr: tc.verifyErr}}
+			s.verifyWriteBack(context.Background())
+			if (s.writer == nil) != tc.wantDisabled {
+				t.Errorf("write-back disabled = %v, want %v", s.writer == nil, tc.wantDisabled)
+			}
+		})
+	}
+}
 
 func TestRetryWrite(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Turns the exact failure you hit — a write credential the forge rejects (here, `POST /app/installations/165748/access_tokens → 404`) — from a per-PR, per-render warning storm (×3 wasted API calls each, on an error that can never succeed) into **one clear startup log line + write-back cleanly disabled**.

## What it does

konflate now verifies the write credential **once at startup**, before any render can post:

- Each `Writer` gains `Verify(ctx)` — a cheap authenticated repo read that exercises the full auth path. For a GitHub App that's the installation-token mint (the call that was 404ing for you).
- The server classifies the result:
  - **Permanent** (`401/403/404` → `ErrWriteAuthRejected`): bad token, missing permission, wrong App installation, or unreachable repo → log **one** clear error and **disable** write-back. No storm, no wasted retries.
  - **Transient** (5xx / network / timeout): log a warning and **leave write-back enabled** so it recovers on a later render (don't disable on a forge blip at boot).
- Runs before the render queue starts, so flipping the writer off is race-free. Bounded by a 10s startup timeout so a hung forge can't delay boot.

For your case specifically: write-back to `onedr0p/home-ops` can't work (you'd need your App installed on a repo you don't own), so this will now log a single `write-back disabled: the forge rejected the write credential …` line at startup and go quiet — instead of the stream you saw.

## Changes

- **`internal/provider`** — `Writer.Verify`, the `ErrWriteAuthRejected` sentinel, and `rejectedIf` (which also pulls the status off the `ghinstallation` token-mint error, since the `github.Response` is nil there).
- **`internal/server`** — `verifyWriteBack` wired into `Run` (10s timeout); disables on a permanent rejection.
- **README** — a startup-verification note in the Write-back section.

## Testing

- `rejectedIf` classification (401/403/404 → rejected; 0/200/429/5xx → transient).
- Per-forge `Verify` over httptest (200 ok / 404 / 403 rejected / 500 transient) for GitHub, GitLab, Forgejo.
- `verifyWriteBack` disables only on a permanent rejection.
- `go test ./...`, `go vet`, `golangci-lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
