### PR TITLE
ci(e2e): cut the helm-test Helm-4 delete-wait; own-registry test image

### DIFF
--- a/charts/konflate/README.md
+++ b/charts/konflate/README.md
@@ -141,8 +141,8 @@ Kubernetes: `>=1.25.0-0`
 | startupProbe | object | `{}` | Startup probe (optional). Gates liveness/readiness while konflate starts — useful when a large persisted store (see `persistence`) makes the cold start slow, since it loads before serving. Empty disables it. |
 | terminationGracePeriodSeconds | int | `30` | Grace period for a clean shutdown. konflate drains in-flight renders and closes the HTTP/websocket servers on SIGTERM (it caps its own shutdown near 15s), so the default is ample; raise it only if you expect longer drains. |
 | tests.image.pullPolicy | string | `"IfNotPresent"` | `helm test` image pull policy. |
-| tests.image.repository | string | `"mirror.gcr.io/busybox"` | `helm test` pod image; needs a shell with wget (konflate's own image is distroless). |
-| tests.image.tag | string | `"1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d"` | `helm test` image, pinned as `tag@sha256:digest` so Renovate bumps the tag and its digest together. |
+| tests.image.repository | string | `"ghcr.io/home-operations/busybox"` | `helm test` pod image; needs a shell with wget (konflate's own image is distroless). |
+| tests.image.tag | string | `"1.38.0@sha256:7e2c04dd50ede647bf4a7a4c8dbd629dd4971cd139b9b88fb22bfc3c7a6c13df"` | `helm test` image, pinned as `tag@sha256:digest` so Renovate bumps the tag and its digest together. |
 | tolerations | list | `[]` | Tolerations for pod scheduling. |
 | volumeMounts | list | `[]` | Additional volume mounts on the container. |
 | volumes | list | `[]` | Additional volumes on the Deployment. |

--- a/charts/konflate/templates/tests/test-connection.tpl
+++ b/charts/konflate/templates/tests/test-connection.tpl
@@ -7,9 +7,11 @@ metadata:
     {{- include "konflate.labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: test
-    # Recreate on each run; keep the pod on failure so `helm test --logs` (and a
-    # manual `kubectl logs`) can show what happened.
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    # before-hook-creation only (no hook-succeeded): `helm test` then never deletes
+    # the pod itself, so it can't block on Helm 4's wait-for-delete (kstatus) after a
+    # green run — which otherwise stalled `helm test` ~5m. The pod is recreated on
+    # the next run, and a failed run's pod stays for `helm test --logs` / kubectl.
+    helm.sh/hook-delete-policy: before-hook-creation
 spec:
   restartPolicy: Never
   securityContext:

--- a/charts/konflate/values.schema.json
+++ b/charts/konflate/values.schema.json
@@ -946,13 +946,13 @@
               "type": "string"
             },
             "repository": {
-              "default": "mirror.gcr.io/busybox",
+              "default": "ghcr.io/home-operations/busybox",
               "description": "`helm test` pod image; needs a shell with wget (konflate's own image is distroless).",
               "title": "repository",
               "type": "string"
             },
             "tag": {
-              "default": "1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d",
+              "default": "1.38.0@sha256:7e2c04dd50ede647bf4a7a4c8dbd629dd4971cd139b9b88fb22bfc3c7a6c13df",
               "description": "`helm test` image, pinned as `tag",
               "title": "tag",
               "type": "string"

--- a/charts/konflate/values.yaml
+++ b/charts/konflate/values.yaml
@@ -403,8 +403,8 @@ volumeMounts: []
 tests:
   image:
     # -- `helm test` pod image; needs a shell with wget (konflate's own image is distroless).
-    repository: mirror.gcr.io/busybox
+    repository: ghcr.io/home-operations/busybox
     # -- `helm test` image, pinned as `tag@sha256:digest` so Renovate bumps the tag and its digest together.
-    tag: "1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d"
+    tag: "1.38.0@sha256:7e2c04dd50ede647bf4a7a4c8dbd629dd4971cd139b9b88fb22bfc3c7a6c13df"
     # -- `helm test` image pull policy.
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Two changes to the chart's `helm test`, after diagnosing the ~11-min Helm E2E (install is 12s; the rest was all `helm test`):

### 1. Drop `hook-succeeded` from the test pod's delete-policy — the real speed fix (~5 min)
After a green run, Helm 4 deletes the hook pod and **waits for that deletion via kstatus** — the same default-wait that hung `helm uninstall`. That silently stalled the test step ~5 min *after* the test already passed. With `before-hook-creation` only, `helm test` returns as soon as the test passes; the pod is recreated on the next run, and a failed run's pod is kept for `--logs`.

### 2. Point the test image at `ghcr.io/home-operations/busybox` — supply-chain hygiene
The chart's test pod now uses the org's own image instead of the public `mirror.gcr.io` mirror. (Note: this is **not** a speed fix — the remaining ~5 min is the test pod's image *pull inside kind*, which is registry-independent; switching mirrors didn't change it. Kept per preference for using our own registry.)

`helm lint` clean; the `helm-unittest` `busybox:.+@sha256:…` regex still matches. Net: Helm E2E ~11 min → ~6 min (the delete-wait gone; the in-kind pull remains).