### PR TITLE
ci(e2e): drop --wait from the helm-test cleanup so the job stops timing out

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -96,9 +96,10 @@ description = "Install the chart into the current cluster (e.g. a kind context) 
 # KONFLATE_TEST_IMAGE_TAG=e2e + pull policy Never so the test runs the code under
 # review; locally these default to the published `latest` for a quick chart check
 # (the chart appVersion is a release-time placeholder, so a tag is always needed).
-# config.repo is a placeholder; startup doesn't block on it. The trap cleans up.
+# config.repo is a placeholder; startup doesn't block on it. The trap cleans up
+# (without --wait, which can hang on teardown).
 run = """
-trap 'helm uninstall konflate-e2e -n konflate-e2e --wait >/dev/null 2>&1 || true' EXIT
+trap 'helm uninstall konflate-e2e -n konflate-e2e >/dev/null 2>&1 || true' EXIT
 set -e
 helm install konflate-e2e charts/konflate -n konflate-e2e --create-namespace --wait --timeout 5m --set image.tag="${KONFLATE_TEST_IMAGE_TAG:-latest}" --set image.pullPolicy="${KONFLATE_TEST_PULL_POLICY:-IfNotPresent}" --set config.repo=github://home-operations/konflate-e2e
 helm test konflate-e2e -n konflate-e2e --logs


### PR DESCRIPTION
## Problem
The **Helm E2E (kind)** job hit its 15-minute cap and was **cancelled on every run — including `main`**, even though the test itself passed. The cleanup trap's `helm uninstall --wait` (no timeout) hung for ~6 min on teardown: a Helm 4 `--wait` teardown blocks for minutes even on this trivial release (no PVC; `persistence` is off), pushing the job past the cap *after the test had already succeeded*.

## Fix
Drop `--wait` from the cleanup trap in the `helm-test` task — cleanup needn't block, since the kind cluster is ephemeral in CI and a local re-run recreates the release.

One line (plus a comment), one file. ~15 min cancelled-red → **~5 min green** (verified on this PR: install ~13s, test passes, cleanup returns immediately).

```
gh pr merge 211 --squash --repo home-operations/konflate
```