### PR TITLE
chore: cover shipped security code with tests; small clean-ups

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -374,3 +374,35 @@ func TestRepoKey(t *testing.T) {
 		t.Errorf("key %q contains path-unsafe characters", a)
 	}
 }
+
+// TestLoad_PartialAppCredential pins the fail-loud check: a GitHub App write
+// credential needs both halves, so a lone client id (which would otherwise leave
+// write-back silently disabled) or a lone key must error at startup.
+func TestLoad_PartialAppCredential(t *testing.T) {
+	t.Run("client id without key errors", func(t *testing.T) {
+		t.Setenv("KONFLATE_REPO", "github://owner/repo")
+		t.Setenv("KONFLATE_APP_CLIENT_ID", "Iv1")
+		if _, err := Load(); err == nil || !strings.Contains(err.Error(), "only one is set") {
+			t.Fatalf("Load with a lone client id = %v, want an 'only one is set' error", err)
+		}
+	})
+	t.Run("key without client id errors", func(t *testing.T) {
+		t.Setenv("KONFLATE_REPO", "github://owner/repo")
+		t.Setenv("KONFLATE_APP_PRIVATE_KEY", "-----BEGIN KEY-----")
+		if _, err := Load(); err == nil || !strings.Contains(err.Error(), "only one is set") {
+			t.Fatalf("Load with a lone key = %v, want an 'only one is set' error", err)
+		}
+	})
+	t.Run("both halves is valid and configured", func(t *testing.T) {
+		t.Setenv("KONFLATE_REPO", "github://owner/repo")
+		t.Setenv("KONFLATE_APP_CLIENT_ID", "Iv1")
+		t.Setenv("KONFLATE_APP_PRIVATE_KEY", "-----BEGIN KEY-----")
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load with both halves: %v", err)
+		}
+		if !cfg.AppConfigured() {
+			t.Error("both halves set should report AppConfigured")
+		}
+	})
+}

--- a/internal/diff/flux.go
+++ b/internal/diff/flux.go
@@ -2,7 +2,7 @@ package diff
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/home-operations/konflate/internal/api"
@@ -139,7 +139,7 @@ func aggregateParentWarnings(counts map[string]int, rule string, detail func(par
 	for l := range counts {
 		labels = append(labels, l)
 	}
-	sort.Strings(labels)
+	slices.Sort(labels)
 	out := make([]api.Warning, 0, len(labels))
 	for _, l := range labels {
 		out = append(out, api.Warning{

--- a/internal/diff/immutable.go
+++ b/internal/diff/immutable.go
@@ -143,11 +143,11 @@ func changedSpecKeysOutside(c Change, mutable map[string]bool) []string {
 // changedFields returns "spec.<key>" for each named spec key whose value
 // differs between the two sides, in the given order.
 func changedFields(c Change, keys ...string) []string {
+	oldSpec, _ := nestedMap(c.Old, "spec")
+	newSpec, _ := nestedMap(c.New, "spec")
 	var out []string
 	for _, k := range keys {
-		oldV, _ := nestedMap(c.Old, "spec")
-		newV, _ := nestedMap(c.New, "spec")
-		if !jsonEqual(oldV[k], newV[k]) {
+		if !jsonEqual(oldSpec[k], newSpec[k]) {
 			out = append(out, "spec."+k)
 		}
 	}

--- a/internal/prfilter/prfilter_test.go
+++ b/internal/prfilter/prfilter_test.go
@@ -120,3 +120,31 @@ func TestSource(t *testing.T) {
 		t.Fatalf("Source() = %q, want %q", p.Source(), expr)
 	}
 }
+
+func TestEval_CostBounded(t *testing.T) {
+	t.Parallel()
+	// The cel.CostLimit must bound a pathological expression rather than let it run
+	// unbounded. A quadratic comprehension over a large label list blows the budget.
+	labels := make([]any, 1500)
+	for i := range labels {
+		labels[i] = map[string]any{"name": "x", "color": "0"}
+	}
+	pr := sampleVars(map[string]any{"labels": labels})
+
+	heavy, err := Compile(`pr.labels.all(a, pr.labels.all(b, a.name == b.name))`)
+	if err != nil {
+		t.Fatalf("Compile heavy: %v", err)
+	}
+	if _, err := heavy.Eval(pr); err == nil {
+		t.Fatal("a quadratic expression over a large label list should exceed the cost limit and error")
+	}
+
+	// A cheap expression over the same input stays well under the limit.
+	cheap, err := Compile("!pr.draft")
+	if err != nil {
+		t.Fatalf("Compile cheap: %v", err)
+	}
+	if _, err := cheap.Eval(pr); err != nil {
+		t.Fatalf("cheap expression must not hit the cost limit: %v", err)
+	}
+}

--- a/internal/server/avatar_test.go
+++ b/internal/server/avatar_test.go
@@ -1,0 +1,39 @@
+package server
+
+import "testing"
+
+// TestAvatarDialControl is the SSRF guard on the avatar proxy: it must refuse to
+// dial non-public addresses (loopback, RFC1918/ULA private, link-local incl. the
+// cloud-metadata IP, multicast, unspecified — including IPv4-mapped IPv6) and
+// allow public ones. The hook runs on every dial and redirect hop, so this is the
+// last line of defense against a forge-returned avatar URL reaching the cluster.
+func TestAvatarDialControl(t *testing.T) {
+	t.Parallel()
+	blocked := []string{
+		"127.0.0.1:443",                // loopback
+		"10.0.0.1:443",                 // RFC1918
+		"172.16.5.4:443",               // RFC1918
+		"192.168.1.1:443",              // RFC1918
+		"169.254.169.254:443",          // link-local / cloud metadata
+		"[::1]:443",                    // IPv6 loopback
+		"[fd00::1]:443",                // IPv6 unique-local (private)
+		"[fe80::1]:443",                // IPv6 link-local
+		"[::ffff:169.254.169.254]:443", // IPv4-mapped metadata — guards the Unmap()
+		"224.0.0.1:443",                // multicast
+		"0.0.0.0:443",                  // unspecified
+	}
+	for _, addr := range blocked {
+		if err := avatarDialControl("tcp", addr, nil); err == nil {
+			t.Errorf("avatarDialControl(%q) = nil, want a refusal", addr)
+		}
+	}
+	allowed := []string{
+		"93.184.216.34:443",                        // public IPv4
+		"[2606:2800:220:1:248:1893:25c8:1946]:443", // public IPv6
+	}
+	for _, addr := range allowed {
+		if err := avatarDialControl("tcp", addr, nil); err != nil {
+			t.Errorf("avatarDialControl(%q) = %v, want nil (public)", addr, err)
+		}
+	}
+}

--- a/internal/server/markdown.go
+++ b/internal/server/markdown.go
@@ -23,9 +23,10 @@ func summaryMarkdown(env api.DiffEnvelope, reviewURL string, admonitions bool) s
 	return konflateMarker(env.PR.Number) + "\n" + summaryMarkdownBody(env, reviewURL, admonitions)
 }
 
-// summaryMarkdownBody is the marker-less summary body. With admonitions=true it
-// uses GitHub-flavoured alert blocks (> [!CAUTION] / > [!WARNING]); otherwise a
-// plain bold-heading + bullet list that renders anywhere. Every forge-controlled
+// summaryMarkdownBody is the marker-less summary body. It opens with an H3 title
+// (### konflate — summary); with admonitions=true the sections use GitHub-flavoured
+// alert blocks (> [!CAUTION] / > [!WARNING]), otherwise plain bold-subheading bullet
+// lists that render anywhere. Every forge-controlled
 // value is escaped (see mdInline/mdCode) so a crafted resource name or a render
 // error can't break the table or inject HTML. Exposed to a custom comment
 // template as {{ .Summary }}.

--- a/internal/server/status_test.go
+++ b/internal/server/status_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"strings"
 	"testing"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/home-operations/konflate/internal/api"
@@ -52,5 +53,33 @@ func TestTruncateStatus(t *testing.T) {
 	multi := truncateStatus(strings.Repeat("é", 200))
 	if !utf8.ValidString(multi) {
 		t.Errorf("truncation split a multibyte rune: %q", multi)
+	}
+}
+
+func TestOneLine(t *testing.T) {
+	t.Parallel()
+	// oneLine guards the commit-status description against newline / control-char
+	// injection from a fork-PR render error.
+	cases := []struct{ name, in, want string }{
+		{"newline to space", "line1\nline2", "line1 line2"},
+		{"crlf and tab collapse", "a\r\n\tb", "a b"},
+		{"esc and nul become spaces", "a\x1b\x00b", "a b"},
+		{"runs collapse and trim", "  multiple   spaces  ", "multiple spaces"},
+		{"plain passes through", "plain", "plain"},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := oneLine(tc.in)
+			if got != tc.want {
+				t.Errorf("oneLine(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			for _, r := range got {
+				if unicode.IsControl(r) {
+					t.Errorf("oneLine(%q) left a control char %U", tc.in, r)
+				}
+			}
+		})
 	}
 }

--- a/internal/webhook/parse.go
+++ b/internal/webhook/parse.go
@@ -36,7 +36,7 @@ func Parse(forge config.ForgeKind, header http.Header, body []byte) Event {
 	case config.ForgeGitHub:
 		switch header.Get("X-GitHub-Event") {
 		case "pull_request":
-			return parsePullRequest(true, body)
+			return parsePullRequest(body)
 		case "status", "check_run", "check_suite":
 			return parseStatus(body)
 		default:
@@ -45,7 +45,7 @@ func Parse(forge config.ForgeKind, header http.Header, body []byte) Event {
 	case config.ForgeForgejo:
 		switch header.Get("X-Gitea-Event") {
 		case "pull_request":
-			return parsePullRequest(true, body)
+			return parsePullRequest(body)
 		case "status":
 			return parseStatus(body)
 		default:
@@ -79,10 +79,7 @@ func unwrapFormPayload(header http.Header, body []byte) []byte {
 // parsePullRequest handles GitHub and Forgejo/Gitea, whose "pull_request"
 // payloads share a shape: {action, number, pull_request:{number}}. The actions
 // that change the open-PR set are the same on both.
-func parsePullRequest(isPullRequest bool, body []byte) Event {
-	if !isPullRequest {
-		return Event{Relist: true}
-	}
+func parsePullRequest(body []byte) Event {
 	var p struct {
 		Action      string `json:"action"`
 		Number      int    `json:"number"`


### PR DESCRIPTION
Follow-ups from a thorough code review (DRY / idiomatic-Go-1.26 / coverage / clean code). **No behavior change** — new tests plus minor, no-op refactors.

The review found the backend already in strong shape on DRY/idiomatic/clean (the three-forge provider "duplication" is irreducible — distinct SDKs; modern stdlib is used widely; `resolvedString` is correctly *not* `sync.OnceValue` since it must retry on failure). The one real gap was **test coverage of the security code shipped earlier this session (0%)** — this closes it.

## Tests added
- **`oneLine`** ([server.go:271](internal/server/server.go:271)) — the status-description sanitizer; asserts newlines/tabs/ESC/NUL collapse to single spaces and the output carries no control runes.
- **`avatarDialControl`** ([handlers.go:281](internal/server/handlers.go:281)) — the avatar-proxy SSRF guard; refuses loopback / RFC1918+ULA / link-local (incl. `169.254.169.254`) / multicast / unspecified / IPv4-mapped-IPv6, allows public addresses.
- **`Load` partial-App-credential check** ([config.go:361](internal/config/config.go:361)) — a lone client id or lone key errors at startup; both halves succeed.
- **prfilter `cel.CostLimit`** ([prfilter.go:62](internal/prfilter/prfilter.go:62)) — a quadratic comprehension over a large label list is bounded (errors) while a cheap expression isn't.

## Clean-ups (no-op)
- Drop the dead `isPullRequest bool` param + unreachable branch in `webhook.parsePullRequest` — both callers passed `true`.
- Hoist the per-key `spec` lookups out of `diff.changedFields`'s loop, matching its sibling `changedSpecKeysOutside`.
- `sort.Strings` → `slices.Sort` in `diff/flux.go` (the last `sort.*` holdout).
- Fix the stale `summaryMarkdownBody` doc (it emits an `### H3` title, not a "bold heading").

## Deferred (noted in the review, intentionally not here)
- Heavier httptest-scaffolded tests (`repoInstallTransport` resolve/cache, `reportOutcome`/`postStatus` gating, the App `slug→[bot]` self-resolver).
- A note that `UpsertComment`'s find-then-create isn't atomic under forge read-after-write lag (could post a rare duplicate comment) — cosmetic, low priority.

## Testing
`go test ./...`, `golangci-lint` (0 issues), `gofmt`, chart generate-check — all green. Coverage 77.1% → 77.7%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)