### PR TITLE
ci(e2e): remove the helm-test cleanup trap; use helm upgrade --install

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -96,12 +96,10 @@ description = "Install the chart into the current cluster (e.g. a kind context) 
 # KONFLATE_TEST_IMAGE_TAG=e2e + pull policy Never so the test runs the code under
 # review; locally these default to the published `latest` for a quick chart check
 # (the chart appVersion is a release-time placeholder, so a tag is always needed).
-# config.repo is a placeholder; startup doesn't block on it. The trap cleans up
-# (without --wait, which can hang on teardown).
+# config.repo is a placeholder; startup doesn't block on it.
 run = """
-trap 'helm uninstall konflate-e2e -n konflate-e2e >/dev/null 2>&1 || true' EXIT
 set -e
-helm install konflate-e2e charts/konflate -n konflate-e2e --create-namespace --wait --timeout 5m --set image.tag="${KONFLATE_TEST_IMAGE_TAG:-latest}" --set image.pullPolicy="${KONFLATE_TEST_PULL_POLICY:-IfNotPresent}" --set config.repo=github://home-operations/konflate-e2e
+helm upgrade --install konflate-e2e charts/konflate -n konflate-e2e --create-namespace --wait --timeout 5m --set image.tag="${KONFLATE_TEST_IMAGE_TAG:-latest}" --set image.pullPolicy="${KONFLATE_TEST_PULL_POLICY:-IfNotPresent}" --set config.repo=github://home-operations/konflate-e2e
 helm test konflate-e2e -n konflate-e2e --logs
 """
 


### PR DESCRIPTION
## What
Drop the `helm test` cleanup trap and switch `helm install` → `helm upgrade --install` in the `helm-test` task.

## Why
The trap's `helm uninstall` only ever served **local re-run hygiene** — `helm install` errors on a re-used release name, so the trap cleaned up between local runs. In **CI it's dead weight**: the kind cluster is created fresh per job and destroyed at the end. `helm upgrade --install` is idempotent, so local re-runs need no cleanup either.

This matches the sibling repos that don't uninstall at all (gatus-sidecar's Go e2e, kopiur's Rust integration tests). Follow-up to [#211](https://github.com/home-operations/konflate/pull/211) (which dropped the `--wait` that hung teardown) — this removes the uninstall outright.

```
gh pr merge ci/e2e-drop-uninstall --squash --repo home-operations/konflate
```