### PR TITLE
fix(security): harden write-back and the avatar proxy

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -353,6 +353,16 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("config: %w", err)
 	}
 
+	// A GitHub App write credential needs both halves. Reject a half-set pair
+	// loudly at startup: a lone KONFLATE_APP_CLIENT_ID would otherwise leave
+	// WriteEnabled false and silently keep write-back off (the operator believes
+	// it's live), and a lone key would only surface deep in the writer. GitHub-only
+	// in effect, but the fields are forge-agnostic so the check is too.
+	if (cfg.AppClientID == "") != (cfg.AppPrivateKey == "") {
+		return nil, fmt.Errorf("config: a GitHub App write credential needs both " +
+			"KONFLATE_APP_CLIENT_ID and KONFLATE_APP_PRIVATE_KEY (only one is set)")
+	}
+
 	// Compile the PR filter once, here, so a malformed expression fails at
 	// startup with a clear message rather than silently dropping every PR. An
 	// empty expression falls back to DefaultPRFilter, so cfg.PRFilter is always

--- a/internal/prfilter/prfilter.go
+++ b/internal/prfilter/prfilter.go
@@ -26,6 +26,14 @@ type Program struct {
 	src string
 }
 
+// evalCostLimit caps the CEL cost of a single filter evaluation. The expression
+// is operator-supplied (trusted) and its attacker-influenced inputs (pr.title,
+// pr.labels) are forge-bounded, so this is defense-in-depth against a pathological
+// operator expression rather than a likely attack — a ceiling no reasonable PR
+// predicate approaches, while still bounding an accidental blow-up (CEL has no
+// loops, so a finite cost is guaranteed to exist).
+const evalCostLimit = 1_000_000
+
 // Compile parses and type-checks expr and returns a runnable Program. It fails
 // when the expression is syntactically invalid, references unknown
 // variables/functions, or cannot produce a boolean.
@@ -51,7 +59,7 @@ func Compile(expr string) (*Program, error) {
 	default:
 		return nil, fmt.Errorf("prfilter: expression must evaluate to a boolean, got %s", ast.OutputType())
 	}
-	prg, err := env.Program(ast)
+	prg, err := env.Program(ast, cel.CostLimit(evalCostLimit))
 	if err != nil {
 		return nil, fmt.Errorf("prfilter: program: %w", err)
 	}

--- a/internal/provider/writer.go
+++ b/internal/provider/writer.go
@@ -99,20 +99,45 @@ func strOrNil(s string) *string {
 	return &s
 }
 
+// resolvedString memoizes the first successful result of resolve. A failed
+// attempt is not cached, so a transient error (e.g. a forge blip while learning
+// konflate's own identity) is retried on the next call rather than wedging the
+// feature — the same lazy, cache-on-success pattern as repoInstallTransport.
+type resolvedString struct {
+	mu      sync.Mutex
+	val     string
+	resolve func(ctx context.Context) (string, error)
+}
+
+func (r *resolvedString) get(ctx context.Context) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.val != "" {
+		return r.val, nil
+	}
+	v, err := r.resolve(ctx)
+	if err != nil {
+		return "", err
+	}
+	r.val = v
+	return v, nil
+}
+
 // --- GitHub ---
 
 type githubWriter struct {
 	client      *github.Client
 	owner, repo string
+	self        *resolvedString // login of konflate's own comment author; resolved once
 }
 
 func newGitHubWriter(cfg *config.Config) (*githubWriter, error) {
-	client, err := newGitHubWriteClient(cfg)
+	client, self, err := newGitHubWriteClient(cfg)
 	if err != nil {
 		return nil, err
 	}
 	owner, repo := ownerRepo(cfg.Forge.RepoPath)
-	return &githubWriter{client: client, owner: owner, repo: repo}, nil
+	return &githubWriter{client: client, owner: owner, repo: repo, self: &resolvedString{resolve: self}}, nil
 }
 
 // newGitHubWriteClient builds the authenticated write client. A fully-configured
@@ -120,7 +145,7 @@ func newGitHubWriter(cfg *config.Config) (*githubWriter, error) {
 // short-lived installation tokens rather than carrying a standing PAT — and a
 // write PAT is the fallback (and the only option on Forgejo/GitLab). A partial
 // App config is an explicit error so it can't silently mask a typo'd key.
-func newGitHubWriteClient(cfg *config.Config) (*github.Client, error) {
+func newGitHubWriteClient(cfg *config.Config) (*github.Client, func(context.Context) (string, error), error) {
 	switch {
 	case cfg.AppConfigured():
 		return newGitHubAppClient(cfg)
@@ -129,13 +154,21 @@ func newGitHubWriteClient(cfg *config.Config) (*github.Client, error) {
 			githubEnterpriseOpts(cfg.Forge.Host)...)
 		client, err := github.NewClient(opts...)
 		if err != nil {
-			return nil, fmt.Errorf("github: new write client: %w", err)
+			return nil, nil, fmt.Errorf("github: new write client: %w", err)
 		}
-		return client, nil
+		// The write PAT's own user is konflate's comment-author identity.
+		self := func(ctx context.Context) (string, error) {
+			u, _, err := client.Users.Get(ctx, "")
+			if err != nil {
+				return "", fmt.Errorf("github: resolve write-token user: %w", err)
+			}
+			return u.GetLogin(), nil
+		}
+		return client, self, nil
 	case cfg.AppClientID != "" || cfg.AppPrivateKey != "":
-		return nil, fmt.Errorf("github: App write-back needs both KONFLATE_APP_CLIENT_ID and KONFLATE_APP_PRIVATE_KEY")
+		return nil, nil, fmt.Errorf("github: App write-back needs both KONFLATE_APP_CLIENT_ID and KONFLATE_APP_PRIVATE_KEY")
 	default:
-		return nil, fmt.Errorf("github: write-back needs KONFLATE_WRITE_TOKEN or GitHub App credentials")
+		return nil, nil, fmt.Errorf("github: write-back needs KONFLATE_WRITE_TOKEN or GitHub App credentials")
 	}
 }
 
@@ -144,10 +177,10 @@ func newGitHubWriteClient(cfg *config.Config) (*github.Client, error) {
 // issues the App JWT with a numeric app id; GitHub also accepts — and now
 // recommends — the App's string client id as the issuer, which is the credential
 // konflate is configured with, so clientIDSigner overrides the issuer claim.
-func newGitHubAppClient(cfg *config.Config) (*github.Client, error) {
+func newGitHubAppClient(cfg *config.Config) (*github.Client, func(context.Context) (string, error), error) {
 	key, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(cfg.AppPrivateKey))
 	if err != nil {
-		return nil, fmt.Errorf("github: parse App private key (KONFLATE_APP_PRIVATE_KEY): %w", err)
+		return nil, nil, fmt.Errorf("github: parse App private key (KONFLATE_APP_PRIVATE_KEY): %w", err)
 	}
 	signer := clientIDSigner{
 		clientID: cfg.AppClientID,
@@ -156,7 +189,7 @@ func newGitHubAppClient(cfg *config.Config) (*github.Client, error) {
 	appsTr, err := ghinstallation.NewAppsTransportWithOptions(
 		http.DefaultTransport, 0, ghinstallation.WithSigner(signer))
 	if err != nil {
-		return nil, fmt.Errorf("github: App transport: %w", err)
+		return nil, nil, fmt.Errorf("github: App transport: %w", err)
 	}
 	owner, repo := ownerRepo(cfg.Forge.RepoPath)
 	opts := githubEnterpriseOpts(cfg.Forge.Host)
@@ -171,9 +204,37 @@ func newGitHubAppClient(cfg *config.Config) (*github.Client, error) {
 	}))
 	client, err := github.NewClient(opts...)
 	if err != nil {
-		return nil, fmt.Errorf("github: new App client: %w", err)
+		return nil, nil, fmt.Errorf("github: new App client: %w", err)
 	}
-	return client, nil
+	// konflate's comments are authored by the App's bot user, "<app-slug>[bot]".
+	// Resolve the slug from the App itself (App-JWT auth) so comment write-back only
+	// ever edits konflate's own comment, never one a PR author planted with the
+	// (public) marker.
+	self := func(ctx context.Context) (string, error) {
+		ac, err := appJWTClient(appsTr, cfg.Forge.Host)
+		if err != nil {
+			return "", err
+		}
+		app, _, err := ac.Apps.Get(ctx, "")
+		if err != nil {
+			return "", fmt.Errorf("github: resolve App identity: %w", err)
+		}
+		return app.GetSlug() + "[bot]", nil
+	}
+	return client, self, nil
+}
+
+// appJWTClient builds a go-github client that authenticates as the App itself (the
+// App JWT), on the same API base as the write client. Used to discover the repo
+// installation and konflate's own bot identity.
+func appJWTClient(appsTr *ghinstallation.AppsTransport, host string) (*github.Client, error) {
+	c, err := github.NewClient(append([]github.ClientOptionsFunc{
+		github.WithTransport(appsTr),
+	}, githubEnterpriseOpts(host)...)...)
+	if err != nil {
+		return nil, fmt.Errorf("github: app client: %w", err)
+	}
+	return c, nil
 }
 
 // repoInstallTransport authenticates as the GitHub App and, on first request,
@@ -207,11 +268,9 @@ func (t *repoInstallTransport) installation(ctx context.Context) (*ghinstallatio
 		return t.itr, nil
 	}
 	// An App-JWT client (the apps transport), on the same base as the write client.
-	appClient, err := github.NewClient(append([]github.ClientOptionsFunc{
-		github.WithTransport(t.apps),
-	}, githubEnterpriseOpts(t.host)...)...)
+	appClient, err := appJWTClient(t.apps, t.host)
 	if err != nil {
-		return nil, fmt.Errorf("github: app client: %w", err)
+		return nil, err
 	}
 	inst, _, err := appClient.Apps.GetRepositoryInstallation(ctx, t.owner, t.repo)
 	if err != nil {
@@ -254,13 +313,20 @@ func (w *githubWriter) SetStatus(ctx context.Context, pr api.PR, st Status) erro
 }
 
 func (w *githubWriter) UpsertComment(ctx context.Context, pr api.PR, marker, body string) error {
-	// Find konflate's own comment (the one carrying the hidden marker) and edit it
-	// in place; otherwise post a new one. ListCommentsIter paginates transparently.
+	self, err := w.self.get(ctx)
+	if err != nil {
+		return fmt.Errorf("github: %w", err)
+	}
+	// Find konflate's own comment (the one it authored carrying the hidden marker)
+	// and edit it in place; otherwise post a new one. The marker alone isn't enough:
+	// it's public (the summary API emits it too), so a PR author could plant it to
+	// make konflate adopt their comment — match the author as well. ListCommentsIter
+	// paginates transparently.
 	for c, err := range w.client.Issues.ListCommentsIter(ctx, w.owner, w.repo, pr.Number, nil) {
 		if err != nil {
 			return fmt.Errorf("github: list comments #%d: %w", pr.Number, err)
 		}
-		if c.Body != nil && strings.Contains(*c.Body, marker) {
+		if c.GetUser().GetLogin() == self && c.Body != nil && strings.Contains(*c.Body, marker) {
 			_, _, err = w.client.Issues.EditComment(ctx, w.owner, w.repo, c.GetID(), &github.IssueComment{Body: &body})
 			if err != nil {
 				return fmt.Errorf("github: edit comment #%d: %w", pr.Number, err)
@@ -306,6 +372,7 @@ func githubStatus(resp *github.Response, err error) int {
 type forgejoWriter struct {
 	client      *forgejo.Client
 	owner, repo string
+	self        *resolvedString // username of konflate's own comment author; resolved once
 }
 
 func newForgejoWriter(cfg *config.Config) (*forgejoWriter, error) {
@@ -318,7 +385,14 @@ func newForgejoWriter(cfg *config.Config) (*forgejoWriter, error) {
 		return nil, fmt.Errorf("forgejo: new write client: %w", err)
 	}
 	owner, repo := ownerRepo(cfg.Forge.RepoPath)
-	return &forgejoWriter{client: client, owner: owner, repo: repo}, nil
+	self := func(context.Context) (string, error) {
+		u, _, err := client.GetMyUserInfo() // the Forgejo SDK can't take a context
+		if err != nil {
+			return "", fmt.Errorf("forgejo: resolve write-token user: %w", err)
+		}
+		return u.UserName, nil
+	}
+	return &forgejoWriter{client: client, owner: owner, repo: repo, self: &resolvedString{resolve: self}}, nil
 }
 
 func (w *forgejoWriter) SetStatus(_ context.Context, pr api.PR, st Status) error {
@@ -335,7 +409,11 @@ func (w *forgejoWriter) SetStatus(_ context.Context, pr api.PR, st Status) error
 	return nil
 }
 
-func (w *forgejoWriter) UpsertComment(_ context.Context, pr api.PR, marker, body string) error {
+func (w *forgejoWriter) UpsertComment(ctx context.Context, pr api.PR, marker, body string) error {
+	self, err := w.self.get(ctx)
+	if err != nil {
+		return fmt.Errorf("forgejo: %w", err)
+	}
 	// The Forgejo SDK can't take a context (see provider ListPRs).
 	idx := int64(pr.Number)
 	opts := forgejo.ListIssueCommentOptions{ListOptions: forgejo.ListOptions{PageSize: 50}}
@@ -345,7 +423,8 @@ func (w *forgejoWriter) UpsertComment(_ context.Context, pr api.PR, marker, body
 			return fmt.Errorf("forgejo: list comments #%d: %w", pr.Number, err)
 		}
 		for _, c := range comments {
-			if strings.Contains(c.Body, marker) {
+			// Match konflate's own comment (author + marker), not just the public marker.
+			if c.Poster != nil && c.Poster.UserName == self && strings.Contains(c.Body, marker) {
 				_, _, err = w.client.EditIssueComment(w.owner, w.repo, c.ID, forgejo.EditIssueCommentOption{Body: body})
 				if err != nil {
 					return fmt.Errorf("forgejo: edit comment #%d: %w", pr.Number, err)
@@ -381,6 +460,7 @@ func (w *forgejoWriter) Verify(_ context.Context) error {
 type gitlabWriter struct {
 	client  *gitlab.Client
 	project string
+	self    *resolvedString // username of konflate's own note author; resolved once
 }
 
 func newGitLabWriter(cfg *config.Config) (*gitlabWriter, error) {
@@ -391,7 +471,14 @@ func newGitLabWriter(cfg *config.Config) (*gitlabWriter, error) {
 	if err != nil {
 		return nil, fmt.Errorf("gitlab: new write client: %w", err)
 	}
-	return &gitlabWriter{client: client, project: cfg.Forge.RepoPath}, nil
+	self := func(ctx context.Context) (string, error) {
+		u, _, err := client.Users.CurrentUser(gitlab.WithContext(ctx))
+		if err != nil {
+			return "", fmt.Errorf("gitlab: resolve write-token user: %w", err)
+		}
+		return u.Username, nil
+	}
+	return &gitlabWriter{client: client, project: cfg.Forge.RepoPath, self: &resolvedString{resolve: self}}, nil
 }
 
 func (w *gitlabWriter) SetStatus(ctx context.Context, pr api.PR, st Status) error {
@@ -408,6 +495,10 @@ func (w *gitlabWriter) SetStatus(ctx context.Context, pr api.PR, st Status) erro
 }
 
 func (w *gitlabWriter) UpsertComment(ctx context.Context, pr api.PR, marker, body string) error {
+	self, err := w.self.get(ctx)
+	if err != nil {
+		return fmt.Errorf("gitlab: %w", err)
+	}
 	mr := int64(pr.Number)
 	opts := &gitlab.ListMergeRequestNotesOptions{ListOptions: gitlab.ListOptions{PerPage: 100}}
 	for {
@@ -416,7 +507,8 @@ func (w *gitlabWriter) UpsertComment(ctx context.Context, pr api.PR, marker, bod
 			return fmt.Errorf("gitlab: list notes !%d: %w", pr.Number, err)
 		}
 		for _, n := range notes {
-			if strings.Contains(n.Body, marker) {
+			// Match konflate's own note (author + marker), not just the public marker.
+			if n.Author.Username == self && strings.Contains(n.Body, marker) {
 				_, _, err = w.client.Notes.UpdateMergeRequestNote(w.project, mr, n.ID,
 					&gitlab.UpdateMergeRequestNoteOptions{Body: &body}, gitlab.WithContext(ctx))
 				if err != nil {

--- a/internal/provider/writer_test.go
+++ b/internal/provider/writer_test.go
@@ -124,7 +124,7 @@ func TestNewGitHubWriteClient(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			client, err := newGitHubWriteClient(tc.cfg)
+			client, _, err := newGitHubWriteClient(tc.cfg)
 			if tc.wantErr == "" {
 				if err != nil {
 					t.Fatalf("newGitHubWriteClient: unexpected error %v", err)
@@ -285,9 +285,31 @@ func commentCapture(listJSON string, sink *commentSink) http.HandlerFunc {
 
 const upsertMarker = "<!-- konflate:pr-7 -->"
 
-// markerList is a one-comment listing (id 99) whose body carries the marker.
+// selfLogin is the login the test writers resolve as konflate's own identity (via
+// konflateSelf); the marked comment in markerList is authored by it.
+const selfLogin = "konflate[bot]"
+
+// konflateSelf is a resolvedString reporting konflate's own identity (selfLogin)
+// with no network call — the test stand-in for the per-forge "who am I" lookup.
+func konflateSelf() *resolvedString {
+	return &resolvedString{resolve: func(context.Context) (string, error) { return selfLogin, nil }}
+}
+
+// markerList is a one-comment listing (id 99) whose body carries the marker and is
+// authored by konflate itself. It carries both a GitHub/Forgejo-style `user.login`
+// and a GitLab-style `author.username` so the one fixture serves all three forges
+// (each SDK reads its own field).
 func markerList() string {
-	return fmt.Sprintf(`[{"id":99,"body":%q}]`, upsertMarker+"\nold")
+	return fmt.Sprintf(`[{"id":99,"body":%q,"user":{"login":%q},"author":{"username":%q}}]`,
+		upsertMarker+"\nold", selfLogin, selfLogin)
+}
+
+// foreignMarkerList is the marker planted by a DIFFERENT author — the comment-
+// hijack attempt. konflate must NOT edit it (it isn't konflate's) and must post
+// its own comment instead.
+func foreignMarkerList() string {
+	return fmt.Sprintf(`[{"id":99,"body":%q,"user":{"login":"attacker"},"author":{"username":"attacker"}}]`,
+		upsertMarker+"\nplanted")
 }
 
 func assertCreated(t *testing.T, sink commentSink) {
@@ -317,22 +339,33 @@ func TestGitHubWriter_UpsertComment(t *testing.T) {
 		var sink commentSink
 		srv := httptest.NewServer(commentCapture(`[]`, &sink))
 		t.Cleanup(srv.Close)
-		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web"}
+		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
 		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nhi"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
 		assertCreated(t, sink)
 	})
-	t.Run("edits when present", func(t *testing.T) {
+	t.Run("edits its own when present", func(t *testing.T) {
 		t.Parallel()
 		var sink commentSink
 		srv := httptest.NewServer(commentCapture(markerList(), &sink))
 		t.Cleanup(srv.Close)
-		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web"}
+		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
 		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nnew"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
 		assertEdited(t, sink)
+	})
+	t.Run("ignores a foreign comment carrying the marker", func(t *testing.T) {
+		t.Parallel()
+		var sink commentSink
+		srv := httptest.NewServer(commentCapture(foreignMarkerList(), &sink))
+		t.Cleanup(srv.Close)
+		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
+		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nhi"); err != nil {
+			t.Fatalf("UpsertComment: %v", err)
+		}
+		assertCreated(t, sink) // posts its own; must not edit the planted comment
 	})
 }
 
@@ -351,22 +384,33 @@ func TestGitlabWriter_UpsertComment(t *testing.T) {
 		var sink commentSink
 		srv := httptest.NewServer(commentCapture(`[]`, &sink))
 		t.Cleanup(srv.Close)
-		wr := &gitlabWriter{client: newClient(t, srv.URL), project: "acme/web"}
+		wr := &gitlabWriter{client: newClient(t, srv.URL), project: "acme/web", self: konflateSelf()}
 		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nhi"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
 		assertCreated(t, sink)
 	})
-	t.Run("edits when present", func(t *testing.T) {
+	t.Run("edits its own when present", func(t *testing.T) {
 		t.Parallel()
 		var sink commentSink
 		srv := httptest.NewServer(commentCapture(markerList(), &sink))
 		t.Cleanup(srv.Close)
-		wr := &gitlabWriter{client: newClient(t, srv.URL), project: "acme/web"}
+		wr := &gitlabWriter{client: newClient(t, srv.URL), project: "acme/web", self: konflateSelf()}
 		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nnew"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
 		assertEdited(t, sink)
+	})
+	t.Run("ignores a foreign note carrying the marker", func(t *testing.T) {
+		t.Parallel()
+		var sink commentSink
+		srv := httptest.NewServer(commentCapture(foreignMarkerList(), &sink))
+		t.Cleanup(srv.Close)
+		wr := &gitlabWriter{client: newClient(t, srv.URL), project: "acme/web", self: konflateSelf()}
+		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nhi"); err != nil {
+			t.Fatalf("UpsertComment: %v", err)
+		}
+		assertCreated(t, sink) // posts its own; must not edit the planted note
 	})
 }
 
@@ -385,22 +429,33 @@ func TestForgejoWriter_UpsertComment(t *testing.T) {
 		var sink commentSink
 		srv := httptest.NewServer(commentCapture(`[]`, &sink))
 		t.Cleanup(srv.Close)
-		wr := &forgejoWriter{client: newClient(t, srv.URL), owner: "acme", repo: "web"}
+		wr := &forgejoWriter{client: newClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
 		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nhi"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
 		assertCreated(t, sink)
 	})
-	t.Run("edits when present", func(t *testing.T) {
+	t.Run("edits its own when present", func(t *testing.T) {
 		t.Parallel()
 		var sink commentSink
 		srv := httptest.NewServer(commentCapture(markerList(), &sink))
 		t.Cleanup(srv.Close)
-		wr := &forgejoWriter{client: newClient(t, srv.URL), owner: "acme", repo: "web"}
+		wr := &forgejoWriter{client: newClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
 		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nnew"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
 		assertEdited(t, sink)
+	})
+	t.Run("ignores a foreign comment carrying the marker", func(t *testing.T) {
+		t.Parallel()
+		var sink commentSink
+		srv := httptest.NewServer(commentCapture(foreignMarkerList(), &sink))
+		t.Cleanup(srv.Close)
+		wr := &forgejoWriter{client: newClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
+		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nhi"); err != nil {
+			t.Fatalf("UpsertComment: %v", err)
+		}
+		assertCreated(t, sink) // posts its own; must not edit the planted comment
 	})
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -12,10 +12,13 @@ import (
 	"hash/fnv"
 	"io"
 	"mime"
+	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/home-operations/konflate/internal/api"
@@ -269,11 +272,53 @@ func renderStatus(env api.DiffEnvelope) string {
 	}
 }
 
-// avatarClient fetches author avatars with a tight timeout; responses are
-// size-capped and must be images (see handleAvatar).
-var avatarClient = &http.Client{Timeout: 8 * time.Second}
+// avatarDialControl refuses to open a connection to a non-public address. It runs
+// for the initial dial and for every redirect hop, after DNS resolution, against
+// the concrete IP being dialed — so it also defeats DNS rebinding and a redirect
+// aimed at an internal host. Blocks loopback, RFC1918/ULA private ranges,
+// link-local (incl. the 169.254.169.254 cloud-metadata address), multicast, and
+// the unspecified address.
+func avatarDialControl(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return err
+	}
+	ip, err := netip.ParseAddr(host)
+	if err != nil {
+		return errors.New("avatar: unresolved dial address")
+	}
+	ip = ip.Unmap() // normalize ::ffff:a.b.c.d so the IPv4 checks below apply
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsMulticast() || ip.IsUnspecified() {
+		return errors.New("avatar: refusing to connect to a non-public address")
+	}
+	return nil
+}
+
+// avatarClient fetches author avatars with a tight timeout. It refuses to connect
+// to non-public addresses (avatarDialControl) and re-validates every redirect, so
+// a forge-returned avatar URL — the only kind handleAvatar will fetch, see the
+// HMAC gate — can't be steered to cloud metadata, loopback, or in-cluster services
+// via a redirect or DNS rebinding. Responses are size-capped and must be images.
+var avatarClient = &http.Client{
+	Timeout: 8 * time.Second,
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 5 {
+			return errors.New("avatar: stopped after 5 redirects")
+		}
+		if req.URL.Scheme != schemeHTTPS {
+			return errors.New("avatar: refusing a non-https redirect")
+		}
+		return nil
+	},
+	Transport: &http.Transport{
+		DialContext: (&net.Dialer{Timeout: 5 * time.Second, Control: avatarDialControl}).DialContext,
+	},
+}
 
 const maxAvatarBytes = 2 << 20 // 2 MiB
+
+// schemeHTTPS is the only URL scheme konflate will fetch or link over.
+const schemeHTTPS = "https"
 
 // avatarProxyPath rewrites a raw forge avatar URL into a signed, same-origin
 // /api/avatar path. The HMAC (a per-process key) means handleAvatar will only
@@ -301,7 +346,7 @@ func (s *Server) handleAvatar(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusForbidden, "invalid avatar signature")
 		return
 	}
-	if u, err := url.Parse(raw); err != nil || u.Scheme != "https" {
+	if u, err := url.Parse(raw); err != nil || u.Scheme != schemeHTTPS {
 		writeError(w, http.StatusBadRequest, "avatar must be an https URL")
 		return
 	}

--- a/internal/server/markdown.go
+++ b/internal/server/markdown.go
@@ -316,7 +316,7 @@ func isHex(s string) bool {
 // from the inbound request, honouring the usual reverse-proxy headers (konflate
 // typically sits behind an ingress).
 func reviewURLFromRequest(r *http.Request, number int) string {
-	scheme := "https"
+	scheme := schemeHTTPS
 	if p := r.Header.Get("X-Forwarded-Proto"); p != "" {
 		scheme = strings.TrimSpace(strings.Split(p, ",")[0])
 	} else if r.TLS == nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"text/template"
 	"time"
+	"unicode"
 
 	"golang.org/x/sync/errgroup"
 
@@ -209,7 +210,7 @@ func (s *Server) postStatus(pr api.PR, st api.JobStatus, sig *api.Signals, errMs
 		status.Description = renderedStatusDescription(sig)
 	case api.JobError:
 		status.State = provider.StatusFailure
-		status.Description = truncateStatus("render failed: " + errMsg)
+		status.Description = truncateStatus("render failed: " + oneLine(errMsg))
 	default:
 		return
 	}
@@ -260,6 +261,21 @@ func renderedStatusDescription(sig *api.Signals) string {
 		d += fmt.Sprintf(", %d render %s", sig.Failures, plural(sig.Failures, "failure", "failures"))
 	}
 	return d
+}
+
+// oneLine flattens s to a single line for a commit-status description: every
+// control character (newlines, tabs, CR, ESC, NUL, …) becomes a space and runs of
+// whitespace collapse to one. A failed render's error message can echo
+// fork-controlled manifest/template text, so this keeps it from injecting line
+// breaks or terminal-control sequences into the status the forge displays.
+func oneLine(s string) string {
+	mapped := strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return ' '
+		}
+		return r
+	}, s)
+	return strings.Join(strings.Fields(mapped), " ")
 }
 
 // truncateStatus clamps a status description to the forge limit (GitHub caps the


### PR DESCRIPTION
Fixes the konflate-owned findings from a security audit of the write-back surface (the flate-dependency findings — fork-render SSRF / host-file read — are tracked separately; they're in the render engine and gated behind `KONFLATE_RENDER_FORK_PRS`, off by default).

## Fixes

### Comment-marker hijack (the headline one)
Comment write-back identified "its" comment purely by a hidden marker substring (`<!-- konflate:pr-N -->`). That marker is **public** — the `GET /api/prs/{n}/summary` endpoint emits it — so any user who can comment on a PR could plant it *before* konflate posts, and konflate would then adopt and edit the attacker's comment (oldest match wins), lending its trusted summary to an attacker-owned comment and suppressing its own.

Now write-back edits a comment only when it's authored by **konflate's own identity** *and* carries the marker. Identity is resolved lazily per forge and cached: the App's bot login (`<slug>[bot]`, via `GET /app` on the App JWT), or the write token's user (`GET /user` / GitLab `CurrentUser` / Forgejo `GetMyUserInfo`). Existing konflate comments are authored by that same identity, so they're still edited in place — no duplicates on upgrade.

### Avatar proxy SSRF hardening
`/api/avatar` is HMAC-gated (only forge-emitted URLs are fetchable), but the client followed redirects with no re-validation and no private-IP block. The fetch now runs through a dialer that **refuses non-public addresses** (loopback, RFC1918/ULA, link-local incl. `169.254.169.254`, multicast) on every connection — so it covers the initial dial, each redirect hop, and DNS rebinding — and re-checks `https` on each redirect.

### Status-description sanitization
A failed render's error message (which can echo fork-PR manifest/template text) is flattened to a single line before becoming the commit-status description, so it can't carry newlines or control characters.

### Fail loud on a half-set GitHub App credential
A lone `KONFLATE_APP_CLIENT_ID` (no key) used to leave write-back silently disabled (because `WriteEnabled()` keys off the private key). `Load` now rejects an exactly-one-of pair at startup.

### CEL PR-filter cost limit
The operator-supplied PR filter now compiles with a `cel.CostLimit` — defense in depth against a pathological expression (inputs are already forge-bounded).

## Testing
- New per-forge regression test: a marker comment authored by someone other than konflate is **not** edited (konflate posts its own).
- Existing UpsertComment / SetStatus / Verify / credential-selection tests updated for the resolved-identity path.
- `go build`, `go test ./...`, `golangci-lint` (0 issues), `gofmt` all green. No chart changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)