### PR TITLE
fix(writeback): skip the comment edit when the body is unchanged

### DIFF
--- a/internal/provider/writer.go
+++ b/internal/provider/writer.go
@@ -46,7 +46,9 @@ type Writer interface {
 	// SetStatus posts (or overwrites) konflate's commit status on the PR head.
 	SetStatus(ctx context.Context, pr api.PR, st Status) error
 	// UpsertComment posts body as a PR comment, or edits konflate's existing
-	// comment in place — the one whose body contains marker — if there is one.
+	// comment in place — the one konflate authored whose body contains marker — if
+	// there is one. An existing comment already carrying this exact body is left
+	// untouched, so a re-render of an unchanged PR doesn't mark the comment "edited".
 	UpsertComment(ctx context.Context, pr api.PR, marker, body string) error
 	// Verify checks the credential can reach the repo, exercising the full auth
 	// path (for a GitHub App, minting the installation token). It returns nil on
@@ -342,6 +344,9 @@ func (w *githubWriter) UpsertComment(ctx context.Context, pr api.PR, marker, bod
 			return fmt.Errorf("github: list comments #%d: %w", pr.Number, err)
 		}
 		if c.GetUser().GetLogin() == self && c.Body != nil && strings.Contains(*c.Body, marker) {
+			if strings.TrimSpace(*c.Body) == strings.TrimSpace(body) {
+				return nil // unchanged — skip the no-op edit so a re-render doesn't mark it "edited"
+			}
 			_, _, err = w.client.Issues.EditComment(ctx, w.owner, w.repo, c.GetID(), &github.IssueComment{Body: &body})
 			if err != nil {
 				return fmt.Errorf("github: edit comment #%d: %w", pr.Number, err)
@@ -436,6 +441,9 @@ func (w *forgejoWriter) UpsertComment(ctx context.Context, pr api.PR, marker, bo
 		for _, c := range comments {
 			// Match konflate's own comment (author + marker), not just the public marker.
 			if c.Poster != nil && c.Poster.UserName == self && strings.Contains(c.Body, marker) {
+				if strings.TrimSpace(c.Body) == strings.TrimSpace(body) {
+					return nil // unchanged — skip the no-op edit
+				}
 				_, _, err = w.client.EditIssueComment(w.owner, w.repo, c.ID, forgejo.EditIssueCommentOption{Body: body})
 				if err != nil {
 					return fmt.Errorf("forgejo: edit comment #%d: %w", pr.Number, err)
@@ -520,6 +528,9 @@ func (w *gitlabWriter) UpsertComment(ctx context.Context, pr api.PR, marker, bod
 		for _, n := range notes {
 			// Match konflate's own note (author + marker), not just the public marker.
 			if n.Author.Username == self && strings.Contains(n.Body, marker) {
+				if strings.TrimSpace(n.Body) == strings.TrimSpace(body) {
+					return nil // unchanged — skip the no-op edit
+				}
 				_, _, err = w.client.Notes.UpdateMergeRequestNote(w.project, mr, n.ID,
 					&gitlab.UpdateMergeRequestNoteOptions{Body: &body}, gitlab.WithContext(ctx))
 				if err != nil {

--- a/internal/provider/writer_test.go
+++ b/internal/provider/writer_test.go
@@ -336,6 +336,13 @@ func assertEdited(t *testing.T, sink commentSink) {
 	}
 }
 
+func assertNoop(t *testing.T, sink commentSink) {
+	t.Helper()
+	if sink.created || sink.edited {
+		t.Fatalf("want no write for an unchanged body, got created=%v edited=%v", sink.created, sink.edited)
+	}
+}
+
 func TestGitHubWriter_UpsertComment(t *testing.T) {
 	t.Parallel()
 	t.Run("creates when absent", func(t *testing.T) {
@@ -370,6 +377,18 @@ func TestGitHubWriter_UpsertComment(t *testing.T) {
 			t.Fatalf("UpsertComment: %v", err)
 		}
 		assertCreated(t, sink) // posts its own; must not edit the planted comment
+	})
+	t.Run("leaves an unchanged comment untouched", func(t *testing.T) {
+		t.Parallel()
+		var sink commentSink
+		srv := httptest.NewServer(commentCapture(markerList(), &sink))
+		t.Cleanup(srv.Close)
+		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
+		// Same body as the listed comment — konflate must skip the no-op edit.
+		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nold"); err != nil {
+			t.Fatalf("UpsertComment: %v", err)
+		}
+		assertNoop(t, sink)
 	})
 }
 
@@ -416,6 +435,17 @@ func TestGitlabWriter_UpsertComment(t *testing.T) {
 		}
 		assertCreated(t, sink) // posts its own; must not edit the planted note
 	})
+	t.Run("leaves an unchanged note untouched", func(t *testing.T) {
+		t.Parallel()
+		var sink commentSink
+		srv := httptest.NewServer(commentCapture(markerList(), &sink))
+		t.Cleanup(srv.Close)
+		wr := &gitlabWriter{client: newClient(t, srv.URL), project: "acme/web", self: konflateSelf()}
+		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nold"); err != nil {
+			t.Fatalf("UpsertComment: %v", err)
+		}
+		assertNoop(t, sink)
+	})
 }
 
 func TestForgejoWriter_UpsertComment(t *testing.T) {
@@ -460,6 +490,17 @@ func TestForgejoWriter_UpsertComment(t *testing.T) {
 			t.Fatalf("UpsertComment: %v", err)
 		}
 		assertCreated(t, sink) // posts its own; must not edit the planted comment
+	})
+	t.Run("leaves an unchanged comment untouched", func(t *testing.T) {
+		t.Parallel()
+		var sink commentSink
+		srv := httptest.NewServer(commentCapture(markerList(), &sink))
+		t.Cleanup(srv.Close)
+		wr := &forgejoWriter{client: newClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
+		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nold"); err != nil {
+			t.Fatalf("UpsertComment: %v", err)
+		}
+		assertNoop(t, sink)
 	})
 }
 


### PR DESCRIPTION
A user noticed konflate's PR comment shows "edited" on every re-render even when nothing changed. A re-render of a PR whose head hasn't moved (a periodic refresh, a label-only webhook, the queue's trailing render) produces an **identical** comment body but still called `EditComment` — so the forge marks the comment edited with no actual change.

## Fix
Each forge's `UpsertComment`, once it's found konflate's own marked comment, compares the new body to the existing one and returns without editing when they're equal:

```go
if strings.TrimSpace(*c.Body) == strings.TrimSpace(body) {
    return nil // unchanged — skip the no-op edit
}
```

(GitHub `EditComment`, GitLab `UpdateMergeRequestNote`, Forgejo `EditIssueComment`.) `TrimSpace` guards against trailing-newline drift; any real content change still differs and edits. The body is deterministic for a given diff (no timestamps), so an unchanged head ⇒ identical body ⇒ no edit. Create, and the author + marker match, are unchanged.

This complements the write-back serialization fix (#204): that stops duplicate *creates* from concurrent renders; this stops no-op *edits* from unchanged re-renders.

## Testing
- New per-forge case: a listed comment whose body equals the new body is left untouched (neither created nor edited).
- Existing create / edit-its-own / ignore-foreign-author cases unchanged and green.
- `go build`, `go test ./...`, `golangci-lint` (0 issues), `gofmt` — all clean. No chart/UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)