### PR TITLE
feat(ui): tidy the summary pane — blast radius + image changes

### DIFF
--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -188,7 +188,7 @@ a.repo:focus-visible .repo-ext {
 }
 /* One focus ring for every interactive element, matching .copy-btn's accent
    treatment. Inset so it never clips inside scroll containers. */
-:is(.btn, .card, .card-expand, .forge-link, .expand-all, .scroll-top, .tree-item, .tree-summary, .expand-btn, .view-toggle button, .flag-link, .sum-pill, .ov-head):focus-visible {
+:is(.btn, .card, .card-expand, .forge-link, .expand-all, .scroll-top, .tree-item, .tree-summary, .expand-btn, .view-toggle button, .flag-link, .sum-pill):focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }
@@ -1233,27 +1233,6 @@ button.sum-pill:hover {
 }
 .ov-section.caution-section h3 {
   color: var(--caution);
-}
-/* A collapsible section heading (Image changes when long): the same look as the
-   h3 above, but a button with a leading chevron. */
-.ov-head {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  margin: 0 0 10px;
-  padding: 0;
-  background: none;
-  border: 0;
-  font: inherit;
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--text);
-  letter-spacing: 0.01em;
-  cursor: pointer;
-}
-.ov-head:hover {
-  color: var(--accent);
 }
 /* The per-section item count: a quiet muted number trailing the heading. */
 .ov-count {

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -1200,6 +1200,16 @@ button.sum-pill:hover {
   align-items: start;
   max-width: 860px;
 }
+/* Each grid track stacks its sections vertically: action items (failures +
+   cautions) in the left column, the informational blast radius + image list in
+   the right. The gap matches the grid's row gap so a wrapped single column on a
+   narrow pane reads evenly. */
+.ov-col {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  min-width: 0;
+}
 /* Overview sections sit flat on the pane — headed lists, not boxed cards. The
    grid gap spaces them now, so no per-section margin. */
 .ov-section {
@@ -1338,7 +1348,7 @@ button.sum-pill:hover {
   font-size: 12px;
 }
 /* Name, from → to and the copy button share one baseline row; long digests
-   wrap rather than overflow. The refs trail muted below. */
+   wrap rather than overflow. */
 .img-top {
   display: flex;
   align-items: baseline;
@@ -1368,12 +1378,6 @@ button.sum-pill:hover {
 }
 .img-arrow {
   color: var(--muted);
-}
-.img-refs {
-  margin-top: 2px;
-  color: var(--muted);
-  font-size: 11px;
-  overflow-wrap: anywhere;
 }
 /* ---- diffs (rail + diff) --------------------------------------------- */
 .diffs {

--- a/internal/web/src/lib/Overview.svelte
+++ b/internal/web/src/lib/Overview.svelte
@@ -1,20 +1,10 @@
 <script lang="ts">
   import { router } from './router.svelte';
   import { store, diffIndex, openSel } from './store.svelte';
-  import Icon from './Icon.svelte';
   import Copy from './Copy.svelte';
-  import { mdiChevronDown, mdiChevronRight } from './icons';
   import type { BlastRadiusEntry } from './types';
 
   const d = $derived(store.diff);
-
-  // Image changes can run long on a big bump; collapse the list past this many so
-  // it doesn't push the higher-signal cautions/failures down the pane. The count
-  // stays in the header and one click expands it; shorter lists render open.
-  // Diffs remounts per PR, so imagesOpen resets with each diff.
-  const imageCollapseThreshold = 6;
-  let imagesOpen = $state(false);
-  const imagesCollapsible = $derived((d?.images?.length ?? 0) > imageCollapseThreshold);
 
   // A warning's resource ("Kind ns/name") matches the diff resource's title, so
   // a warning can deep-link to the diff it flags. Null when the resource didn't
@@ -135,36 +125,24 @@
 
         {#if d.images?.length}
           <section class="ov-section">
-            <!-- A long image list collapses behind its count (imageCollapseThreshold)
-                 so it doesn't crowd the blast radius above; a short one renders open. -->
-            {#if imagesCollapsible}
-              <button class="ov-head" aria-expanded={imagesOpen} onclick={() => (imagesOpen = !imagesOpen)}>
-                <Icon path={imagesOpen ? mdiChevronDown : mdiChevronRight} size={14} />
-                Image changes
-                <span class="ov-count">{d.images.length}</span>
-              </button>
-            {:else}
-              <h3>Image changes <span class="ov-count">{d.images.length}</span></h3>
-            {/if}
-            {#if !imagesCollapsible || imagesOpen}
-              <ul class="img-list">
-                {#each d.images as img}
-                  <li class="img-change">
-                    <!-- Name, from → to and copy share one line; ∅ = no reference on
-                         that side (image added/removed) and the tooltip spells it out. -->
-                    <div class="img-top">
-                      <span class="img-name">{img.name}</span>
-                      <span class="img-delta">
-                        <span class="img-ver from" title={img.from || 'not present before this change'}>{shortVer(img.from)}</span>
-                        <span class="img-arrow">→</span>
-                        <span class="img-ver to" title={img.to || 'not present after this change'}>{shortVer(img.to)}</span>
-                      </span>
-                      {#if img.to}<Copy text={imageRef(img.name, img.to)} label="Copy new image reference" />{/if}
-                    </div>
-                  </li>
-                {/each}
-              </ul>
-            {/if}
+            <h3>Image changes <span class="ov-count">{d.images.length}</span></h3>
+            <ul class="img-list">
+              {#each d.images as img}
+                <li class="img-change">
+                  <!-- Name, from → to and copy share one line; ∅ = no reference on
+                       that side (image added/removed) and the tooltip spells it out. -->
+                  <div class="img-top">
+                    <span class="img-name">{img.name}</span>
+                    <span class="img-delta">
+                      <span class="img-ver from" title={img.from || 'not present before this change'}>{shortVer(img.from)}</span>
+                      <span class="img-arrow">→</span>
+                      <span class="img-ver to" title={img.to || 'not present after this change'}>{shortVer(img.to)}</span>
+                    </span>
+                    {#if img.to}<Copy text={imageRef(img.name, img.to)} label="Copy new image reference" />{/if}
+                  </div>
+                </li>
+              {/each}
+            </ul>
           </section>
         {/if}
       </div>

--- a/internal/web/src/lib/Overview.svelte
+++ b/internal/web/src/lib/Overview.svelte
@@ -4,6 +4,7 @@
   import Icon from './Icon.svelte';
   import Copy from './Copy.svelte';
   import { mdiChevronDown, mdiChevronRight } from './icons';
+  import type { BlastRadiusEntry } from './types';
 
   const d = $derived(store.diff);
 
@@ -40,6 +41,26 @@
   // with '@' (a tag can never contain ':', so a ':' in the version means digest).
   function imageRef(name: string, ver: string): string {
     return ver.includes(':') ? `${name}@${ver}` : `${name}:${ver}`;
+  }
+
+  // Blast-radius dependents are "Kind ns/name" and are always the parent's own
+  // kind (Flux dependsOn is same-kind), so name the kind once in the count and
+  // list the bare "ns/name" — no per-row "Kustomization"/"HelmRelease" repeat.
+  function blastKind(parent: string): string {
+    const sp = parent.indexOf(' ');
+    return sp < 0 ? '' : parent.slice(0, sp);
+  }
+  function bareRef(ref: string): string {
+    const sp = ref.indexOf(' ');
+    return sp < 0 ? ref : ref.slice(sp + 1);
+  }
+  // The count is the directly-named dependents — what the list below shows —
+  // not the transitive closure, so the number always matches the names beneath it.
+  function dependentsLabel(br: BlastRadiusEntry): string {
+    const n = br.direct.length;
+    const kind = blastKind(br.parent);
+    const noun = n === 1 ? 'dependent' : 'dependents';
+    return kind ? `${n} ${kind} ${noun}` : `${n} ${noun}`;
   }
 </script>
 
@@ -103,9 +124,9 @@
             {#each d.blastRadius as br}
               <div class="blast">
                 <span class="blast-parent">{br.parent}</span>
-                <span class="blast-count">{br.transitive} {br.transitive === 1 ? 'dependent' : 'dependents'}</span>
+                <span class="blast-count">{dependentsLabel(br)}</span>
                 {#if br.direct?.length}
-                  <div class="blast-deps">{br.direct.join(', ')}</div>
+                  <div class="blast-deps">{br.direct.map(bareRef).join(', ')}</div>
                 {/if}
               </div>
             {/each}

--- a/internal/web/src/lib/Overview.svelte
+++ b/internal/web/src/lib/Overview.svelte
@@ -54,94 +54,99 @@
 <div class="overview">
   <!-- The impact summary (scope counts + change delta) now rides in the sticky
        summary header (see Diffs.svelte); this content is just the sections. -->
-  <!-- Two columns on a wide pane (see .ov-grid). Flags first — render failures,
-       then cautions — then the informational blast radius and image list, so the
-       things a reviewer must act on lead and don't get buried. -->
+  <!-- Two columns on a wide pane (see .ov-grid / .ov-col): the things a reviewer
+       must act on — render failures, then cautions — lead in the left column; the
+       informational blast radius and image list sit together in the right one. -->
   <div class="ov-grid">
-    {#if d.failures?.length}
-      <section class="ov-section fail-section">
-        <h3>Render failures <span class="ov-count">{d.failures.length}</span></h3>
-        {#each d.failures as f}
-          <div class="flag">
-            <span class="flag-title">{f.parent}</span>
-            <span class="flag-detail">{f.message}</span>
-          </div>
-        {/each}
-      </section>
-    {/if}
-
-    {#if d.warnings?.length}
-      <section class="ov-section caution-section">
-        <h3>Cautions <span class="ov-count">{d.warnings.length}</span></h3>
-        {#each d.warnings as w}
-          {@const target = warningTarget(w.resource)}
-          <!-- Cautions whose resource rendered into the diff deep-link to it. -->
-          {#if target}
-            <button class="flag flag-link {w.level}" title="View the resource diff" onclick={() => openWarning(target)}>
-              {@render warningBody(w)}
-            </button>
-          {:else}
-            <div class="flag {w.level}">{@render warningBody(w)}</div>
-          {/if}
-        {/each}
-      </section>
-    {/if}
-
-    <!-- Blast radius: for each changed/failed app, how many downstream apps
-         declare a transitive spec.dependsOn on it — the reconciliation reach a
-         raw file diff can't show. Direct dependents are named; the count is the
-         full transitive closure. Absent when nothing changed depends-on anything. -->
-    {#if d.blastRadius?.length}
-      <section class="ov-section">
-        <h3>Blast radius <span class="ov-count">{d.blastRadius.length}</span></h3>
-        {#each d.blastRadius as br}
-          <div class="blast">
-            <span class="blast-parent">{br.parent}</span>
-            <span class="blast-count">{br.transitive} {br.transitive === 1 ? 'dependent' : 'dependents'}</span>
-            {#if br.direct?.length}
-              <div class="blast-deps">{br.direct.join(', ')}</div>
-            {/if}
-          </div>
-        {/each}
-      </section>
-    {/if}
-
-    {#if d.images?.length}
-      <section class="ov-section">
-        <!-- A long image list collapses behind its count (imageCollapseThreshold)
-             so it doesn't crowd out the flags above; a short one renders open. -->
-        {#if imagesCollapsible}
-          <button class="ov-head" aria-expanded={imagesOpen} onclick={() => (imagesOpen = !imagesOpen)}>
-            <Icon path={imagesOpen ? mdiChevronDown : mdiChevronRight} size={14} />
-            Image changes
-            <span class="ov-count">{d.images.length}</span>
-          </button>
-        {:else}
-          <h3>Image changes <span class="ov-count">{d.images.length}</span></h3>
-        {/if}
-        {#if !imagesCollapsible || imagesOpen}
-          <ul class="img-list">
-            {#each d.images as img}
-              <li class="img-change">
-                <!-- Name, from → to and copy share one line; ∅ = no reference on
-                     that side (image added/removed) and the tooltip spells it out. -->
-                <div class="img-top">
-                  <span class="img-name">{img.name}</span>
-                  <span class="img-delta">
-                    <span class="img-ver from" title={img.from || 'not present before this change'}>{shortVer(img.from)}</span>
-                    <span class="img-arrow">→</span>
-                    <span class="img-ver to" title={img.to || 'not present after this change'}>{shortVer(img.to)}</span>
-                  </span>
-                  {#if img.to}<Copy text={imageRef(img.name, img.to)} label="Copy new image reference" />{/if}
-                </div>
-                {#if img.refs?.length}
-                  <div class="img-refs">{img.refs.join(', ')}</div>
-                {/if}
-              </li>
+    {#if d.failures?.length || d.warnings?.length}
+      <div class="ov-col">
+        {#if d.failures?.length}
+          <section class="ov-section fail-section">
+            <h3>Render failures <span class="ov-count">{d.failures.length}</span></h3>
+            {#each d.failures as f}
+              <div class="flag">
+                <span class="flag-title">{f.parent}</span>
+                <span class="flag-detail">{f.message}</span>
+              </div>
             {/each}
-          </ul>
+          </section>
         {/if}
-      </section>
+
+        {#if d.warnings?.length}
+          <section class="ov-section caution-section">
+            <h3>Cautions <span class="ov-count">{d.warnings.length}</span></h3>
+            {#each d.warnings as w}
+              {@const target = warningTarget(w.resource)}
+              <!-- Cautions whose resource rendered into the diff deep-link to it. -->
+              {#if target}
+                <button class="flag flag-link {w.level}" title="View the resource diff" onclick={() => openWarning(target)}>
+                  {@render warningBody(w)}
+                </button>
+              {:else}
+                <div class="flag {w.level}">{@render warningBody(w)}</div>
+              {/if}
+            {/each}
+          </section>
+        {/if}
+      </div>
+    {/if}
+
+    {#if d.blastRadius?.length || d.images?.length}
+      <div class="ov-col">
+        <!-- Blast radius: for each changed/failed app, how many downstream apps
+             declare a transitive spec.dependsOn on it — the reconciliation reach a
+             raw file diff can't show. Direct dependents are named; the count is the
+             full transitive closure. Absent when nothing changed depends-on anything. -->
+        {#if d.blastRadius?.length}
+          <section class="ov-section">
+            <h3>Blast radius <span class="ov-count">{d.blastRadius.length}</span></h3>
+            {#each d.blastRadius as br}
+              <div class="blast">
+                <span class="blast-parent">{br.parent}</span>
+                <span class="blast-count">{br.transitive} {br.transitive === 1 ? 'dependent' : 'dependents'}</span>
+                {#if br.direct?.length}
+                  <div class="blast-deps">{br.direct.join(', ')}</div>
+                {/if}
+              </div>
+            {/each}
+          </section>
+        {/if}
+
+        {#if d.images?.length}
+          <section class="ov-section">
+            <!-- A long image list collapses behind its count (imageCollapseThreshold)
+                 so it doesn't crowd the blast radius above; a short one renders open. -->
+            {#if imagesCollapsible}
+              <button class="ov-head" aria-expanded={imagesOpen} onclick={() => (imagesOpen = !imagesOpen)}>
+                <Icon path={imagesOpen ? mdiChevronDown : mdiChevronRight} size={14} />
+                Image changes
+                <span class="ov-count">{d.images.length}</span>
+              </button>
+            {:else}
+              <h3>Image changes <span class="ov-count">{d.images.length}</span></h3>
+            {/if}
+            {#if !imagesCollapsible || imagesOpen}
+              <ul class="img-list">
+                {#each d.images as img}
+                  <li class="img-change">
+                    <!-- Name, from → to and copy share one line; ∅ = no reference on
+                         that side (image added/removed) and the tooltip spells it out. -->
+                    <div class="img-top">
+                      <span class="img-name">{img.name}</span>
+                      <span class="img-delta">
+                        <span class="img-ver from" title={img.from || 'not present before this change'}>{shortVer(img.from)}</span>
+                        <span class="img-arrow">→</span>
+                        <span class="img-ver to" title={img.to || 'not present after this change'}>{shortVer(img.to)}</span>
+                      </span>
+                      {#if img.to}<Copy text={imageRef(img.name, img.to)} label="Copy new image reference" />{/if}
+                    </div>
+                  </li>
+                {/each}
+              </ul>
+            {/if}
+          </section>
+        {/if}
+      </div>
     {/if}
   </div>
 </div>

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -938,9 +938,9 @@ test('zero counts stay neutral (impact delta) and hidden (diff header)', async (
   await expect(page.locator('[data-sel="r2"] .res-counts .add')).toHaveCount(0);
 });
 
-test('a long image list collapses behind its count and expands on click', async ({ page }) => {
-  // Past the collapse threshold the Image changes list is folded so it can't bury
-  // the higher-signal sections; the count stays visible and one click opens it.
+test('a long image list renders in full by default (no collapse)', async ({ page }) => {
+  // Image changes live in their own summary column, so even a long list renders
+  // open by default — there's no fold-behind-the-count control.
   const many = Array.from({ length: 9 }, (_, i) => ({
     name: `ghcr.io/app-${i}`,
     from: `v1.${i}.0`,
@@ -954,14 +954,8 @@ test('a long image list collapses behind its count and expands on click', async 
   await page.routeWebSocket('**/ws', () => {});
   await page.goto('/#/pr/142');
 
-  const head = page.locator('.ov-head', { hasText: 'Image changes' });
-  await expect(head).toContainText('9');
-  await expect(head).toHaveAttribute('aria-expanded', 'false');
-  await expect(page.locator('.img-list')).toHaveCount(0);
-
-  await head.click();
-  await expect(head).toHaveAttribute('aria-expanded', 'true');
   await expect(page.locator('.img-change')).toHaveCount(9);
+  await expect(page.locator('.ov-head')).toHaveCount(0); // no fold control
 });
 
 test('an open PR with cautions carries an amber card edge', async ({ page }) => {


### PR DESCRIPTION
Summary-pane tidy-up.

## 1. Image changes moves next to Blast radius
The two-column grid (`.ov-grid`) placed sections row-major, so on a wide pane the image list wrapped under Cautions instead of with the blast radius. Sections are now grouped into two explicit columns: **left** = the things to act on (render failures, cautions); **right** = the informational blast radius + image changes, stacked. Each column renders only when it has content, and the grid still collapses to one column on a narrow pane.

## 2. Image changes always shown (collapse removed)
Image changes used to fold behind their count past 6 items — that existed only to stop a long list from burying the cautions/failures. Now that image changes sit in their own column, that rationale is gone, so the list always renders open. Dropped `imagesOpen` / the threshold, the `.ov-head` toggle button + its CSS, and the now-unused chevron/Icon imports.

## 3. Per-image refs line removed
Each image change dropped the resource-reference subline (`img.refs`, e.g. "Deployment rook-ceph/rook-ceph-operator, ConfigMap …"), so it's one compact row: name, `from → to`, copy. The referencing resources are still in the full resource diffs. The now-unused `.img-refs` CSS was removed.

## 4. Blast radius: count the named dependents, drop the per-row kind
The dependent count was the **transitive closure** while the list showed only the **direct** dependents — so an entry read "27 dependents" above a single name (rook-ceph → rook-ceph-cluster → that cluster's 26 apps = 27). Now the count is the directly-named dependents (so the number matches the list below it), the kind is stated once in the label — **"26 Kustomization dependents"** — and each row is the bare `ns/name`, no repeated "Kustomization"/"HelmRelease".

The transitive closure is no longer surfaced in the web UI; the markdown PR-comment summary still renders it with its own "+N more" style (left unchanged here to keep this PR UI-only).

## Testing
`ui-typecheck` (0 errors), `ui-build`, `ui-test` (Playwright, 66 passed / 1 skipped) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)