### PR TITLE
feat: surface forge rate-limit / poll failures instead of an empty list

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,13 +495,16 @@ reverse proxy / ingress and rate-limit there.
 
 Served on the separate operational port (keep it off your public ingress):
 
-| Metric                           | Type      | Meaning                                |
-| -------------------------------- | --------- | -------------------------------------- |
-| `konflate_diff_jobs_total`       | counter   | Completed renders, by `result`.        |
-| `konflate_diff_duration_seconds` | histogram | Render wall-clock (clone + 2 renders). |
-| `konflate_diff_queue_depth`      | gauge     | PRs queued or rendering.               |
-| `konflate_pull_requests`         | gauge     | Open PRs tracked.                      |
-| `konflate_http_requests_total`   | counter   | Main-server requests, by status class. |
+| Metric                                              | Type      | Meaning                                                     |
+| --------------------------------------------------- | --------- | ----------------------------------------------------------- |
+| `konflate_diff_jobs_total`                          | counter   | Completed renders, by `result`.                             |
+| `konflate_diff_duration_seconds`                    | histogram | Render wall-clock (clone + 2 renders).                      |
+| `konflate_diff_queue_depth`                         | gauge     | PRs queued or rendering.                                    |
+| `konflate_pull_requests`                            | gauge     | Open PRs tracked.                                           |
+| `konflate_http_requests_total`                      | counter   | Main-server requests, by status class.                      |
+| `konflate_forge_list_errors_total`                  | counter   | Failed PR-list polls, by `reason` (`rate_limited`/`error`). |
+| `konflate_forge_rate_limited`                       | gauge     | `1` when the last PR-list poll hit a rate limit, else `0`.  |
+| `konflate_forge_rate_limit_reset_timestamp_seconds` | gauge     | Unix time the rate limit resets (`0` when not limited).     |
 
 Plus the standard Go runtime and process collectors.
 

--- a/README.md
+++ b/README.md
@@ -231,13 +231,16 @@ scheme://[host]/path
 ## Authentication
 
 The forge token (`KONFLATE_TOKEN`) is **optional** and used only for forge read
-auth — it raises the API rate limit and unlocks private repositories. It gates
-no behaviour: konflate works the same with or without it.
+auth — it authenticates both the API calls and the renderer's `git` clone/fetch,
+raising the API rate limit and unlocking private repositories. It gates no
+behaviour: konflate works the same with or without it.
 
 On GitHub, configuring a **GitHub App** (`KONFLATE_APP_CLIENT_ID` +
 `KONFLATE_APP_PRIVATE_KEY`) authenticates reads too — its installation token is
-konflate's forge identity for the API as well as for [write-back](#write-back) —
-so an App-only instance needs no separate `KONFLATE_TOKEN`.
+konflate's forge identity for the API, the renderer's `git` clone/fetch, and
+[write-back](#write-back) alike (minted fresh, never a standing PAT) — so an
+App-only instance clones private repos and lifts the rate limit with no separate
+`KONFLATE_TOKEN`.
 
 The inbound endpoints are gated solely by **their own secret**, independent of
 the token:

--- a/cmd/konflate/main.go
+++ b/cmd/konflate/main.go
@@ -64,7 +64,15 @@ func run() error {
 		return fmt.Errorf("provider: %w", err)
 	}
 
-	srv := server.New(cfg, prov, engine.New(cfg), web.FS(), logger)
+	// The renderer clones with the same forge identity as the API client — a PAT or
+	// a GitHub App installation token — so it reaches private repos and isn't capped
+	// by the anonymous rate limit.
+	gitToken, err := provider.GitTokenSource(cfg)
+	if err != nil {
+		return fmt.Errorf("git credential: %w", err)
+	}
+
+	srv := server.New(cfg, prov, engine.New(cfg, gitToken), web.FS(), logger)
 	srv.Version = version // surfaced at /api/meta for the UI footer
 
 	// Graceful shutdown on the usual termination signals. SIGQUIT is deliberately

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/klauspost/compress v1.18.6
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	gitlab.com/gitlab-org/api/client-go/v2 v2.39.0
 	golang.org/x/sync v0.21.0
 	k8s.io/apimachinery v0.36.2
@@ -150,7 +151,6 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/rs/xid v1.6.0 // indirect

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -96,16 +96,45 @@ type Meta struct {
 	// "auto-updates every Nm". konflate always auto-refreshes; there is no manual
 	// refresh trigger.
 	RefreshIntervalSeconds int `json:"refreshIntervalSeconds"`
+	// Sync reports forge-polling health; present (with OK=false) only when the last
+	// PR-list attempt failed, so the UI can show a banner instead of a misleading
+	// empty list. Omitted when healthy.
+	Sync *SyncStatus `json:"sync,omitempty"`
 }
 
 // Event is a websocket message announcing a change to a PR's diff job, so the
 // UI can update that PR without polling.
 type Event struct {
-	Type   string    `json:"type"`             // "status" (job state changed), "removed" (PR no longer open), or "checks" (CI rollup changed)
-	Number int       `json:"number"`           // the affected PR
+	Type   string    `json:"type"`             // "status", "removed", "checks", or "sync"
+	Number int       `json:"number"`           // the affected PR (status/removed/checks)
 	Status JobStatus `json:"status,omitempty"` // set for "status" events
 	Error  string    `json:"error,omitempty"`
 	// Checks is set on "checks" events — the PR head's new CI rollup (State may be
 	// CheckNone, which clears the indicator). Absent on other event types.
 	Checks *CheckRollup `json:"checks,omitempty"`
+	// Sync is set on "sync" events — the new forge-polling health (OK=true clears
+	// the UI banner, OK=false raises it). Absent on other event types.
+	Sync *SyncStatus `json:"sync,omitempty"`
+}
+
+// SyncReason is the machine-readable tag on a failed SyncStatus, so the UI can
+// branch (a rate limit shows a countdown + token hint; a generic error doesn't).
+type SyncReason string
+
+const (
+	SyncRateLimited SyncReason = "rate_limited" // the forge API rate limit was hit; RetryAt is set
+	SyncError       SyncReason = "error"        // any other failure to reach or list the forge
+)
+
+// SyncStatus reports whether konflate's last attempt to list PRs from the forge
+// succeeded. Surfaced on Meta (initial load) and pushed as a "sync" Event (live),
+// so the UI can show a clear "can't reach the forge / rate-limited" banner instead
+// of a misleading "no pull requests" empty state.
+type SyncStatus struct {
+	OK      bool       `json:"ok"`                // false ⇒ the last PR-list attempt failed
+	Reason  SyncReason `json:"reason,omitempty"`  // why it failed (rate_limited | error)
+	Message string     `json:"message,omitempty"` // human-readable detail for the banner
+	// RetryAt is when a rate limit resets (Unix seconds), set only for
+	// reason=="rate_limited" so the UI can show a countdown; zero otherwise.
+	RetryAt int64 `json:"retryAt,omitempty"`
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -72,8 +72,11 @@ type flateEngine struct {
 	maxDiffResources       int
 }
 
-// New builds the production Engine from config.
-func New(cfg *config.Config) Engine {
+// New builds the production Engine from config. gitToken authenticates the
+// renderer's clone/fetch with the same forge identity as the API client (a PAT or
+// a GitHub App installation token; see provider.GitTokenSource) — nil clones
+// anonymously, for public repositories only.
+func New(cfg *config.Config, gitToken gitclone.TokenFunc) Engine {
 	const mib = 1 << 20
 	conc := cfg.RenderConcurrency
 	if conc <= 0 {
@@ -87,7 +90,7 @@ func New(cfg *config.Config) Engine {
 		// (RepoCacheDir), not the shared CacheDir — otherwise a CacheDir volume
 		// shared across different-repo instances would cross-fetch. flate's
 		// content-addressed source cache below stays on CacheDir and is shared.
-		mirror:                 gitclone.NewMirror(cfg.RepoCacheDir, cfg.CloneDir, cfg.Forge.CloneURL(), cfg.Token, cfg.FetchTimeout),
+		mirror:                 gitclone.NewMirror(cfg.RepoCacheDir, cfg.CloneDir, cfg.Forge.CloneURL(), gitToken, cfg.FetchTimeout),
 		pullHeadRef:            cfg.Forge.PullHeadRef,
 		cache:                  source.NewCache(cacheroot.New(cfg.CacheDir)),
 		helmTemplateCacheBytes: int64(cfg.HelmTemplateCacheMB) * mib,

--- a/internal/gitclone/gitclone.go
+++ b/internal/gitclone/gitclone.go
@@ -58,7 +58,7 @@ type Mirror struct {
 	bareDir  string // persistent bare repo (under the cache dir)
 	workRoot string // parent for the ephemeral per-diff working trees
 	url      string
-	auth     *githttp.BasicAuth
+	token    TokenFunc // forge credential for clone/fetch, resolved per fetch (nil ⇒ anonymous)
 
 	// fetchTimeout bounds a single fetch (and the cold clone) so a slow or hung
 	// forge can't hold the write lock — and thus block every other render — for
@@ -71,23 +71,44 @@ type Mirror struct {
 	mu sync.RWMutex
 }
 
+// TokenFunc yields the forge credential for git-over-HTTPS — the password paired
+// with the x-access-token username — resolved afresh before each fetch so a
+// GitHub App's hourly-expiring installation token stays current. An empty token
+// (or a nil TokenFunc) means anonymous. It receives the fetch's context so the
+// resolution (an App token mint, on first use or refresh) is bounded with it.
+type TokenFunc func(ctx context.Context) (string, error)
+
 // NewMirror builds a Mirror for cloneURL. The bare repo lives under cacheDir
 // (persistent), per-diff working trees under cloneDir (ephemeral). token may be
-// empty for public repositories (anonymous). fetchTimeout bounds each fetch
-// under the write lock (<=0 disables it; see Mirror.fetchTimeout).
-func NewMirror(cacheDir, cloneDir, cloneURL, token string, fetchTimeout time.Duration) *Mirror {
-	var auth *githttp.BasicAuth
-	if token != "" {
-		// Any non-empty username works; the token is the password over HTTPS.
-		auth = &githttp.BasicAuth{Username: "x-access-token", Password: token}
-	}
+// nil for public repositories (anonymous). fetchTimeout bounds each fetch under
+// the write lock (<=0 disables it; see Mirror.fetchTimeout).
+func NewMirror(cacheDir, cloneDir, cloneURL string, token TokenFunc, fetchTimeout time.Duration) *Mirror {
 	return &Mirror{
 		bareDir:      filepath.Join(cacheDir, "git", "mirror.git"),
 		workRoot:     cloneDir,
 		url:          cloneURL,
-		auth:         auth,
+		token:        token,
 		fetchTimeout: fetchTimeout,
 	}
+}
+
+// authFor resolves the git credential for one fetch cycle by calling the token
+// source (a GitHub App mints/refreshes its installation token here), returning
+// nil — anonymous — when there is no source or it yields an empty token. The same
+// credential covers the cycle's clone and both ref fetches.
+func (m *Mirror) authFor(ctx context.Context) (*githttp.BasicAuth, error) {
+	if m.token == nil {
+		return nil, nil
+	}
+	tok, err := m.token(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("gitclone: forge credential: %w", err)
+	}
+	if tok == "" {
+		return nil, nil
+	}
+	// Any non-empty username works; the token is the password over HTTPS.
+	return &githttp.BasicAuth{Username: "x-access-token", Password: tok}, nil
 }
 
 // Trees fetches the PR head and base into the mirror, computes the merge-base of
@@ -172,10 +193,18 @@ func (m *Mirror) fetchScope(ctx context.Context) (context.Context, context.Cance
 // instead of letting it run to the full DiffTimeout. The returned commits carry
 // their own storer reference, so they stay readable after the lock is released.
 func (m *Mirror) fetch(ctx context.Context, headRef, baseRef string) (head, base *object.Commit, err error) {
+	// Resolve the credential before taking the write lock: an App token mint is a
+	// network call, and holding the lock across it would stall every other render.
+	// Once minted it's cached, so subsequent cycles resolve without I/O.
+	auth, err := m.authFor(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	repo, err := m.openOrClone(ctx, baseRef)
+	repo, err := m.openOrClone(ctx, baseRef, auth)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -183,7 +212,7 @@ func (m *Mirror) fetch(ctx context.Context, headRef, baseRef string) (head, base
 	// Refresh the base branch (a no-op right after the seeding clone). A missing
 	// base is a real error — the PR targets it.
 	baseFull := "refs/heads/" + baseRef
-	if err := fetchSpec(ctx, repo, m.auth, baseFull, baseFull); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
+	if err := fetchSpec(ctx, repo, auth, baseFull, baseFull); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
 		return nil, nil, fmt.Errorf("gitclone: fetch base %q: %w", baseRef, err)
 	}
 	// headRef is the forge's pull head ref (refs/pull/N/head), which the base repo
@@ -191,7 +220,7 @@ func (m *Mirror) fetch(ctx context.Context, headRef, baseRef string) (head, base
 	// repo. Fetch it into a private local ref. A missing head ref means the
 	// request was deleted — report it as gone so the caller reconciles the PR
 	// rather than failing the render.
-	if err := fetchSpec(ctx, repo, m.auth, headRef, localHeadRef); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
+	if err := fetchSpec(ctx, repo, auth, headRef, localHeadRef); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
 		if errors.Is(err, git.NoMatchingRefSpecError{}) {
 			return nil, nil, fmt.Errorf("gitclone: fetch head %q: %w", headRef, ErrHeadRefGone)
 		}
@@ -287,7 +316,7 @@ func (m *Mirror) countPacks() (int, error) {
 // would data-race. A private handle per render keeps those reads goroutine-safe;
 // don't "optimize" this into a cached handle without moving all object reads
 // under the write lock.
-func (m *Mirror) openOrClone(ctx context.Context, baseRef string) (*git.Repository, error) {
+func (m *Mirror) openOrClone(ctx context.Context, baseRef string, auth *githttp.BasicAuth) (*git.Repository, error) {
 	repo, err := git.PlainOpen(m.bareDir)
 	if err == nil {
 		return repo, nil
@@ -300,7 +329,7 @@ func (m *Mirror) openOrClone(ctx context.Context, baseRef string) (*git.Reposito
 	}
 	repo, err = git.PlainCloneContext(ctx, m.bareDir, true, &git.CloneOptions{
 		URL:           m.url,
-		Auth:          m.auth,
+		Auth:          auth,
 		NoCheckout:    true,
 		Tags:          git.NoTags,
 		SingleBranch:  true,

--- a/internal/gitclone/gitclone_test.go
+++ b/internal/gitclone/gitclone_test.go
@@ -169,11 +169,53 @@ func TestWithinRoot(t *testing.T) {
 	}
 }
 
+// TestMirror_AuthFor covers the per-fetch credential resolution: a nil or
+// empty-yielding token source clones anonymously (nil auth), a yielded token
+// becomes x-access-token basic auth (the password over HTTPS), and a source
+// error — e.g. a GitHub App token mint that failed — propagates rather than
+// silently degrading to an anonymous clone of a private repo.
+func TestMirror_AuthFor(t *testing.T) {
+	t.Parallel()
+	const tok = "ghs_installationtoken"
+	cases := []struct {
+		name              string
+		token             TokenFunc
+		wantUser, wantPro string // empty wantUser ⇒ expect nil auth (anonymous)
+		wantErr           bool
+	}{
+		{"nil source is anonymous", nil, "", "", false},
+		{"empty token is anonymous", func(context.Context) (string, error) { return "", nil }, "", "", false},
+		{"token becomes x-access-token basic auth", func(context.Context) (string, error) { return tok, nil }, "x-access-token", tok, false},
+		{"source error propagates", func(context.Context) (string, error) { return "", errors.New("mint failed") }, "", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			m := NewMirror(t.TempDir(), t.TempDir(), "https://example.test/x.git", tc.token, 0)
+			auth, err := m.authFor(context.Background())
+			switch {
+			case tc.wantErr:
+				if err == nil {
+					t.Fatal("authFor: want error, got nil")
+				}
+			case err != nil:
+				t.Fatalf("authFor: %v", err)
+			case tc.wantUser == "":
+				if auth != nil {
+					t.Errorf("authFor = %+v, want nil (anonymous)", auth)
+				}
+			case auth == nil || auth.Username != tc.wantUser || auth.Password != tc.wantPro:
+				t.Errorf("authFor = %+v, want {%q, %q}", auth, tc.wantUser, tc.wantPro)
+			}
+		})
+	}
+}
+
 // newTestMirror builds a Mirror with fresh temp dirs for its bare repo and
 // working trees, pointed at the local source repo src.
 func newTestMirror(t *testing.T, src string) *Mirror {
 	t.Helper()
-	return NewMirror(t.TempDir(), t.TempDir(), src, "", 0) // 0: fetch bounded only by ctx
+	return NewMirror(t.TempDir(), t.TempDir(), src, nil, 0) // nil token: anonymous; 0: fetch bounded only by ctx
 }
 
 func read(dir, rel string) (string, bool) {

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -2,14 +2,38 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/google/go-github/v88/github"
 
 	"github.com/home-operations/konflate/internal/api"
 	"github.com/home-operations/konflate/internal/config"
 )
+
+// RateLimit reports whether err is a forge rate-limit rejection and, if so, when
+// the limit resets — so the server can surface a clear, time-bounded status to the
+// UI rather than a generic failure. GitHub's SDK returns a typed
+// *github.RateLimitError (carrying the reset time) for the primary limit and
+// *github.AbuseRateLimitError (a retry-after) for secondary limits; both are
+// matched through the wrapped error chain. Non-GitHub forges and non-rate-limit
+// errors report false.
+func RateLimit(err error) (resetAt time.Time, ok bool) {
+	var rl *github.RateLimitError
+	if errors.As(err, &rl) {
+		return rl.Rate.Reset.Time, true
+	}
+	var ab *github.AbuseRateLimitError
+	if errors.As(err, &ab) {
+		if ab.RetryAfter != nil {
+			return time.Now().Add(*ab.RetryAfter), true
+		}
+		return time.Time{}, true
+	}
+	return time.Time{}, false
+}
 
 type githubProvider struct {
 	client      *github.Client

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -53,6 +53,26 @@ func New(cfg *config.Config) (Provider, error) {
 	}
 }
 
+// GitTokenSource returns the credential the renderer uses to authenticate git
+// clone/fetch over HTTPS, so a render reaches the forge with the same identity as
+// the API client: a private repo can be cloned, and an authenticated clone isn't
+// throttled by the anonymous rate limit. GitHub with App credentials yields a
+// fresh installation token per call (they expire hourly); otherwise it returns the
+// static PAT (KONFLATE_TOKEN), or "" when neither is configured — anonymous, for
+// public repositories only. Only GitHub has an App path; GitLab and Forgejo always
+// use the token. The returned function is safe for concurrent use.
+func GitTokenSource(cfg *config.Config) (func(ctx context.Context) (string, error), error) {
+	if cfg.Forge.Kind == config.ForgeGitHub && cfg.AppConfigured() {
+		it, err := newInstallTransport(cfg)
+		if err != nil {
+			return nil, err
+		}
+		return it.token, nil
+	}
+	token := cfg.Token
+	return func(context.Context) (string, error) { return token, nil }, nil
+}
+
 // ownerRepo splits an "owner/repo" path into its two parts.
 func ownerRepo(repoPath string) (owner, repo string) {
 	owner, repo, _ = strings.Cut(repoPath, "/")

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/google/go-github/v88/github"
 
@@ -192,5 +193,30 @@ func TestNewGitHubReadAuth(t *testing.T) {
 	}
 	if _, ok := anon.client.Client().Transport.(*installTransport); ok {
 		t.Error("read client without App creds must not use App installation auth")
+	}
+}
+
+// TestRateLimit covers the rate-limit classifier the server uses to turn a failed
+// PR-list into a time-bounded UI status: GitHub's primary RateLimitError carries
+// the reset time, the secondary AbuseRateLimitError a retry-after, and both are
+// recognized through the wrapped error chain; an ordinary error is not a limit.
+func TestRateLimit(t *testing.T) {
+	t.Parallel()
+	reset := time.Now().Add(11 * time.Minute).Truncate(time.Second)
+	wrapped := fmt.Errorf("github: list PRs: %w", &github.RateLimitError{
+		Rate:    github.Rate{Reset: github.Timestamp{Time: reset}},
+		Message: "API rate limit exceeded",
+	})
+	if got, ok := RateLimit(wrapped); !ok || !got.Equal(reset) {
+		t.Errorf("RateLimit(primary) = (%v, %v); want (%v, true)", got, ok, reset)
+	}
+
+	after := 30 * time.Second
+	if _, ok := RateLimit(fmt.Errorf("x: %w", &github.AbuseRateLimitError{RetryAfter: &after})); !ok {
+		t.Error("RateLimit(secondary/abuse) ok = false; want true")
+	}
+
+	if _, ok := RateLimit(errors.New("connection refused")); ok {
+		t.Error("RateLimit(plain error) ok = true; want false")
 	}
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -196,6 +196,47 @@ func TestNewGitHubReadAuth(t *testing.T) {
 	}
 }
 
+// TestGitTokenSource covers the renderer's git credential selection, which must
+// mirror the read client's: a configured GitHub App yields a (lazy) token source so
+// the clone authenticates as the same installation reads use, a PAT is returned
+// verbatim (the x-access-token password), and with neither the source is anonymous.
+func TestGitTokenSource(t *testing.T) {
+	t.Parallel()
+	gh := config.ForgeURI{Kind: config.ForgeGitHub, RepoPath: "acme/web"}
+
+	// PAT: returned verbatim.
+	src, err := GitTokenSource(&config.Config{Forge: gh, Token: "pat-123"})
+	if err != nil {
+		t.Fatalf("GitTokenSource (pat): %v", err)
+	}
+	if tok, err := src(context.Background()); err != nil || tok != "pat-123" {
+		t.Errorf("pat source = (%q, %v), want (\"pat-123\", nil)", tok, err)
+	}
+
+	// Neither credential: anonymous (empty token ⇒ the mirror clones without auth).
+	src, err = GitTokenSource(&config.Config{Forge: gh})
+	if err != nil {
+		t.Fatalf("GitTokenSource (anon): %v", err)
+	}
+	if tok, err := src(context.Background()); err != nil || tok != "" {
+		t.Errorf("anon source = (%q, %v), want (\"\", nil)", tok, err)
+	}
+
+	// GitHub App: a token source is built (no network until it's invoked).
+	src, err = GitTokenSource(&config.Config{Forge: gh, AppClientID: "Iv1", AppPrivateKey: testRSAKeyPEM(t)})
+	if err != nil {
+		t.Fatalf("GitTokenSource (app): %v", err)
+	}
+	if src == nil {
+		t.Error("App-configured git token source must not be nil")
+	}
+	// A malformed App key is rejected here — the App branch parses it, the static
+	// PAT path never would, so this also proves App config takes the App branch.
+	if _, err := GitTokenSource(&config.Config{Forge: gh, AppClientID: "Iv1", AppPrivateKey: "not-a-pem-key"}); err == nil {
+		t.Error("GitTokenSource must reject a malformed App private key")
+	}
+}
+
 // TestRateLimit covers the rate-limit classifier the server uses to turn a failed
 // PR-list into a time-bounded UI status: GitHub's primary RateLimitError carries
 // the reset time, the secondary AbuseRateLimitError a retry-after, and both are

--- a/internal/provider/writer.go
+++ b/internal/provider/writer.go
@@ -208,26 +208,40 @@ func newGitHubAppClient(cfg *config.Config) (*github.Client, func(context.Contex
 // the read provider and the Writer use it, so an App-configured instance
 // authenticates its forge reads as well as its write-back.
 func newGitHubAppInstallClient(cfg *config.Config) (install, apps *github.Client, err error) {
-	key, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(cfg.AppPrivateKey))
+	it, err := newInstallTransport(cfg)
 	if err != nil {
-		return nil, nil, fmt.Errorf("github: parse App private key (KONFLATE_APP_PRIVATE_KEY): %w", err)
+		return nil, nil, err
 	}
-	// githubEnterpriseOpts points both clients at the GHES API base (nil ⇒ github.com).
-	hostOpts := githubEnterpriseOpts(cfg.Forge.Host)
-	apps, err = github.NewClient(append([]github.ClientOptionsFunc{
-		github.WithTransport(&appJWTTransport{base: http.DefaultTransport, clientID: cfg.AppClientID, key: key}),
-	}, hostOpts...)...)
-	if err != nil {
-		return nil, nil, fmt.Errorf("github: App client: %w", err)
-	}
-	owner, repo := ownerRepo(cfg.Forge.RepoPath)
+	// githubEnterpriseOpts points the client at the GHES API base (nil ⇒ github.com).
 	install, err = github.NewClient(append([]github.ClientOptionsFunc{
-		github.WithTransport(&installTransport{base: http.DefaultTransport, apps: apps, owner: owner, repo: repo}),
-	}, hostOpts...)...)
+		github.WithTransport(it),
+	}, githubEnterpriseOpts(cfg.Forge.Host)...)...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("github: new App client: %w", err)
 	}
-	return install, apps, nil
+	return install, it.apps, nil
+}
+
+// newInstallTransport builds the App installation-token transport for the repo:
+// an App-JWT client (for installation lookup + token mint) wrapped in an
+// installTransport that mints, caches, and refreshes the installation token. It
+// backs the App-authenticated read client and the Writer (via
+// newGitHubAppInstallClient) and the renderer's git credential (via
+// GitTokenSource), so all three authenticate as the same App installation. No
+// network call happens until the token is first needed.
+func newInstallTransport(cfg *config.Config) (*installTransport, error) {
+	key, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(cfg.AppPrivateKey))
+	if err != nil {
+		return nil, fmt.Errorf("github: parse App private key (KONFLATE_APP_PRIVATE_KEY): %w", err)
+	}
+	apps, err := github.NewClient(append([]github.ClientOptionsFunc{
+		github.WithTransport(&appJWTTransport{base: http.DefaultTransport, clientID: cfg.AppClientID, key: key}),
+	}, githubEnterpriseOpts(cfg.Forge.Host)...)...)
+	if err != nil {
+		return nil, fmt.Errorf("github: App client: %w", err)
+	}
+	owner, repo := ownerRepo(cfg.Forge.RepoPath)
+	return &installTransport{base: http.DefaultTransport, apps: apps, owner: owner, repo: repo}, nil
 }
 
 // appJWT mints a short-lived GitHub App JWT signed with the App's client id as the

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -56,6 +56,7 @@ func (s *Server) handleMeta(w http.ResponseWriter, _ *http.Request) {
 		RepoURL:                s.cfg.Forge.CloneURL(),
 		Version:                s.Version,
 		RefreshIntervalSeconds: int(s.cfg.RefreshInterval.Seconds()),
+		Sync:                   s.metaSync(),
 	})
 }
 
@@ -525,6 +526,7 @@ func (s *Server) authorizedPush(r *http.Request) bool {
 // verified webhook also calls it when the open-PR set may have changed.
 func (s *Server) refreshList(ctx context.Context) {
 	prs, err := s.prov.ListPRs(ctx)
+	s.noteSyncResult(err) // record forge-polling health (raises/clears the UI banner + metrics)
 	if err != nil {
 		s.log.Error("refresh: list PRs failed", "error", err)
 		return

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -18,6 +18,12 @@ type metrics struct {
 	queueDepth   prometheus.Gauge
 	prsKnown     prometheus.Gauge
 	httpReqs     *prometheus.CounterVec // code: 2xx|4xx|5xx
+	// Forge read-polling health (see syncTracker): list failures by reason,
+	// whether the last list hit a rate limit, and when that limit resets — so an
+	// operator can alert before the limit bites rather than find it in the logs.
+	listErrors     *prometheus.CounterVec // reason: rate_limited|error
+	rateLimited    prometheus.Gauge
+	rateLimitReset prometheus.Gauge
 }
 
 // metricNamespace prefixes every konflate metric name.
@@ -48,11 +54,24 @@ func newMetrics() *metrics {
 			Namespace: metricNamespace, Name: "http_requests_total",
 			Help: "HTTP requests served by the main server, by status class.",
 		}, []string{"code"}),
+		listErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricNamespace, Name: "forge_list_errors_total",
+			Help: "Failed attempts to list PRs from the forge, by reason (rate_limited|error).",
+		}, []string{"reason"}),
+		rateLimited: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: metricNamespace, Name: "forge_rate_limited",
+			Help: "1 when the last forge PR-list attempt hit a rate limit, else 0.",
+		}),
+		rateLimitReset: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: metricNamespace, Name: "forge_rate_limit_reset_timestamp_seconds",
+			Help: "Unix time the forge rate limit resets (0 when not rate-limited or unknown).",
+		}),
 	}
 	reg.MustRegister(
 		collectors.NewGoCollector(),
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 		m.diffTotal, m.diffDuration, m.queueDepth, m.prsKnown, m.httpReqs,
+		m.listErrors, m.rateLimited, m.rateLimitReset,
 	)
 	return m
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -52,6 +52,7 @@ type Server struct {
 	store   *store
 	hub     *hub
 	metrics *metrics
+	sync    *syncTracker // forge read-polling health, for /api/meta + "sync" events
 	queue   *queue
 	runCtx  context.Context
 
@@ -88,7 +89,7 @@ func New(cfg *config.Config, prov provider.Provider, eng Engine, ui fs.FS, log *
 
 	s := &Server{
 		cfg: cfg, prov: prov, writer: writer, engine: eng, ui: ui, log: log,
-		store: newStore(), hub: newHub(log), metrics: newMetrics(),
+		store: newStore(), hub: newHub(log), metrics: newMetrics(), sync: newSyncTracker(),
 		avatarKey:   avatarKey,
 		mergeTmpl:   newMergeTemplate(cfg, log),
 		commentTmpl: newCommentTemplate(cfg, log),

--- a/internal/server/sync.go
+++ b/internal/server/sync.go
@@ -1,0 +1,89 @@
+package server
+
+import (
+	"sync"
+
+	"github.com/home-operations/konflate/internal/api"
+	"github.com/home-operations/konflate/internal/provider"
+)
+
+// syncTracker holds the latest forge-polling health (see [api.SyncStatus]): did
+// the most recent attempt to list PRs from the forge succeed? It's read by
+// /api/meta for initial load and updated after every list attempt; a health
+// change is pushed as a "sync" websocket event so the UI raises or clears its
+// banner live. Starts healthy so no banner shows before the first attempt.
+type syncTracker struct {
+	mu  sync.Mutex
+	cur api.SyncStatus
+}
+
+func newSyncTracker() *syncTracker {
+	return &syncTracker{cur: api.SyncStatus{OK: true}}
+}
+
+func (t *syncTracker) status() api.SyncStatus {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.cur
+}
+
+// set stores st and reports whether the health changed (its OK or Reason), so the
+// caller broadcasts a "sync" event only on a transition rather than every refresh.
+func (t *syncTracker) set(st api.SyncStatus) (changed bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	changed = t.cur.OK != st.OK || t.cur.Reason != st.Reason
+	t.cur = st
+	return changed
+}
+
+// classifyListResult maps a PR-list outcome to a SyncStatus: healthy on nil; a
+// time-bounded "rate_limited" when the forge says so (see [provider.RateLimit]),
+// raising the API rate limit is the fix); otherwise a generic "error".
+func classifyListResult(err error) api.SyncStatus {
+	if err == nil {
+		return api.SyncStatus{OK: true}
+	}
+	if reset, ok := provider.RateLimit(err); ok {
+		st := api.SyncStatus{OK: false, Reason: api.SyncRateLimited, Message: "The forge API rate limit was exceeded."}
+		if !reset.IsZero() {
+			st.RetryAt = reset.Unix()
+		}
+		return st
+	}
+	return api.SyncStatus{OK: false, Reason: api.SyncError, Message: "Couldn't reach the forge to list pull requests."}
+}
+
+// noteSyncResult records the outcome of a forge PR-list attempt: it updates the
+// rate-limit metrics and the tracker, and broadcasts a "sync" event on a health
+// transition so connected UIs raise or clear the banner without a reload.
+func (s *Server) noteSyncResult(err error) {
+	st := classifyListResult(err)
+
+	// Derive both rate-limit gauges from the current status on every call, so a
+	// recovery (or a non-rate-limit error) clears them rather than leaving a stale
+	// reset timestamp behind.
+	if st.Reason == api.SyncRateLimited {
+		s.metrics.rateLimited.Set(1)
+		s.metrics.rateLimitReset.Set(float64(st.RetryAt)) // 0 when the forge gave no reset time
+	} else {
+		s.metrics.rateLimited.Set(0)
+		s.metrics.rateLimitReset.Set(0)
+	}
+	if !st.OK {
+		s.metrics.listErrors.WithLabelValues(string(st.Reason)).Inc()
+	}
+
+	if s.sync.set(st) {
+		s.hub.broadcast(api.Event{Type: "sync", Sync: &st})
+	}
+}
+
+// metaSync is the SyncStatus for /api/meta: nil (omitted) when healthy so the UI
+// shows no banner, the failed status otherwise.
+func (s *Server) metaSync() *api.SyncStatus {
+	if st := s.sync.status(); !st.OK {
+		return &st
+	}
+	return nil
+}

--- a/internal/server/sync_test.go
+++ b/internal/server/sync_test.go
@@ -1,0 +1,144 @@
+package server
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v88/github"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/home-operations/konflate/internal/api"
+)
+
+// gaugeValue reads a gauge's current value via the canonical Metric.Write
+// interface (no extra test dependency just to assert one number).
+func gaugeValue(t *testing.T, g prometheus.Gauge) float64 {
+	t.Helper()
+	var m dto.Metric
+	if err := g.Write(&m); err != nil {
+		t.Fatalf("read gauge: %v", err)
+	}
+	return m.GetGauge().GetValue()
+}
+
+// TestClassifyListResult pins how a PR-list outcome becomes a UI sync status: a
+// nil error is healthy; a recognized rate limit carries its reset time so the
+// banner can count down; any other error is a generic, untimed failure. A failed
+// status always carries a human message for the banner.
+func TestClassifyListResult(t *testing.T) {
+	t.Parallel()
+	reset := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name       string
+		err        error
+		wantOK     bool
+		wantReason api.SyncReason
+		wantRetry  int64
+	}{
+		{"healthy", nil, true, "", 0},
+		{
+			"rate limit carries the reset",
+			&github.RateLimitError{Rate: github.Rate{Reset: github.Timestamp{Time: reset}}, Message: "exceeded"},
+			false, api.SyncRateLimited, reset.Unix(),
+		},
+		{
+			"rate limit without a reset has no countdown",
+			&github.RateLimitError{Message: "exceeded"},
+			false, api.SyncRateLimited, 0,
+		},
+		{"any other error is generic", errors.New("connection refused"), false, api.SyncError, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			st := classifyListResult(tc.err)
+			if st.OK != tc.wantOK || st.Reason != tc.wantReason || st.RetryAt != tc.wantRetry {
+				t.Errorf("classifyListResult(%v) = %+v; want ok=%v reason=%q retryAt=%d",
+					tc.err, st, tc.wantOK, tc.wantReason, tc.wantRetry)
+			}
+			if !tc.wantOK && st.Message == "" {
+				t.Error("a failed sync status must carry a banner message")
+			}
+		})
+	}
+}
+
+// TestSyncTracker_SetReportsTransitions verifies set() reports a change only when
+// the health actually flips (its OK or reason) — the signal noteSyncResult uses to
+// broadcast a "sync" event once per transition rather than on every refresh. A
+// later reset time alone is not a transition, so a steady rate limit doesn't spam.
+func TestSyncTracker_SetReportsTransitions(t *testing.T) {
+	t.Parallel()
+	tr := newSyncTracker()
+	if !tr.status().OK {
+		t.Fatal("a fresh tracker must start healthy (no banner before the first poll)")
+	}
+	steps := []struct {
+		st          api.SyncStatus
+		wantChanged bool
+	}{
+		{api.SyncStatus{OK: false, Reason: api.SyncRateLimited}, true},               // healthy → limited
+		{api.SyncStatus{OK: false, Reason: api.SyncRateLimited, RetryAt: 99}, false}, // same health, later reset → no re-broadcast
+		{api.SyncStatus{OK: false, Reason: api.SyncError}, true},                     // reason flipped
+		{api.SyncStatus{OK: true}, true},                                             // recovered
+		{api.SyncStatus{OK: true}, false},                                            // still healthy
+	}
+	for i, step := range steps {
+		if got := tr.set(step.st); got != step.wantChanged {
+			t.Errorf("step %d set(%+v) changed = %v, want %v", i, step.st, got, step.wantChanged)
+		}
+	}
+}
+
+// TestServer_SyncStatusSurfacing is the integration: a rate-limited ListPRs must
+// surface on /api/meta (so a fresh page load shows the banner, not a misleading
+// empty list) and flip the rate-limit metrics, and a later healthy list must clear
+// both. The failing refresh must not drop PRs already loaded.
+func TestServer_SyncStatusSurfacing(t *testing.T) {
+	t.Parallel()
+	reset := time.Now().Add(11 * time.Minute)
+	prov := &fakeProvider{listErr: &github.RateLimitError{
+		Rate:    github.Rate{Reset: github.Timestamp{Time: reset}},
+		Message: "API rate limit exceeded",
+	}}
+	s := newTestServer(t, ghCfg("tok"), prov, okEngine())
+	h := s.mainHandler()
+
+	s.refreshList(s.runCtx)
+
+	var limited api.Meta
+	mustJSON(t, do(h, "GET", "/api/meta", nil, nil), &limited)
+	if limited.Sync == nil || limited.Sync.OK ||
+		limited.Sync.Reason != api.SyncRateLimited || limited.Sync.RetryAt != reset.Unix() {
+		t.Fatalf("meta sync = %+v, want ok=false reason=rate_limited retryAt=%d", limited.Sync, reset.Unix())
+	}
+	if got := gaugeValue(t, s.metrics.rateLimited); got != 1 {
+		t.Errorf("forge_rate_limited = %v, want 1", got)
+	}
+	if got := gaugeValue(t, s.metrics.rateLimitReset); got != float64(reset.Unix()) {
+		t.Errorf("forge_rate_limit_reset = %v, want %d", got, reset.Unix())
+	}
+
+	// The forge recovers: the next list succeeds, clearing the banner and gauge.
+	prov.mu.Lock()
+	prov.listErr = nil
+	prov.prs = []api.PR{{Number: 7, Open: true, HeadRef: "a", BaseRef: "main"}}
+	prov.mu.Unlock()
+	s.refreshList(s.runCtx)
+
+	// Decode into a fresh value: sync is omitempty, and Unmarshal won't clear a
+	// reused struct's stale pointer.
+	var healthy api.Meta
+	mustJSON(t, do(h, "GET", "/api/meta", nil, nil), &healthy)
+	if healthy.Sync != nil {
+		t.Errorf("after recovery meta sync = %+v, want nil (healthy ⇒ omitted)", healthy.Sync)
+	}
+	if got := gaugeValue(t, s.metrics.rateLimited); got != 0 {
+		t.Errorf("forge_rate_limited = %v, want 0 after recovery", got)
+	}
+	if got := gaugeValue(t, s.metrics.rateLimitReset); got != 0 {
+		t.Errorf("forge_rate_limit_reset = %v, want 0 after recovery (no stale timestamp)", got)
+	}
+}

--- a/internal/web/src/App.svelte
+++ b/internal/web/src/App.svelte
@@ -19,6 +19,7 @@
   import List from './lib/List.svelte';
   import Review from './lib/Review.svelte';
   import Palette from './lib/Palette.svelte';
+  import SyncBanner from './lib/SyncBanner.svelte';
   import type { Meta } from './lib/types';
 
   onMount(() => {
@@ -115,6 +116,8 @@
       </button>
     </div>
   </header>
+
+  <SyncBanner />
 
   {#if router.route.name === 'review'}
     <Review />

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -103,6 +103,28 @@ body {
   border-bottom: 1px solid var(--border);
   flex: 0 0 auto;
 }
+/* Forge-poll failure banner (SyncBanner.svelte): a full-width amber strip below
+   the topbar when konflate can't list PRs (rate-limited / forge unreachable), so
+   an empty list reads as "couldn't fetch" rather than "no open PRs". */
+.sync-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  padding: 8px 14px;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--caution);
+  background: color-mix(in srgb, var(--caution) 12%, var(--panel));
+  border-bottom: 1px solid color-mix(in srgb, var(--caution) 40%, var(--border));
+}
+.sync-banner-text {
+  color: var(--text);
+}
+.sync-banner-text strong {
+  color: var(--caution);
+  font-weight: 600;
+}
 .brand {
   display: flex;
   align-items: center;

--- a/internal/web/src/lib/SyncBanner.svelte
+++ b/internal/web/src/lib/SyncBanner.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { mdiAlertOutline } from '@mdi/js';
+  import Icon from './Icon.svelte';
+  import { store } from './store.svelte';
+
+  // Non-null only when the last forge poll failed (rate-limited or unreachable);
+  // see the store's `sync` and the "sync" websocket event.
+  const sync = $derived(store.sync);
+
+  // A "resets in ~Nm" countdown for a rate-limit reset (retryAt is Unix seconds).
+  // The 30s tick refreshes the minute-granularity label while the banner is up;
+  // it only runs when there's a reset time to show, so a healthy app idles.
+  let now = $state(Math.floor(Date.now() / 1000));
+  $effect(() => {
+    if (!sync || sync.ok || !sync.retryAt) return;
+    const id = setInterval(() => (now = Math.floor(Date.now() / 1000)), 30_000);
+    return () => clearInterval(id);
+  });
+
+  function resetsIn(retryAt: number): string {
+    const secs = retryAt - now;
+    if (secs <= 0) return 'momentarily';
+    const m = Math.ceil(secs / 60);
+    return m === 1 ? '~1 minute' : `~${m} minutes`;
+  }
+</script>
+
+{#if sync && !sync.ok}
+  <div class="sync-banner" role="status" aria-live="polite">
+    <Icon path={mdiAlertOutline} size={16} />
+    <span class="sync-banner-text">
+      Couldn’t list pull requests — {sync.message ?? 'the forge is unreachable.'}
+      {#if sync.reason === 'rate_limited'}
+        {#if sync.retryAt}<strong>Resets in {resetsIn(sync.retryAt)}.</strong>{/if}
+        Configure a forge token or GitHub App to raise the API rate limit.
+      {:else}
+        Any pull requests already loaded are still shown below.
+      {/if}
+    </span>
+  </div>
+{/if}

--- a/internal/web/src/lib/store.svelte.ts
+++ b/internal/web/src/lib/store.svelte.ts
@@ -11,6 +11,7 @@ import type {
   Meta,
   PRStatus,
   RenderFailure,
+  SyncStatus,
   Warning,
   WSEvent,
 } from './types';
@@ -57,6 +58,7 @@ interface Store {
   loading: boolean; // a diff fetch/render is in flight
   previews: Record<number, RowPreview>; // lazy list-row diff summaries, by PR number
   connected: boolean;
+  sync: SyncStatus | null; // forge-polling health; non-null ⇒ last poll failed (show the banner)
 }
 
 export const store: Store = $state({
@@ -76,6 +78,7 @@ export const store: Store = $state({
   loading: false,
   previews: {},
   connected: false,
+  sync: null,
 });
 
 // ---- derived helpers ------------------------------------------------------
@@ -299,6 +302,7 @@ async function getJSON<T>(path: string): Promise<T> {
 export async function loadMeta(): Promise<void> {
   try {
     store.meta = await getJSON<Meta>('/api/meta');
+    store.sync = store.meta.sync ?? null; // seed the banner from the initial poll health
   } catch (err) {
     console.error('loadMeta', err);
   }
@@ -465,6 +469,11 @@ function onEvent(ev: WSEvent): void {
   if (ev.type === 'checks') {
     const pr = store.prs.find((p) => p.number === ev.number);
     if (pr) pr.checks = ev.checks.state ? ev.checks : undefined;
+    return;
+  }
+  // Forge-polling health changed: raise the banner (ok=false) or clear it (ok=true).
+  if (ev.type === 'sync') {
+    store.sync = ev.sync.ok ? null : ev.sync;
     return;
   }
   // ev is narrowed to the 'status' variant here — status is guaranteed present.

--- a/internal/web/src/lib/types.ts
+++ b/internal/web/src/lib/types.ts
@@ -181,7 +181,22 @@ export interface DiffEnvelope {
 export type WSEvent =
   | { type: 'status'; number: number; status: JobStatus; error?: string }
   | { type: 'removed'; number: number }
-  | { type: 'checks'; number: number; checks: CheckRollup };
+  | { type: 'checks'; number: number; checks: CheckRollup }
+  | { type: 'sync'; sync: SyncStatus };
+
+// Why a forge poll failed: a rate limit shows a countdown + token hint, a generic
+// error doesn't. Mirrors api.SyncReason.
+export type SyncReason = 'rate_limited' | 'error';
+
+// Forge-polling health. Surfaced on Meta (initial load) and pushed as a "sync"
+// WSEvent (live); the UI shows a banner when ok is false instead of a misleading
+// empty PR list.
+export interface SyncStatus {
+  ok: boolean;
+  reason?: SyncReason;
+  message?: string; // human-readable detail for the banner
+  retryAt?: number; // Unix seconds the rate limit resets (rate_limited only)
+}
 
 export interface Meta {
   forge: string;
@@ -189,4 +204,5 @@ export interface Meta {
   repoUrl?: string; // the repo's web page on its forge (the header links to it)
   version?: string; // konflate build version ("dev" for local builds)
   refreshIntervalSeconds: number;
+  sync?: SyncStatus; // present (ok=false) only when the last forge poll failed
 }

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -1122,6 +1122,60 @@ test('an empty PR list reads as the success state, not an error', async ({ page 
   await page.routeWebSocket('**/ws', () => {});
   await page.goto('/');
   await expect(page.locator('.all-clear')).toContainText('All caught up');
+  // A healthy poll shows no sync banner — the empty list is genuine, not a failure.
+  await expect(page.locator('.sync-banner')).toHaveCount(0);
+});
+
+test('a rate-limited forge poll shows a banner with a reset countdown, not a bare empty list', async ({ page }) => {
+  // The misread that motivated this: an anonymous (rate-limited) poll returned no
+  // PRs and the UI read as "all caught up". Now meta carries sync.ok=false and the
+  // banner explains why — with the reset time and how to raise the limit.
+  const retryAt = Math.floor(Date.now() / 1000) + 11 * 60;
+  await page.route('**/api/meta', (r) =>
+    r.fulfill({
+      json: {
+        ...defaultMeta,
+        sync: { ok: false, reason: 'rate_limited', message: 'GitHub API rate limit exceeded.', retryAt },
+      },
+    }),
+  );
+  await page.route('**/api/prs', (r) => r.fulfill({ json: [] }));
+  await page.routeWebSocket('**/ws', () => {});
+  await page.goto('/');
+
+  const banner = page.locator('.sync-banner');
+  await expect(banner).toBeVisible();
+  await expect(banner).toContainText('GitHub API rate limit exceeded.');
+  await expect(banner).toContainText(/Resets in ~\d+ minutes?\./);
+  await expect(banner).toContainText('Configure a forge token or GitHub App');
+});
+
+test('a generic poll failure banners the error but keeps any loaded PRs', async ({ page }) => {
+  // Unlike a rate limit, an unreachable forge has no reset time or token remedy —
+  // the banner just names the failure and reassures that the list below is stale,
+  // not empty. (Pushed live as a "sync" websocket event here.)
+  await stubApi(page);
+  let pushSync: ((data: string) => void) | null = null;
+  await page.routeWebSocket('**/ws', (ws) => {
+    pushSync = (data) => ws.send(data);
+  });
+  await page.goto('/');
+  await expect(page.locator('.card')).toHaveCount(3);
+  await expect(page.locator('.sync-banner')).toHaveCount(0); // healthy to start
+
+  await expect.poll(() => pushSync !== null).toBe(true);
+  pushSync!(JSON.stringify({ type: 'sync', sync: { ok: false, reason: 'error', message: 'forge unreachable' } }));
+
+  const banner = page.locator('.sync-banner');
+  await expect(banner).toBeVisible();
+  await expect(banner).toContainText('forge unreachable');
+  await expect(banner).toContainText('still shown below');
+  await expect(banner).not.toContainText('Resets in');
+  await expect(page.locator('.card')).toHaveCount(3); // the kept PRs remain
+
+  // A recovering "sync" event (ok=true) clears the banner.
+  pushSync!(JSON.stringify({ type: 'sync', sync: { ok: true } }));
+  await expect(page.locator('.sync-banner')).toHaveCount(0);
 });
 
 test('mobile: back and prev/next share one header row, title below (compact chrome)', async ({ page }) => {


### PR DESCRIPTION
This PR makes konflate's forge connectivity honest when something goes wrong, and consistent about authentication. Two related changes:

## 1. Surface forge poll failures instead of an empty list

When konflate can't list PRs from the forge — a hit **rate limit** or an **unreachable host** — the UI showed the same *"All caught up"* empty state as a genuinely empty repo. A failure read as success. This is exactly what happens on a token-less instance hitting GitHub's 60/hr anonymous limit.

- `provider.RateLimit(err)` classifies GitHub's primary `*RateLimitError` (with reset time) and secondary `*AbuseRateLimitError` (retry-after) through the wrapped chain.
- `internal/server/sync.go`: a `syncTracker` records polling health, surfaced on `/api/meta` and pushed as a `"sync"` websocket event **only on a health transition**.
- Typed `api.SyncReason` enum (`rate_limited` | `error`), mirroring `JobStatus`.
- UI `SyncBanner`: an amber strip with a reset countdown + "configure a token / GitHub App" hint for rate limits; clears on recovery; loaded PRs stay visible.
- Metrics: `konflate_forge_list_errors_total{reason}`, `konflate_forge_rate_limited`, `konflate_forge_rate_limit_reset_timestamp_seconds`.

## 2. Authenticate **all** forge requests (clone included)

#213 fixed the API *read* path, but the renderer's `git` clone/fetch was still built with `KONFLATE_TOKEN` (the PAT) alone — so a **GitHub-App-only** instance (no PAT) cloned **anonymously**, failing on private repos and subject to the anonymous rate limit, even though its API and write-back authenticated as the App. (App installation tokens also expire hourly, so a token captured at startup couldn't be reused.)

- The mirror now takes a credential **resolved per fetch** (`gitclone.TokenFunc`) instead of a static token.
- `provider.GitTokenSource` selects it by the same precedence as the read client: a GitHub App mints a **fresh installation token** each fetch, else the PAT, else anonymous.
- So clone/fetch carries the same forge identity as every other request — a render reaches private repos and isn't capped by the anonymous limit.
- **Audited the remaining outbound paths:** API reads (read client), write-back (write client), and CI checks are already authenticated; the **avatar proxy stays unauthenticated by design** — it fetches public CDN URLs the forge returned, and attaching the token there would leak it to a third-party host.

## Tests
- `provider`: `TestRateLimit`, `TestGitTokenSource` (App / PAT / anonymous selection + malformed-key rejection).
- `gitclone`: `TestMirror_AuthFor` (nil/empty → anonymous, token → x-access-token basic auth, source error propagates).
- `server`: `TestClassifyListResult`, `TestSyncTracker_SetReportsTransitions`, `TestServer_SyncStatusSurfacing`.
- UI: Playwright cases for the rate-limited banner, the generic poll-failure banner, and a healthy empty list (no banner).

All green locally: `fmt-check`, `vet`, `lint` (0 issues), `generate-check`, `go test ./...`, `ui-typecheck`, `ui-build`, `ui-test` (70 passed). No chart changes; no new module dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)