### PR TITLE
feat(ui): always show all four summary columns, with empty-state placeholders

### DIFF
--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -1190,20 +1190,19 @@ button.sum-pill:hover {
   font-weight: 600;
   color: var(--warn);
 }
-/* Up to three columns, each a fixed measure rather than a stretching 1fr, capped
-   by max-width so the band doesn't span a wide pane edge-to-edge; auto-fit drops
-   to fewer (then one) as the pane narrows. */
+/* Four columns — render failures, cautions, blast radius, image changes — each a
+   shrinkable track so all four fit the pane the old three did; auto-fit drops to
+   fewer (then one) as the pane narrows. max-width keeps a wide pane from spreading
+   them edge-to-edge. */
 .ov-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 380px));
-  gap: 28px 44px;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 24px;
   align-items: start;
-  max-width: 1240px;
+  max-width: 1280px;
 }
-/* Each grid track stacks its sections vertically: action items (failures +
-   cautions) in the first column, the informational blast radius and image changes
-   each in their own. The gap matches the grid's row gap so wrapped columns on a
-   narrow pane read evenly. */
+/* One section per column. min-width lets the track shrink below its content's
+   intrinsic width so a long identifier wraps instead of widening the column. */
 .ov-col {
   display: flex;
   flex-direction: column;
@@ -1241,6 +1240,15 @@ button.sum-pill:hover {
   color: var(--muted);
   font-variant-numeric: tabular-nums;
 }
+/* An empty section's placeholder — same flat left-rule row as a flag, but green:
+   the absence is reassuring, the colour matches the red/amber rules on real flags
+   so the four columns read as one family whether or not they have content. */
+.ov-empty {
+  padding-left: 12px;
+  border-left: 2px solid var(--ok);
+  color: var(--muted);
+  font-size: 12px;
+}
 /* A flag — a render failure or a caution — is a flat row with a single left
    rule, not a bordered, tinted card. The rule is red by default (a render
    failure: the diff broke); cautions step it down to amber. The resource leads
@@ -1275,6 +1283,7 @@ button.sum-pill:hover {
   font-family: var(--font-mono);
   font-size: 12px;
   font-weight: 600;
+  overflow-wrap: anywhere;
 }
 .flag-detail {
   display: block;
@@ -1303,6 +1312,7 @@ button.sum-pill:hover {
   font-family: var(--font-mono);
   font-size: 12px;
   font-weight: 600;
+  overflow-wrap: anywhere;
 }
 .blast-count {
   font-size: 11px;

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -1128,8 +1128,11 @@ button.sum-pill:hover {
 /* ---- overview -------------------------------------------------------- */
 /* Flush-left like the diff sections below it — the Summary is one of the
    stacked sections, not a centered page. */
+/* Query container for the summary grid: its 4/2/1 column breakpoints measure this
+   pane's width directly, so they're right whether or not the tree rail is present. */
 .overview {
   padding: 14px;
+  container-type: inline-size;
 }
 /* The impact summary now rides in the sticky summary header (see Diffs.svelte),
    left of the merge command — so it centers in the bar with no bottom margin and
@@ -1190,16 +1193,27 @@ button.sum-pill:hover {
   font-weight: 600;
   color: var(--warn);
 }
-/* Four columns — render failures, cautions, blast radius, image changes — each a
-   shrinkable track so all four fit the pane the old three did; auto-fit drops to
-   fewer (then one) as the pane narrows. max-width keeps a wide pane from spreading
-   them edge-to-edge. */
+/* Four columns — render failures, cautions, blast radius, image changes. Explicit
+   4 / 2 / 1 breakpoints rather than auto-fit, which packs three then orphans the
+   fourth onto a lonely second row: wide → four across, medium → a balanced 2×2,
+   narrow → a single stack. Always a balanced grid, never a 3+1. The queries read
+   .overview's width (the pane), so they're right with or without the tree rail. */
 .ov-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  grid-template-columns: minmax(0, 1fr);
   gap: 24px;
   align-items: start;
   max-width: 1280px;
+}
+@container (min-width: 440px) {
+  .ov-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+@container (min-width: 820px) {
+  .ov-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
 }
 /* One section per column. min-width lets the track shrink below its content's
    intrinsic width so a long identifier wraps instead of widening the column. */

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -1190,20 +1190,20 @@ button.sum-pill:hover {
   font-weight: 600;
   color: var(--warn);
 }
-/* Up to two columns, each a fixed measure rather than a stretching 1fr, capped
+/* Up to three columns, each a fixed measure rather than a stretching 1fr, capped
    by max-width so the band doesn't span a wide pane edge-to-edge; auto-fit drops
-   to one when narrow. */
+   to fewer (then one) as the pane narrows. */
 .ov-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 380px));
   gap: 28px 44px;
   align-items: start;
-  max-width: 860px;
+  max-width: 1240px;
 }
 /* Each grid track stacks its sections vertically: action items (failures +
-   cautions) in the left column, the informational blast radius + image list in
-   the right. The gap matches the grid's row gap so a wrapped single column on a
-   narrow pane reads evenly. */
+   cautions) in the first column, the informational blast radius and image changes
+   each in their own. The gap matches the grid's row gap so wrapped columns on a
+   narrow pane read evenly. */
 .ov-col {
   display: flex;
   flex-direction: column;

--- a/internal/web/src/lib/Overview.svelte
+++ b/internal/web/src/lib/Overview.svelte
@@ -65,9 +65,11 @@
 <div class="overview">
   <!-- The impact summary (scope counts + change delta) now rides in the sticky
        summary header (see Diffs.svelte); this content is just the sections. -->
-  <!-- Two columns on a wide pane (see .ov-grid / .ov-col): the things a reviewer
-       must act on — render failures, then cautions — lead in the left column; the
-       informational blast radius and image list sit together in the right one. -->
+  <!-- Three columns on a wide pane (see .ov-grid / .ov-col): the things a reviewer
+       must act on — render failures, then cautions — lead in the first column; the
+       informational blast radius and image changes each get their own. Each column
+       renders only when it has content, so an empty one leaves no gap and a narrow
+       pane collapses them to fewer columns. -->
   <div class="ov-grid">
     {#if d.failures?.length || d.warnings?.length}
       <div class="ov-col">
@@ -102,49 +104,49 @@
       </div>
     {/if}
 
-    {#if d.blastRadius?.length || d.images?.length}
+    {#if d.blastRadius?.length}
       <div class="ov-col">
         <!-- Blast radius: for each changed/failed app, how many downstream apps
              declare a transitive spec.dependsOn on it — the reconciliation reach a
              raw file diff can't show. Direct dependents are named; the count is the
              full transitive closure. Absent when nothing changed depends-on anything. -->
-        {#if d.blastRadius?.length}
-          <section class="ov-section">
-            <h3>Blast radius <span class="ov-count">{d.blastRadius.length}</span></h3>
-            {#each d.blastRadius as br}
-              <div class="blast">
-                <span class="blast-parent">{br.parent}</span>
-                <span class="blast-count">{dependentsLabel(br)}</span>
-                {#if br.direct?.length}
-                  <div class="blast-deps">{br.direct.map(bareRef).join(', ')}</div>
-                {/if}
-              </div>
-            {/each}
-          </section>
-        {/if}
+        <section class="ov-section">
+          <h3>Blast radius <span class="ov-count">{d.blastRadius.length}</span></h3>
+          {#each d.blastRadius as br}
+            <div class="blast">
+              <span class="blast-parent">{br.parent}</span>
+              <span class="blast-count">{dependentsLabel(br)}</span>
+              {#if br.direct?.length}
+                <div class="blast-deps">{br.direct.map(bareRef).join(', ')}</div>
+              {/if}
+            </div>
+          {/each}
+        </section>
+      </div>
+    {/if}
 
-        {#if d.images?.length}
-          <section class="ov-section">
-            <h3>Image changes <span class="ov-count">{d.images.length}</span></h3>
-            <ul class="img-list">
-              {#each d.images as img}
-                <li class="img-change">
-                  <!-- Name, from → to and copy share one line; ∅ = no reference on
-                       that side (image added/removed) and the tooltip spells it out. -->
-                  <div class="img-top">
-                    <span class="img-name">{img.name}</span>
-                    <span class="img-delta">
-                      <span class="img-ver from" title={img.from || 'not present before this change'}>{shortVer(img.from)}</span>
-                      <span class="img-arrow">→</span>
-                      <span class="img-ver to" title={img.to || 'not present after this change'}>{shortVer(img.to)}</span>
-                    </span>
-                    {#if img.to}<Copy text={imageRef(img.name, img.to)} label="Copy new image reference" />{/if}
-                  </div>
-                </li>
-              {/each}
-            </ul>
-          </section>
-        {/if}
+    {#if d.images?.length}
+      <div class="ov-col">
+        <section class="ov-section">
+          <h3>Image changes <span class="ov-count">{d.images.length}</span></h3>
+          <ul class="img-list">
+            {#each d.images as img}
+              <li class="img-change">
+                <!-- Name, from → to and copy share one line; ∅ = no reference on
+                     that side (image added/removed) and the tooltip spells it out. -->
+                <div class="img-top">
+                  <span class="img-name">{img.name}</span>
+                  <span class="img-delta">
+                    <span class="img-ver from" title={img.from || 'not present before this change'}>{shortVer(img.from)}</span>
+                    <span class="img-arrow">→</span>
+                    <span class="img-ver to" title={img.to || 'not present after this change'}>{shortVer(img.to)}</span>
+                  </span>
+                  {#if img.to}<Copy text={imageRef(img.name, img.to)} label="Copy new image reference" />{/if}
+                </div>
+              </li>
+            {/each}
+          </ul>
+        </section>
       </div>
     {/if}
   </div>

--- a/internal/web/src/lib/Overview.svelte
+++ b/internal/web/src/lib/Overview.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { router } from './router.svelte';
   import { store, diffIndex, openSel } from './store.svelte';
   import Copy from './Copy.svelte';
@@ -54,9 +55,85 @@
   }
 </script>
 
+<!-- One always-rendered column: the heading (with a count when non-empty and a
+     severity colour when there's something to act on), then either the section's
+     body or a green "No …" placeholder so the four columns line up even when a
+     section is empty. The empty text follows the heading, so renaming a column
+     renames its placeholder too. -->
+{#snippet column(title: string, count: number, severity: string, body: Snippet)}
+  <div class="ov-col">
+    <section class="ov-section {count ? severity : ''}">
+      <h3>{title}{#if count} <span class="ov-count">{count}</span>{/if}</h3>
+      {#if count}
+        {@render body()}
+      {:else}
+        <div class="ov-empty">No {title.toLowerCase()}</div>
+      {/if}
+    </section>
+  </div>
+{/snippet}
+
 {#snippet warningBody(w: { level: string; resource: string; detail: string })}
   <span class="flag-title">{w.resource}</span>
   <span class="flag-detail">{w.detail}</span>
+{/snippet}
+
+{#snippet failuresBody()}
+  {#each d?.failures ?? [] as f}
+    <div class="flag">
+      <span class="flag-title">{f.parent}</span>
+      <span class="flag-detail">{f.message}</span>
+    </div>
+  {/each}
+{/snippet}
+
+{#snippet cautionsBody()}
+  {#each d?.warnings ?? [] as w}
+    {@const target = warningTarget(w.resource)}
+    <!-- Cautions whose resource rendered into the diff deep-link to it. -->
+    {#if target}
+      <button class="flag flag-link {w.level}" title="View the resource diff" onclick={() => openWarning(target)}>
+        {@render warningBody(w)}
+      </button>
+    {:else}
+      <div class="flag {w.level}">{@render warningBody(w)}</div>
+    {/if}
+  {/each}
+{/snippet}
+
+{#snippet blastBody()}
+  <!-- Blast radius: for each changed/failed app, how many downstream apps declare
+       a transitive spec.dependsOn on it — the reconciliation reach a raw file diff
+       can't show. Direct dependents are named; the count is the direct dependents. -->
+  {#each d?.blastRadius ?? [] as br}
+    <div class="blast">
+      <span class="blast-parent">{br.parent}</span>
+      <span class="blast-count">{dependentsLabel(br)}</span>
+      {#if br.direct?.length}
+        <div class="blast-deps">{br.direct.map(bareRef).join(', ')}</div>
+      {/if}
+    </div>
+  {/each}
+{/snippet}
+
+{#snippet imagesBody()}
+  <ul class="img-list">
+    {#each d?.images ?? [] as img}
+      <li class="img-change">
+        <!-- Name, from → to and copy share one line; ∅ = no reference on that
+             side (image added/removed) and the tooltip spells it out. -->
+        <div class="img-top">
+          <span class="img-name">{img.name}</span>
+          <span class="img-delta">
+            <span class="img-ver from" title={img.from || 'not present before this change'}>{shortVer(img.from)}</span>
+            <span class="img-arrow">→</span>
+            <span class="img-ver to" title={img.to || 'not present after this change'}>{shortVer(img.to)}</span>
+          </span>
+          {#if img.to}<Copy text={imageRef(img.name, img.to)} label="Copy new image reference" />{/if}
+        </div>
+      </li>
+    {/each}
+  </ul>
 {/snippet}
 
 <!-- d can briefly be null while a new diff loads (ensureDiff clears it); the
@@ -65,90 +142,16 @@
 <div class="overview">
   <!-- The impact summary (scope counts + change delta) now rides in the sticky
        summary header (see Diffs.svelte); this content is just the sections. -->
-  <!-- Three columns on a wide pane (see .ov-grid / .ov-col): the things a reviewer
-       must act on — render failures, then cautions — lead in the first column; the
-       informational blast radius and image changes each get their own. Each column
-       renders only when it has content, so an empty one leaves no gap and a narrow
-       pane collapses them to fewer columns. -->
+  <!-- Four columns, always shown so the layout is stable across PRs: the things a
+       reviewer must act on lead — render failures (red), then cautions (amber) —
+       followed by the informational blast radius and image changes. An empty
+       section keeps its column and shows a green "No …" placeholder. The grid
+       collapses to fewer columns as the pane narrows. -->
   <div class="ov-grid">
-    {#if d.failures?.length || d.warnings?.length}
-      <div class="ov-col">
-        {#if d.failures?.length}
-          <section class="ov-section fail-section">
-            <h3>Render failures <span class="ov-count">{d.failures.length}</span></h3>
-            {#each d.failures as f}
-              <div class="flag">
-                <span class="flag-title">{f.parent}</span>
-                <span class="flag-detail">{f.message}</span>
-              </div>
-            {/each}
-          </section>
-        {/if}
-
-        {#if d.warnings?.length}
-          <section class="ov-section caution-section">
-            <h3>Cautions <span class="ov-count">{d.warnings.length}</span></h3>
-            {#each d.warnings as w}
-              {@const target = warningTarget(w.resource)}
-              <!-- Cautions whose resource rendered into the diff deep-link to it. -->
-              {#if target}
-                <button class="flag flag-link {w.level}" title="View the resource diff" onclick={() => openWarning(target)}>
-                  {@render warningBody(w)}
-                </button>
-              {:else}
-                <div class="flag {w.level}">{@render warningBody(w)}</div>
-              {/if}
-            {/each}
-          </section>
-        {/if}
-      </div>
-    {/if}
-
-    {#if d.blastRadius?.length}
-      <div class="ov-col">
-        <!-- Blast radius: for each changed/failed app, how many downstream apps
-             declare a transitive spec.dependsOn on it — the reconciliation reach a
-             raw file diff can't show. Direct dependents are named; the count is the
-             full transitive closure. Absent when nothing changed depends-on anything. -->
-        <section class="ov-section">
-          <h3>Blast radius <span class="ov-count">{d.blastRadius.length}</span></h3>
-          {#each d.blastRadius as br}
-            <div class="blast">
-              <span class="blast-parent">{br.parent}</span>
-              <span class="blast-count">{dependentsLabel(br)}</span>
-              {#if br.direct?.length}
-                <div class="blast-deps">{br.direct.map(bareRef).join(', ')}</div>
-              {/if}
-            </div>
-          {/each}
-        </section>
-      </div>
-    {/if}
-
-    {#if d.images?.length}
-      <div class="ov-col">
-        <section class="ov-section">
-          <h3>Image changes <span class="ov-count">{d.images.length}</span></h3>
-          <ul class="img-list">
-            {#each d.images as img}
-              <li class="img-change">
-                <!-- Name, from → to and copy share one line; ∅ = no reference on
-                     that side (image added/removed) and the tooltip spells it out. -->
-                <div class="img-top">
-                  <span class="img-name">{img.name}</span>
-                  <span class="img-delta">
-                    <span class="img-ver from" title={img.from || 'not present before this change'}>{shortVer(img.from)}</span>
-                    <span class="img-arrow">→</span>
-                    <span class="img-ver to" title={img.to || 'not present after this change'}>{shortVer(img.to)}</span>
-                  </span>
-                  {#if img.to}<Copy text={imageRef(img.name, img.to)} label="Copy new image reference" />{/if}
-                </div>
-              </li>
-            {/each}
-          </ul>
-        </section>
-      </div>
-    {/if}
+    {@render column('Render failures', d.failures?.length ?? 0, 'fail-section', failuresBody)}
+    {@render column('Cautions', d.warnings?.length ?? 0, 'caution-section', cautionsBody)}
+    {@render column('Blast radius', d.blastRadius?.length ?? 0, '', blastBody)}
+    {@render column('Image changes', d.images?.length ?? 0, '', imagesBody)}
   </div>
 </div>
 {/if}

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -958,9 +958,11 @@ test('a long image list renders in full by default (no collapse)', async ({ page
   await expect(page.locator('.ov-head')).toHaveCount(0); // no fold control
 });
 
-test('the summary lays out three columns: cautions, blast radius, image changes', async ({ page }) => {
-  // Action items lead (column one); the informational blast radius and image
-  // changes each get their own. Columns render only when their section is present.
+test('the summary always lays out four columns, with a green placeholder for an empty section', async ({ page }) => {
+  // The four columns — render failures, cautions, blast radius, image changes —
+  // are always present so the layout holds steady across PRs. This fixture has no
+  // render failures, so that column shows a "No render failures" placeholder
+  // rather than collapsing.
   const diff = {
     ...diffEnvelope.diff!,
     failures: [],
@@ -975,10 +977,15 @@ test('the summary lays out three columns: cautions, blast radius, image changes'
   await page.goto('/#/pr/142');
 
   const cols = page.locator('.ov-col');
-  await expect(cols).toHaveCount(3);
-  await expect(cols.nth(0)).toContainText('Cautions');
-  await expect(cols.nth(1)).toContainText('Blast radius');
-  await expect(cols.nth(2)).toContainText('Image changes');
+  await expect(cols).toHaveCount(4);
+  await expect(cols.nth(0)).toContainText('Render failures');
+  await expect(cols.nth(1)).toContainText('Cautions');
+  await expect(cols.nth(2)).toContainText('Blast radius');
+  await expect(cols.nth(3)).toContainText('Image changes');
+
+  // The empty render-failures column shows the green placeholder, not a flag.
+  await expect(cols.nth(0).locator('.ov-empty')).toHaveText('No render failures');
+  await expect(cols.nth(0).locator('.flag')).toHaveCount(0);
 });
 
 test('an open PR with cautions carries an amber card edge', async ({ page }) => {

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -958,6 +958,29 @@ test('a long image list renders in full by default (no collapse)', async ({ page
   await expect(page.locator('.ov-head')).toHaveCount(0); // no fold control
 });
 
+test('the summary lays out three columns: cautions, blast radius, image changes', async ({ page }) => {
+  // Action items lead (column one); the informational blast radius and image
+  // changes each get their own. Columns render only when their section is present.
+  const diff = {
+    ...diffEnvelope.diff!,
+    failures: [],
+    warnings: [{ level: 'caution', rule: 'removed-statefulset', resource: 'StatefulSet default/db', detail: 'data may be deleted' }],
+    blastRadius: [{ parent: 'Kustomization a/b', direct: ['Kustomization c/d'], transitive: 1 }],
+    images: [{ name: 'ghcr.io/app', from: 'v1.0.0', to: 'v1.1.0', refs: null }],
+  };
+  await page.route('**/api/meta', (r) => r.fulfill({ json: defaultMeta }));
+  await page.route('**/api/prs', (r) => r.fulfill({ json: samplePRs }));
+  await page.route('**/api/prs/142/diff', (r) => r.fulfill({ json: { ...diffEnvelope, diff } }));
+  await page.routeWebSocket('**/ws', () => {});
+  await page.goto('/#/pr/142');
+
+  const cols = page.locator('.ov-col');
+  await expect(cols).toHaveCount(3);
+  await expect(cols.nth(0)).toContainText('Cautions');
+  await expect(cols.nth(1)).toContainText('Blast radius');
+  await expect(cols.nth(2)).toContainText('Image changes');
+});
+
 test('an open PR with cautions carries an amber card edge', async ({ page }) => {
   await stubApi(page);
   await page.goto('/');

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -988,6 +988,31 @@ test('the summary always lays out four columns, with a green placeholder for an 
   await expect(cols.nth(0).locator('.flag')).toHaveCount(0);
 });
 
+test('the summary grid resolves to 4 / 2 / 1 columns by pane width (never an orphaned 3+1)', async ({ page }) => {
+  // The grid uses explicit container-query breakpoints, not auto-fit, so the four
+  // columns always land in a balanced shape: four across when wide, a 2×2 at medium
+  // widths, a single stack when narrow. The resolved track count is the assertion —
+  // a count of 3 would be the old orphaned "3 + lonely 1" layout.
+  await stubApi(page);
+  // getComputedStyle resolves grid-template-columns to one px value per track.
+  const trackCount = () =>
+    page.locator('.ov-grid').evaluate((el) => getComputedStyle(el).gridTemplateColumns.split(' ').length);
+
+  // Wide desktop (rail + a roomy pane): four across.
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto('/#/pr/142');
+  await expect(page.locator('.ov-grid')).toBeVisible();
+  await expect.poll(trackCount).toBe(4);
+
+  // Mid width — the pane auto-fit used to orphan (3 + 1). Now a balanced 2×2.
+  await page.setViewportSize({ width: 960, height: 900 });
+  await expect.poll(trackCount).toBe(2);
+
+  // Mobile (the switcher's Summary pane, full width): a single stack.
+  await page.setViewportSize({ width: 390, height: 900 });
+  await expect.poll(trackCount).toBe(1);
+});
+
 test('an open PR with cautions carries an amber card edge', async ({ page }) => {
   await stubApi(page);
   await page.goto('/');


### PR DESCRIPTION
The diff summary now always lays out its four sections as four side-by-side columns:

**Render failures** · **Cautions** · **Blast radius** · **Image changes**

Previously a column rendered only when its section had content, so the layout shifted from PR to PR and a clean PR collapsed to a near-empty pane. Now the four columns are always present, so the layout holds steady across PRs.

When a section is empty it shows a `No <section>` placeholder (e.g. *No render failures*) with a **green left rule** — matching the red (failures) and amber (cautions) rules on real flags, so the columns read as one family whether or not they have content.

### Responsive layout
The grid uses explicit container-query breakpoints (not `auto-fit`, which packed three columns then orphaned the fourth onto a lonely second row across a common range — a half-width desktop window or a tablet). It now resolves to a balanced shape at every width:

- **wide** → 4 across
- **medium** → a balanced 2×2
- **narrow / mobile** → a single stack

The query reads the summary pane's width directly (`container-type: inline-size` on `.overview`), so it's correct whether or not the tree rail is present — never a 3+1.

### Changes
- `Overview.svelte` — factor the repeated column shell (wrapper + heading + count + empty state) into one `column` snippet; each section is its own always-rendered column with a body snippet, falling back to a green `.ov-empty` placeholder.
- `app.css` — always-on `.ov-empty` placeholder (green `--ok` left rule, muted text); `.ov-grid` 4/2/1 container-query breakpoints with `.overview` as the query container; long mono identifiers (`.flag-title`, `.blast-parent`) wrap rather than widen a column.
- `ui.spec.ts` — assert four always-present columns + the green placeholder, and that the grid resolves to 4/2/1 tracks by pane width (never an orphaned 3+1).

### Verify
`mise run ui-typecheck` · `mise run ui-build` · `mise run ui-test` — all green (68 passed, 1 skipped).

```
gh pr merge 209 --squash --repo home-operations/konflate
```