### PR TITLE
feat(writeback): post a GitHub Check Run for the render verdict

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,12 +277,22 @@ open a "render failed" comment on a PR it can't render.
 Write-back is **off until you opt in** — it needs a write credential **and** at
 least one of the feature toggles:
 
-- `KONFLATE_STATUS_CHECKS=true` — post the commit status.
+- `KONFLATE_STATUS_CHECKS=true` — report the render verdict as a status check.
 - `KONFLATE_PR_COMMENTS=true` — post (and update in place) the summary comment.
 - a write credential — a write token, or GitHub App credentials (below).
 
 Set `KONFLATE_PUBLIC_URL` as well so the status and comment link back to the
 review; without it they're still posted, just without a link.
+
+With `KONFLATE_STATUS_CHECKS` on, a **GitHub App** that holds the **Checks**
+permission posts a **Check Run** — a pass / neutral / fail conclusion plus the
+rendered summary (cautions, render failures, blast radius, image changes) in the
+PR's Checks tab, which you can require as a merge gate (cautions are a
+non-blocking _neutral_). A write PAT, GitLab, Forgejo, or an App without
+`checks:write` posts a plain commit status instead; konflate detects the missing
+permission and falls back automatically, so granting `checks:write` upgrades an
+existing App with no other change. The check is upserted per head commit, so a
+re-render refreshes one check rather than stacking duplicates.
 
 Write-back is **best-effort**: each write runs off the render path, a transient
 forge failure (a 5xx, a blip, a brief outage) is retried a few times with
@@ -310,12 +320,12 @@ comments on that repo.
 Scopes depend on which write-back you enable: commit statuses and PR comments are
 governed by different permissions.
 
-| Forge           | Credential                                                             | Scope                                                                                                                                 |
-| --------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| GitHub          | **GitHub App** (preferred) — `KONFLATE_APP_CLIENT_ID` + `_PRIVATE_KEY` | App permissions, installed on the repo: **Commit statuses: R/W** (statuses) and/or **Pull requests: R/W** (comments).                 |
-| GitHub          | or a write PAT — `KONFLATE_WRITE_TOKEN`                                | Fine-grained **Commit statuses** and/or **Pull requests** (R/W); or a classic `repo:status` (statuses only) / `repo` (also comments). |
-| GitLab          | `KONFLATE_WRITE_TOKEN`                                                 | Token with the `api` scope and at least **Developer** on the project (covers both statuses and notes).                                |
-| Forgejo / Gitea | `KONFLATE_WRITE_TOKEN`                                                 | Token with `write:repository` (statuses) and, for comments, `write:issue`.                                                            |
+| Forge           | Credential                                                             | Scope                                                                                                                                                 |
+| --------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GitHub          | **GitHub App** (preferred) — `KONFLATE_APP_CLIENT_ID` + `_PRIVATE_KEY` | App permissions, installed on the repo: **Checks: R/W** (Check Run; falls back to **Commit statuses: R/W**) and/or **Pull requests: R/W** (comments). |
+| GitHub          | or a write PAT — `KONFLATE_WRITE_TOKEN`                                | Fine-grained **Commit statuses** and/or **Pull requests** (R/W); or a classic `repo:status` (statuses only) / `repo` (also comments).                 |
+| GitLab          | `KONFLATE_WRITE_TOKEN`                                                 | Token with the `api` scope and at least **Developer** on the project (covers both statuses and notes).                                                |
+| Forgejo / Gitea | `KONFLATE_WRITE_TOKEN`                                                 | Token with `write:repository` (statuses) and, for comments, `write:issue`.                                                                            |
 
 On GitHub the **App is preferred**: konflate authenticates as the App and mints
 short-lived installation tokens, so no long-lived PAT sits in the deployment, the

--- a/internal/provider/writer.go
+++ b/internal/provider/writer.go
@@ -57,6 +57,40 @@ type Writer interface {
 	Verify(ctx context.Context) error
 }
 
+// Check Run conclusions konflate reports (a superset of the commit-status states,
+// GitHub-only). Neutral is a non-blocking heads-up — cautions surface without
+// failing the PR, and an operator can still gate on them by making the check
+// required.
+const (
+	CheckSuccess = "success"
+	CheckNeutral = "neutral"
+	CheckFailure = "failure"
+)
+
+// CheckResult is one Check Run konflate posts on a PR head: a conclusion plus a
+// markdown report, richer than a commit status (it shows in the Checks tab and can
+// be a required merge gate). Only a GitHub App can create one — see [CheckRunner].
+type CheckResult struct {
+	Name       string // the check's name on the PR (config StatusCheckName)
+	Conclusion string // CheckSuccess | CheckNeutral | CheckFailure
+	Title      string // short one-line headline
+	Summary    string // markdown body (GitHub renders its admonitions in check output)
+	DetailsURL string // konflate's review URL for the PR
+}
+
+// CheckRunner is a [Writer] that can additionally post a GitHub Check Run. The
+// REST API only lets a GitHub App create check runs, so a write-PAT writer reports
+// ChecksSupported()==false and the GitLab/Forgejo writers don't implement this at
+// all — callers fall back to SetStatus in every non-App case.
+type CheckRunner interface {
+	// ChecksSupported reports whether this writer can post Check Runs (App-authed).
+	ChecksSupported() bool
+	// CheckRun creates or updates konflate's Check Run on the PR head. A permanent
+	// permission rejection (the App lacks checks:write) is wrapped as
+	// ErrWriteAuthRejected so the caller can fall back to a commit status.
+	CheckRun(ctx context.Context, pr api.PR, res CheckResult) error
+}
+
 // ErrWriteAuthRejected marks a write-back credential the forge rejected in a way
 // that won't fix itself — a 401/403/404 (bad token, missing permission, a wrong
 // GitHub App installation, or an unreachable repo), as opposed to a transient 5xx
@@ -131,6 +165,7 @@ func (r *resolvedString) get(ctx context.Context) (string, error) {
 type githubWriter struct {
 	client      *github.Client
 	owner, repo string
+	app         bool            // App-authed ⇒ can post Check Runs (a PAT can't)
 	self        *resolvedString // login of konflate's own comment author; resolved once
 }
 
@@ -140,7 +175,7 @@ func newGitHubWriter(cfg *config.Config) (*githubWriter, error) {
 		return nil, err
 	}
 	owner, repo := ownerRepo(cfg.Forge.RepoPath)
-	return &githubWriter{client: client, owner: owner, repo: repo, self: &resolvedString{resolve: self}}, nil
+	return &githubWriter{client: client, owner: owner, repo: repo, app: cfg.AppConfigured(), self: &resolvedString{resolve: self}}, nil
 }
 
 // newGitHubWriteClient builds the authenticated write client. A fully-configured
@@ -354,6 +389,71 @@ func (w *githubWriter) SetStatus(ctx context.Context, pr api.PR, st Status) erro
 		return fmt.Errorf("github: set status #%d: %w", pr.Number, err)
 	}
 	return nil
+}
+
+// ChecksSupported reports whether this writer can post Check Runs — true only for
+// the App identity (the REST API forbids check runs over a PAT).
+func (w *githubWriter) ChecksSupported() bool { return w.app }
+
+// CheckRun creates konflate's Check Run on the PR head, or updates the existing one
+// for that head SHA in place (found by the check name) so a re-render of the same
+// commit refreshes a single check rather than stacking duplicates.
+func (w *githubWriter) CheckRun(ctx context.Context, pr api.PR, res CheckResult) error {
+	completed, now := "completed", github.Timestamp{Time: time.Now()}
+	output := &github.CheckRunOutput{Title: &res.Title, Summary: &res.Summary}
+
+	id, err := w.findCheckRun(ctx, pr.HeadSHA, res.Name)
+	if err != nil {
+		return err
+	}
+	if id != 0 {
+		_, resp, err := w.client.Checks.UpdateCheckRun(ctx, w.owner, w.repo, id, github.UpdateCheckRunOptions{
+			Name:        res.Name,
+			Status:      &completed,
+			Conclusion:  &res.Conclusion,
+			CompletedAt: &now,
+			DetailsURL:  strOrNil(res.DetailsURL),
+			Output:      output,
+		})
+		if err != nil {
+			return rejectedIf(githubStatus(resp, err), fmt.Errorf("github: update check run #%d: %w", pr.Number, err))
+		}
+		return nil
+	}
+	_, resp, err := w.client.Checks.CreateCheckRun(ctx, w.owner, w.repo, github.CreateCheckRunOptions{
+		Name:        res.Name,
+		HeadSHA:     pr.HeadSHA,
+		Status:      &completed,
+		Conclusion:  &res.Conclusion,
+		CompletedAt: &now,
+		DetailsURL:  strOrNil(res.DetailsURL),
+		Output:      output,
+	})
+	if err != nil {
+		return rejectedIf(githubStatus(resp, err), fmt.Errorf("github: create check run #%d: %w", pr.Number, err))
+	}
+	return nil
+}
+
+// findCheckRun returns the id of konflate's existing Check Run (matched by name) on
+// sha, or 0 if there is none. Matching by name is enough — konflate owns its check
+// name; in the improbable event another app's check shares it, updating it 404/403s
+// and the caller falls back to a commit status.
+func (w *githubWriter) findCheckRun(ctx context.Context, sha, name string) (int64, error) {
+	if sha == "" {
+		return 0, nil
+	}
+	runs, resp, err := w.client.Checks.ListCheckRunsForRef(ctx, w.owner, w.repo, sha, &github.ListCheckRunsOptions{
+		CheckName:   &name,
+		ListOptions: github.ListOptions{PerPage: 1},
+	})
+	if err != nil {
+		return 0, rejectedIf(githubStatus(resp, err), fmt.Errorf("github: list check runs: %w", err))
+	}
+	for _, r := range runs.CheckRuns {
+		return r.GetID(), nil
+	}
+	return 0, nil
 }
 
 func (w *githubWriter) UpsertComment(ctx context.Context, pr api.PR, marker, body string) error {

--- a/internal/provider/writer_test.go
+++ b/internal/provider/writer_test.go
@@ -69,6 +69,112 @@ func TestGitHubWriter_SetStatus(t *testing.T) {
 	}
 }
 
+func TestGitHubWriter_CheckRun(t *testing.T) {
+	t.Parallel()
+	const sha = "deadbeefcafe"
+
+	t.Run("creates a check run when none exists", func(t *testing.T) {
+		t.Parallel()
+		var created struct {
+			Name       string `json:"name"`
+			HeadSHA    string `json:"head_sha"`
+			Status     string `json:"status"`
+			Conclusion string `json:"conclusion"`
+			DetailsURL string `json:"details_url"`
+			Output     struct {
+				Title, Summary string
+			} `json:"output"`
+		}
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/acme/web/commits/"+sha+"/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"total_count":0,"check_runs":[]}`))
+		})
+		mux.HandleFunc("/repos/acme/web/check-runs", func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewDecoder(r.Body).Decode(&created)
+			_, _ = w.Write([]byte(`{"id":1}`))
+		})
+		srv := httptest.NewServer(mux)
+		t.Cleanup(srv.Close)
+
+		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", app: true}
+		err := wr.CheckRun(context.Background(), api.PR{Number: 7, HeadSHA: sha}, CheckResult{
+			Name: "konflate", Conclusion: CheckNeutral, Title: "1 caution",
+			Summary: "### konflate — summary", DetailsURL: "https://k.example/#/pr/7",
+		})
+		if err != nil {
+			t.Fatalf("CheckRun (create): %v", err)
+		}
+		if created.Name != "konflate" || created.HeadSHA != sha || created.Status != "completed" ||
+			created.Conclusion != "neutral" || created.DetailsURL != "https://k.example/#/pr/7" ||
+			created.Output.Title != "1 caution" || created.Output.Summary != "### konflate — summary" {
+			t.Errorf("create payload = %+v", created)
+		}
+	})
+
+	t.Run("updates the existing run for the head SHA", func(t *testing.T) {
+		t.Parallel()
+		var patched string
+		var conclusion string
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/acme/web/commits/"+sha+"/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"total_count":1,"check_runs":[{"id":42,"name":"konflate"}]}`))
+		})
+		mux.HandleFunc("/repos/acme/web/check-runs/42", func(w http.ResponseWriter, r *http.Request) {
+			patched = r.URL.Path
+			var body struct {
+				Conclusion string `json:"conclusion"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			conclusion = body.Conclusion
+			_, _ = w.Write([]byte(`{"id":42}`))
+		})
+		mux.HandleFunc("/repos/acme/web/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+			t.Error("created a new check run when one already existed; want update")
+			_, _ = w.Write([]byte(`{"id":99}`))
+		})
+		srv := httptest.NewServer(mux)
+		t.Cleanup(srv.Close)
+
+		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", app: true}
+		err := wr.CheckRun(context.Background(), api.PR{Number: 7, HeadSHA: sha}, CheckResult{
+			Name: "konflate", Conclusion: CheckSuccess, Title: "clean", Summary: "ok",
+		})
+		if err != nil {
+			t.Fatalf("CheckRun (update): %v", err)
+		}
+		if patched != "/repos/acme/web/check-runs/42" || conclusion != "success" {
+			t.Errorf("update path=%q conclusion=%q, want .../check-runs/42 + success", patched, conclusion)
+		}
+	})
+
+	t.Run("a permission rejection is classified so the server can fall back", func(t *testing.T) {
+		t.Parallel()
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/acme/web/commits/"+sha+"/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, `{"message":"Resource not accessible by integration"}`, http.StatusForbidden)
+		})
+		srv := httptest.NewServer(mux)
+		t.Cleanup(srv.Close)
+
+		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", app: true}
+		err := wr.CheckRun(context.Background(), api.PR{Number: 7, HeadSHA: sha},
+			CheckResult{Name: "konflate", Conclusion: CheckSuccess})
+		if !errors.Is(err, ErrWriteAuthRejected) {
+			t.Fatalf("CheckRun on a 403 = %v, want ErrWriteAuthRejected", err)
+		}
+	})
+
+	t.Run("ChecksSupported tracks App auth", func(t *testing.T) {
+		t.Parallel()
+		if !(&githubWriter{app: true}).ChecksSupported() {
+			t.Error("an App-authed writer must support check runs")
+		}
+		if (&githubWriter{app: false}).ChecksSupported() {
+			t.Error("a PAT-authed writer must not advertise check-run support")
+		}
+	})
+}
+
 func TestNewWriter_NilWhenDisabled(t *testing.T) {
 	t.Parallel()
 	w, err := NewWriter(&config.Config{}) // no write credential

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"text/template"
 	"time"
 	"unicode"
@@ -41,9 +42,13 @@ type Server struct {
 	cfg    *config.Config
 	prov   provider.Provider
 	writer provider.Writer // forge write-back (commit statuses); nil when disabled
-	engine Engine
-	ui     fs.FS
-	log    *slog.Logger
+	// checksRejected latches once the forge rejects a Check Run for lack of
+	// permission (the App has no checks:write): subsequent renders skip straight to
+	// the commit-status fallback instead of retrying a write that can't succeed.
+	checksRejected atomic.Bool
+	engine         Engine
+	ui             fs.FS
+	log            *slog.Logger
 
 	// Version is the build version (main stamps it from ldflags after New);
 	// served at /api/meta for the UI footer. "dev" or empty for local builds.
@@ -252,7 +257,10 @@ func sleepCtx(ctx context.Context, d time.Duration) bool {
 	}
 }
 
-// postStatus writes konflate's commit status for a terminal render outcome.
+// postStatus reports a terminal render outcome on the PR head. A GitHub App with
+// checks:write gets a richer Check Run (a conclusion + a markdown report, gate-able
+// as a required check); a write-PAT, GitLab/Forgejo, or an App without checks:write
+// falls back to a plain commit status — so enabling write-back never regresses.
 func (s *Server) postStatus(pr api.PR, st api.JobStatus, sig *api.Signals, errMsg string) {
 	status := provider.Status{Context: s.cfg.StatusCheckName, TargetURL: s.reviewURL(pr.Number)}
 	switch st {
@@ -265,9 +273,69 @@ func (s *Server) postStatus(pr api.PR, st api.JobStatus, sig *api.Signals, errMs
 	default:
 		return
 	}
+
+	cr, canCheck := s.writer.(provider.CheckRunner)
+	canCheck = canCheck && cr.ChecksSupported() && !s.checksRejected.Load()
+	var check provider.CheckResult
+	if canCheck {
+		check = s.checkResult(pr, st, sig, errMsg)
+	}
+
 	s.writeBack("status", pr.Number, func(ctx context.Context) error {
+		if canCheck {
+			err := cr.CheckRun(ctx, pr, check)
+			if !errors.Is(err, provider.ErrWriteAuthRejected) {
+				return err // success, or a transient error worth retrying as a check run
+			}
+			// The App can't post check runs (no checks:write). Latch it so later
+			// renders skip straight to the commit status, warning once rather than on
+			// every render; fall back to the status for this one now.
+			if s.checksRejected.CompareAndSwap(false, true) {
+				s.log.Warn("check run rejected; falling back to a commit status (grant the GitHub App checks:write to post check runs)",
+					"pr", pr.Number, "error", err)
+			}
+			canCheck = false
+		}
 		return s.writer.SetStatus(ctx, pr, status)
 	})
+}
+
+// checkResult assembles the Check Run payload for a terminal outcome: a conclusion
+// from the verdict and a markdown report reusing the comment summary renderer
+// (GitHub renders its admonitions in check output too).
+func (s *Server) checkResult(pr api.PR, st api.JobStatus, sig *api.Signals, errMsg string) provider.CheckResult {
+	res := provider.CheckResult{
+		Name:       s.cfg.StatusCheckName,
+		DetailsURL: s.reviewURL(pr.Number),
+		Conclusion: checkConclusion(st, sig),
+	}
+	if st == api.JobError {
+		res.Title = truncateStatus("render failed: " + oneLine(errMsg))
+	} else {
+		res.Title = renderedStatusDescription(sig)
+	}
+	// The stored envelope drives the markdown body (it handles ready/error/pending);
+	// fall back to the title alone if it's somehow gone.
+	if env, ok := s.store.get(pr.Number); ok {
+		res.Summary = summaryMarkdownBody(env, res.DetailsURL, true)
+	} else {
+		res.Summary = res.Title
+	}
+	return res
+}
+
+// checkConclusion maps a render verdict to a Check Run conclusion: a render error
+// or any render failure fails the check; cautions are a non-blocking neutral; an
+// otherwise-clean render passes.
+func checkConclusion(st api.JobStatus, sig *api.Signals) string {
+	switch {
+	case st == api.JobError, sig != nil && sig.Failures > 0:
+		return provider.CheckFailure
+	case sig != nil && sig.Caution > 0:
+		return provider.CheckNeutral
+	default:
+		return provider.CheckSuccess
+	}
 }
 
 // postComment posts (or updates in place) the rendered summary as a PR comment.

--- a/internal/server/writeback_test.go
+++ b/internal/server/writeback_test.go
@@ -44,6 +44,99 @@ func TestVerifyWriteBack(t *testing.T) {
 	}
 }
 
+func TestCheckConclusion(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		st   api.JobStatus
+		sig  *api.Signals
+		want string
+	}{
+		{"render error fails", api.JobError, nil, provider.CheckFailure},
+		{"render failures fail", api.JobReady, &api.Signals{Failures: 1, Caution: 2}, provider.CheckFailure},
+		{"cautions are neutral (non-blocking)", api.JobReady, &api.Signals{Caution: 1}, provider.CheckNeutral},
+		{"a clean render passes", api.JobReady, &api.Signals{Resources: 3}, provider.CheckSuccess},
+		{"a ready render with no signals passes", api.JobReady, nil, provider.CheckSuccess},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := checkConclusion(tc.st, tc.sig); got != tc.want {
+				t.Errorf("checkConclusion(%q, %+v) = %q, want %q", tc.st, tc.sig, got, tc.want)
+			}
+		})
+	}
+}
+
+// recordingWriter is a provider.Writer + CheckRunner that records which write the
+// server ultimately made, signalling the method name once the async write-back
+// settles. checkErr lets a test force the check run to be rejected.
+type recordingWriter struct {
+	supports bool
+	checkErr error
+	checkRun atomic.Int32
+	done     chan string
+}
+
+func (w *recordingWriter) SetStatus(context.Context, api.PR, provider.Status) error {
+	w.done <- "status"
+	return nil
+}
+func (w *recordingWriter) UpsertComment(context.Context, api.PR, string, string) error { return nil }
+func (*recordingWriter) Verify(context.Context) error                                  { return nil }
+func (w *recordingWriter) ChecksSupported() bool                                       { return w.supports }
+func (w *recordingWriter) CheckRun(context.Context, api.PR, provider.CheckResult) error {
+	w.checkRun.Add(1)
+	if w.checkErr != nil {
+		return w.checkErr // the server falls back to SetStatus, which signals
+	}
+	w.done <- "check"
+	return nil
+}
+
+// TestServer_PostStatusChecksVsStatus verifies the write selection: an App that can
+// post check runs gets one; a rejected check run (no checks:write) falls back to a
+// commit status; and a writer that can't post check runs gets a commit status.
+func TestServer_PostStatusChecksVsStatus(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		supports bool
+		checkErr error
+		want     string
+		triedRun bool
+	}{
+		{"App posts a check run", true, nil, "check", true},
+		{"rejection falls back to a commit status", true, fmt.Errorf("github: %w", provider.ErrWriteAuthRejected), "status", true},
+		{"a non-App writer posts a commit status", false, nil, "status", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			w := &recordingWriter{supports: tc.supports, checkErr: tc.checkErr, done: make(chan string, 2)}
+			s := &Server{
+				cfg:    &config.Config{StatusCheckName: "konflate"},
+				log:    discardLog(),
+				runCtx: context.Background(),
+				store:  newStore(),
+				writer: w,
+			}
+			s.postStatus(api.PR{Number: 7, HeadSHA: "sha"}, api.JobReady, &api.Signals{Resources: 1}, "")
+			select {
+			case got := <-w.done:
+				if got != tc.want {
+					t.Errorf("posted %q, want %q", got, tc.want)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("write-back never completed")
+			}
+			if tried := w.checkRun.Load() > 0; tried != tc.triedRun {
+				t.Errorf("attempted check run = %v, want %v", tried, tc.triedRun)
+			}
+		})
+	}
+}
+
 func TestRetryWrite(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Why

konflate's render verdict (cautions, render failures, blast radius, image changes) lived only in konflate's own UI and a legacy **commit status**. A commit status can't carry a report and reads as a flat pass/fail. A **Check Run** is the App-native, richer surface: a conclusion *plus* a markdown report in the PR's Checks tab, and it can be a required merge gate.

## What

When the status-check write-back is enabled (`KONFLATE_STATUS_CHECKS`) and konflate authenticates as a **GitHub App with `checks:write`**, it now posts a **Check Run** instead of a commit status:

- **Conclusion** from the render verdict — `success` (clean), `neutral` (cautions — a non-blocking heads-up, so a routine StatefulSet bump doesn't hard-fail the PR), `failure` (render failures or a failed render).
- **Markdown report** in the Checks tab — the same summary konflate posts as a comment (cautions, render failures, blast radius, image changes), reusing the existing renderer (GitHub renders its admonitions in check output too).
- **Upserted per head commit** (found by check name) — a re-render refreshes the one check rather than stacking duplicates.
- **Details link** back to the konflate review.

### No regression, no new knob

Check Runs can only be created by a GitHub App (the REST API forbids them over a PAT). So:

- A write **PAT**, **GitLab**, **Forgejo**, or an **App without `checks:write`** falls back to the existing commit status.
- konflate detects a missing-permission rejection at render time, **latches it (warning once)**, and posts the commit status from then on — mirroring the startup `Verify`-disable pattern. Granting `checks:write` later auto-upgrades it (after a restart).
- Reuses the existing `KONFLATE_STATUS_CHECKS` toggle and `StatusCheckName` — **no new env var or chart value.**

## Design note

These are *summary-level* check runs, not inline file annotations: konflate's cautions are keyed to **rendered resources** (`Kind ns/name`), and there's no per-caution source file/line in the pipeline, so GitHub's line-annotation API isn't applicable without new source-provenance plumbing. The conclusion + report is the high-value, fully-reliable surface; inline annotations remain a possible follow-up.

## Tests
- `provider`: `TestGitHubWriter_CheckRun` — create when none exists, update the existing run for the head SHA, a 403 classified as `ErrWriteAuthRejected` (so the server falls back), and `ChecksSupported()` tracks App auth.
- `server`: `TestCheckConclusion` (verdict→conclusion) and `TestServer_PostStatusChecksVsStatus` (App → check run; rejection → commit-status fallback; non-App → commit status).

All green locally: `vet`, `lint` (0 issues), `generate-check` (no chart drift), `go test ./...` (race-clean). README write-back section updated; no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)