### PR TITLE
fix(writeback): serialize write-backs per PR to stop duplicate comments

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,6 +16,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"text/template"
 	"time"
 	"unicode"
@@ -53,6 +54,11 @@ type Server struct {
 	metrics *metrics
 	queue   *queue
 	runCtx  context.Context
+
+	// prWrite serializes forge write-backs per PR (see writeBack): the queue can
+	// finish a PR's in-flight and trailing renders back-to-back, each firing a
+	// write-back, and two for the same PR must not race into duplicate comments.
+	prWrite keyedMutex
 
 	// relist is the coalescing signal for webhook-triggered re-lists. It holds a
 	// single token, so a burst of inbound events collapses to one in-flight
@@ -155,13 +161,60 @@ func (s *Server) reportOutcome(pr api.PR, st api.JobStatus, sig *api.Signals, er
 	}
 }
 
+// keyedMutex serializes work per integer key (a PR number): locking a key blocks
+// only other holders of the same key, so distinct PRs proceed concurrently. The
+// per-key mutex is reference-counted and dropped once idle, so the map can't grow
+// without bound across a long-lived instance's PR numbers.
+type keyedMutex struct {
+	mu sync.Mutex
+	m  map[int]*keyedLock
+}
+
+type keyedLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
+// lock acquires key's mutex and returns its unlock func.
+func (k *keyedMutex) lock(key int) func() {
+	k.mu.Lock()
+	if k.m == nil {
+		k.m = make(map[int]*keyedLock)
+	}
+	kl := k.m[key]
+	if kl == nil {
+		kl = &keyedLock{}
+		k.m[key] = kl
+	}
+	kl.refs++
+	k.mu.Unlock()
+
+	kl.mu.Lock()
+	return func() {
+		kl.mu.Unlock()
+		k.mu.Lock()
+		if kl.refs--; kl.refs == 0 {
+			delete(k.m, key)
+		}
+		k.mu.Unlock()
+	}
+}
+
 // writeBack runs one forge write off the render path: on its own goroutine,
 // retried with backoff and bounded by forgeWriteTimeout, logging (never failing)
 // on giving up so a write-back problem never blocks or fails a render. A write
 // cut short by shutdown (runCtx cancelled) is draining, not a failure, so it
 // isn't warned — matching the render queue's handling of context.Canceled.
+//
+// Write-backs for one PR are serialized (s.prWrite): the queue can finish two
+// renders of a PR back-to-back (in-flight + trailing), each firing a write-back,
+// and unserialized their UpsertComment find-then-create would race into duplicate
+// comments. The later write instead waits, then sees and edits the earlier one's
+// comment. The lock is taken before the timeout so the wait isn't charged against it.
 func (s *Server) writeBack(kind string, number int, fn func(ctx context.Context) error) {
 	go func() {
+		unlock := s.prWrite.lock(number)
+		defer unlock()
 		ctx, cancel := context.WithTimeout(s.runCtx, forgeWriteTimeout)
 		defer cancel()
 		if err := retryWrite(ctx, forgeWriteAttempts, forgeWriteBackoff, func() error { return fn(ctx) }); err != nil &&

--- a/internal/server/writeback_test.go
+++ b/internal/server/writeback_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -89,4 +91,63 @@ func TestRetryWrite(t *testing.T) {
 			t.Fatalf("calls=%d err=%v; want a single try and an error (no long sleep)", calls, err)
 		}
 	})
+}
+
+// TestWriteBack_SerializesPerPR is the duplicate-comment guard: two write-backs
+// for the same PR (the queue can finish its in-flight and trailing renders
+// back-to-back, each firing one) must run one at a time, so the later one sees
+// and edits the earlier one's comment instead of racing into a second create.
+func TestWriteBack_SerializesPerPR(t *testing.T) {
+	t.Parallel()
+	srv := &Server{runCtx: context.Background(), log: discardLog()}
+	var inFlight, maxConc int32
+	var wg sync.WaitGroup
+	work := func(context.Context) error {
+		cur := atomic.AddInt32(&inFlight, 1)
+		for {
+			m := atomic.LoadInt32(&maxConc)
+			if cur <= m || atomic.CompareAndSwapInt32(&maxConc, m, cur) {
+				break
+			}
+		}
+		time.Sleep(3 * time.Millisecond) // widen the window a racing write would overlap in
+		atomic.AddInt32(&inFlight, -1)
+		wg.Done()
+		return nil
+	}
+	wg.Add(2)
+	srv.writeBack("comment", 5, work)
+	srv.writeBack("comment", 5, work)
+	wg.Wait()
+	if maxConc != 1 {
+		t.Fatalf("same-PR write-backs overlapped (max concurrency %d), want serialized (1)", maxConc)
+	}
+}
+
+func TestKeyedMutex_DistinctKeysDoNotBlock(t *testing.T) {
+	t.Parallel()
+	var km keyedMutex
+	unlock1 := km.lock(1)
+	defer unlock1()
+	done := make(chan struct{})
+	go func() {
+		km.lock(2)() // a different key must not wait on key 1
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("lock on a distinct key blocked while another key was held")
+	}
+}
+
+func TestKeyedMutex_DropsIdleEntries(t *testing.T) {
+	t.Parallel()
+	var km keyedMutex
+	km.lock(7)() // lock then immediately unlock
+	km.mu.Lock()
+	defer km.mu.Unlock()
+	if n := len(km.m); n != 0 {
+		t.Fatalf("idle key left %d map entries, want 0 (no unbounded growth)", n)
+	}
 }


### PR DESCRIPTION
A user reported the bot commenting **multiple times on the same PR**. The logs show the race:

```
18:59:12.991  queuing render pr:5462 webhook   ×4   (a GitHub PR-sync burst)
18:59:14.387  diff rendered pr:5462                  ← render A → write-back
18:59:14.959  diff rendered pr:5462                  ← render B → write-back (~0.5s later)
```

The queue coalesces the webhook burst into two renders (in-flight + trailing), and **each render fires its own write-back goroutine**. `UpsertComment` does list → (edit existing | create new) with no serialization, so two write-backs for the same PR both list — neither sees the other's not-yet-posted comment — and both **create**, leaving duplicate comments. The author match added in the security hardening doesn't help here: both comments are konflate's own.

## Fix
Serialize forge write-backs **per PR** with a small reference-counted keyed mutex (`keyedMutex`), held across the bounded retry inside the write-back goroutine. The later write now waits for the earlier one, then finds and edits its comment instead of creating a second. Properties:

- **Per-PR, not global** — distinct PRs still write concurrently (so one slow forge write can't stall others).
- **Lock before the timeout** — the wait isn't charged against the 30s write budget.
- **No unbounded growth** — the per-key mutex is dropped once idle, so the map doesn't accumulate an entry per PR number over a long-lived instance.

The trailing render still fires a write-back, but it's now an idempotent edit of the same comment rather than a duplicate.

## Testing
- `TestWriteBack_SerializesPerPR` — two concurrent write-backs for one PR observe max concurrency 1 (would be 2 without the lock).
- `TestKeyedMutex_DistinctKeysDoNotBlock` — different PRs don't serialize.
- `TestKeyedMutex_DropsIdleEntries` — idle keys are reclaimed.
- `go test ./...` (incl. `-race` on the server package), `golangci-lint` (0 issues), `gofmt` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)