### PR TITLE
feat(ui): review-header + summary layout polish

### DIFF
--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -1218,13 +1218,14 @@ button.sum-pill:hover {
    4 / 2 / 1 breakpoints rather than auto-fit, which packs three then orphans the
    fourth onto a lonely second row: wide → four across, medium → a balanced 2×2,
    narrow → a single stack. Always a balanced grid, never a 3+1. The queries read
-   .overview's width (the pane), so they're right with or without the tree rail. */
+   .overview's width (the pane), so they're right with or without the tree rail.
+   No max-width: the columns (and their content) widen with the pane rather than
+   leaving dead space on the right of a wide viewport. */
 .ov-grid {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   gap: 24px;
   align-items: start;
-  max-width: 1280px;
 }
 @container (min-width: 440px) {
   .ov-grid {

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -727,6 +727,7 @@ a.repo:focus-visible .repo-ext {
 }
 .card-title {
   font-weight: 600;
+  min-width: 0; /* shrink (ellipsis) so a trailing check stays visible */
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -941,9 +941,9 @@ button.sum-pill:hover {
   border-bottom: 1px solid var(--border);
   background: var(--panel);
 }
-/* One row: the title hugs its content with the PR number right after it, and the
-   meta trailer is pushed right (margin-left:auto on .rt-meta). The title shrinks
-   (ellipsis) before the number does. */
+/* One row: the title hugs its content with the CI check right after it, and the
+   meta trailer (with the PR link at its end) is pushed right (margin-left:auto on
+   .rt-meta). The title shrinks (ellipsis) before the check does. */
 .review-title {
   flex: 1 1 auto;
   min-width: 0;
@@ -959,13 +959,6 @@ button.sum-pill:hover {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-/* The PR number rejoins the title as its identifier — no glyph (that's the list
-   rows'), a step up in weight from the muted meta trailer, still a forge link. */
-.review-title > .forge-link {
-  flex: 0 0 auto;
-  font-size: 13px;
-  font-weight: 600;
 }
 .rt-meta {
   display: flex;
@@ -1059,6 +1052,11 @@ button.sum-pill:hover {
    square sitting just left of the disclosure column. */
 .forge-link.icon-only {
   padding: 8px;
+}
+/* In the review meta trailer the PR link is one quiet inline item among the
+   author/sha/time tags — drop the list row's tap padding so it aligns with them. */
+.rt-meta .forge-link {
+  padding: 0;
 }
 .review-nav {
   display: flex;
@@ -2183,10 +2181,10 @@ kbd {
   .review-title {
     order: 1;
     flex-basis: 100%;
-    /* Inline flow, not a flex row: the title text and its #number share line
-       boxes, so the number trails the last word of the (wrapping) title instead
-       of being bumped to its own line once the title fills the width. The meta
-       row is a block beneath. */
+    /* Inline flow, not a flex row: the title text and its trailing CI check share
+       line boxes, so the check sits by the last word of the (wrapping) title
+       instead of being bumped to its own line once the title fills the width. The
+       meta row (with the PR link at its end) is a block beneath. */
     display: block;
   }
   /* 16px so iOS doesn't force-zoom the page when the filter gains focus. */
@@ -2241,18 +2239,14 @@ kbd {
     overflow: hidden;
     min-width: 0;
   }
-  /* The title flows inline here so #number can trail it; override the two-line
-     clamp that .card-title still relies on. */
+  /* The title flows inline here so its trailing CI check sits beside it; override
+     the two-line clamp that .card-title still relies on. */
   .rt-name {
     display: inline;
     -webkit-line-clamp: none;
   }
-  /* #number flows inline right after the last word of the title. */
-  .review-title > .forge-link {
-    margin-left: 6px;
-  }
-  /* The meta row (author · sha · opened · refreshed) sits on its own line below
-     the inline title+number; let it wrap, and clear the desktop margin-left:auto. */
+  /* The meta row (author · sha · opened · refreshed · PR link) sits on its own line
+     below the inline title; let it wrap, and clear the desktop margin-left:auto. */
   .rt-meta {
     margin-top: 6px;
     flex-wrap: wrap;

--- a/internal/web/src/lib/Check.svelte
+++ b/internal/web/src/lib/Check.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import Icon from './Icon.svelte';
+  import { mdiCheckCircle, mdiCloseCircleOutline, mdiCircleOutline } from './icons';
+  import type { CheckRollup } from './types';
+
+  // The PR head's rolled-up CI status, shown beside the PR title in the list and
+  // the review header. success/failure/pending map to the ok/danger/warn-tinted
+  // check / x / hollow-circle (.check-{state} in app.css). The caller renders this
+  // only when pr.checks is present — a head with no checks shows nothing.
+  let { checks, size = 14 }: { checks: CheckRollup; size?: number } = $props();
+
+  const icon = $derived(
+    checks.state === 'success'
+      ? mdiCheckCircle
+      : checks.state === 'failure'
+        ? mdiCloseCircleOutline
+        : mdiCircleOutline,
+  );
+  const title = $derived(
+    checks.state === 'success'
+      ? `Checks passed (${checks.passed}/${checks.total})`
+      : checks.state === 'failure'
+        ? `Checks failing — ${checks.failed} of ${checks.total} failed`
+        : `Checks running (${checks.passed}/${checks.total} done)`,
+  );
+</script>
+
+<span class="check check-{checks.state}" {title}>
+  <Icon path={icon} size={size} />
+</span>

--- a/internal/web/src/lib/List.svelte
+++ b/internal/web/src/lib/List.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { PRStatus, CheckRollup } from './types';
+  import type { PRStatus } from './types';
   import {
     store,
     filteredPRs,
@@ -19,6 +19,7 @@
   import Breakable from './Breakable.svelte';
   import MergeCommand from './MergeCommand.svelte';
   import ForgeLink from './ForgeLink.svelte';
+  import Check from './Check.svelte';
   import {
     mdiAlert,
     mdiPackageVariantClosed,
@@ -36,26 +37,11 @@
     mdiChevronDown,
     mdiChevronUp,
     mdiCheckCircleOutline,
-    mdiCheckCircle,
-    mdiCloseCircleOutline,
-    mdiCircleOutline,
     mdiTrayFull,
     mdiUnfoldMoreHorizontal,
     mdiUnfoldLessHorizontal,
     mdiArrowUp,
   } from './icons';
-
-  // A PR-head CI rollup → an icon + tooltip. success/failure/pending map to the
-  // ok/danger/warn-tinted check / x / hollow-circle; pr.checks is absent when no
-  // checks ran, so the indicator only shows for a real state.
-  function checkIcon(state: string): string {
-    return state === 'success' ? mdiCheckCircle : state === 'failure' ? mdiCloseCircleOutline : mdiCircleOutline;
-  }
-  function checkTitle(c: CheckRollup): string {
-    if (c.state === 'success') return `Checks passed (${c.passed}/${c.total})`;
-    if (c.state === 'failure') return `Checks failing — ${c.failed} of ${c.total} failed`;
-    return `Checks running (${c.passed}/${c.total} done)`;
-  }
 
   // Two filter stages: the text query narrows `prs` (which the summary pills
   // count, so the counts hold steady while a pill is active), then the active
@@ -281,6 +267,7 @@
         <div class="card-top">
         <span class="dot {pr.hidden ? 'dot-hidden' : pr.open ? `dot-${pr.status}` : 'dot-merged'}"></span>
         <span class="card-title"><Breakable text={pr.title} /></span>
+        {#if pr.checks}<Check checks={pr.checks} />{/if}
       </div>
       <div class="card-meta">
         <span class="card-author"><Avatar src={pr.authorAvatar} size={15} /> {pr.author || 'unknown'}</span>
@@ -303,11 +290,6 @@
           <span class="labels"><Icon path={mdiTagOutline} size={12} />{#each pr.labels.slice(0, 4) as l}<span class="label">{#if labelColor(l)}<span class="label-dot" style:background-color={labelColor(l)}></span>{/if}{l.name}</span>{/each}</span>
         {/if}
         <span class="spacer"></span>
-        {#if pr.checks}
-          <span class="check check-{pr.checks.state}" title={checkTitle(pr.checks)}>
-            <Icon path={checkIcon(pr.checks.state)} size={14} />
-          </span>
-        {/if}
         {#if pr.signals}
           <span class="badges">
             {#if pr.refreshError}

--- a/internal/web/src/lib/Review.svelte
+++ b/internal/web/src/lib/Review.svelte
@@ -44,7 +44,6 @@
       <div class="review-title">
         <span class="rt-name"><Breakable text={pr?.title ?? ''} /></span>
         {#if pr?.checks}<Check checks={pr.checks} size={15} />{/if}
-        {#if pr}<ForgeLink url={pr.url} number={pr.number} glyph={false} />{/if}
         <div class="rt-meta">
           {#if pr}
             <span class="rt-tag rt-author"><Avatar src={pr.authorAvatar} size={16} /> {pr.author}</span>
@@ -58,6 +57,9 @@
             {#if pr.updatedAt}
               <span class="rt-tag ago" title={`Last rendered ${absolute(pr.updatedAt)}`}><Icon path={mdiRefresh} size={13} /> {timeAgo(pr.updatedAt, clock.now)}</span>
             {/if}
+            <!-- The link out to the PR trails the meta row as a PR-glyph icon (the
+                 number lives in its tooltip), beside the last-rendered time. -->
+            <ForgeLink url={pr.url} number={pr.number} showNumber={false} />
           {/if}
         </div>
       </div>

--- a/internal/web/src/lib/Review.svelte
+++ b/internal/web/src/lib/Review.svelte
@@ -18,6 +18,7 @@
   import Diffs from './Diffs.svelte';
   import Copy from './Copy.svelte';
   import ForgeLink from './ForgeLink.svelte';
+  import Check from './Check.svelte';
 
   const route = $derived(router.route.name === 'review' ? router.route : null);
   const pr = $derived(currentPR());
@@ -42,6 +43,7 @@
       </div>
       <div class="review-title">
         <span class="rt-name"><Breakable text={pr?.title ?? ''} /></span>
+        {#if pr?.checks}<Check checks={pr.checks} size={15} />{/if}
         {#if pr}<ForgeLink url={pr.url} number={pr.number} glyph={false} />{/if}
         <div class="rt-meta">
           {#if pr}

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -32,6 +32,10 @@ test('PR list shows the forge CI check status per PR (green / amber / red)', asy
   await expect(card(142).locator('.check-success')).toBeVisible(); // 4/4 passed
   await expect(card(138).locator('.check-pending')).toBeVisible(); // still running
   await expect(card(131).locator('.check-failure')).toBeVisible(); // one failed
+  // The check sits in the title row, right next to the title — not down in the
+  // meta row among the signal badges.
+  await expect(card(142).locator('.card-top .check-success')).toBeVisible();
+  await expect(card(142).locator('.card-meta .check')).toHaveCount(0);
 });
 
 test('list → review → single-page flow', async ({ page }) => {
@@ -98,6 +102,9 @@ test('list → review → single-page flow', async ({ page }) => {
   await expect(page.locator('.flag.caution', { hasText: 'StatefulSet' })).toBeVisible();
   await expect(page.locator('.img-list')).toContainText('ghcr.io/rook/ceph');
   await expect(page.locator('.flag', { hasText: 'plex' })).toBeVisible();
+  // The forge CI check rides next to the PR title on the review header too
+  // (#142 is 4/4 green).
+  await expect(page.locator('.review-title .check-success')).toBeVisible();
   // The same forge link sits next to the PR title on the review header.
   await expect(page.locator('.review-title .forge-link')).toHaveAttribute(
     'href',

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -105,12 +105,13 @@ test('list → review → single-page flow', async ({ page }) => {
   // The forge CI check rides next to the PR title on the review header too
   // (#142 is 4/4 green).
   await expect(page.locator('.review-title .check-success')).toBeVisible();
-  // The same forge link sits next to the PR title on the review header.
-  await expect(page.locator('.review-title .forge-link')).toHaveAttribute(
-    'href',
-    'https://github.com/acme/home-ops/pull/142',
-  );
-  await expect(page.locator('.review-title .forge-link')).toHaveAttribute('title', 'Open PR #142 on GitHub');
+  // The PR link lives in the meta trailer (beside the last-rendered time), as an
+  // icon — no "#142" text, and no longer a direct child next to the title.
+  const headerLink = page.locator('.rt-meta .forge-link');
+  await expect(headerLink).toHaveAttribute('href', 'https://github.com/acme/home-ops/pull/142');
+  await expect(headerLink).toHaveAttribute('title', 'Open PR #142 on GitHub');
+  await expect(headerLink).not.toContainText('#142');
+  await expect(page.locator('.review-title > .forge-link')).toHaveCount(0);
   // The tree: a Summary node (selected by default) + one leaf per changed
   // resource. A caution surfaces a marker on the Summary node.
   await expect(page.locator('.tree .tree-summary')).toHaveClass(/selected/);

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -1012,6 +1012,16 @@ test('the summary grid resolves to 4 / 2 / 1 columns by pane width (never an orp
   await expect(page.locator('.ov-grid')).toBeVisible();
   await expect.poll(trackCount).toBe(4);
 
+  // Ultrawide: the grid fills the pane (no fixed cap leaving dead space on the
+  // right). It tracks the pane width — within its 14px side padding of .overview.
+  await page.setViewportSize({ width: 2000, height: 900 });
+  await expect.poll(trackCount).toBe(4);
+  const fill = await page.locator('.ov-grid').evaluate((el) => {
+    const pane = (el.closest('.overview') as HTMLElement).clientWidth - 28; // minus 14px padding each side
+    return el.getBoundingClientRect().width / pane;
+  });
+  expect(fill).toBeGreaterThan(0.98); // fills the pane, not capped at 1280
+
   // Mid width — the pane auto-fit used to orphan (3 + 1). Now a balanced 2×2.
   await page.setViewportSize({ width: 960, height: 900 });
   await expect.poll(trackCount).toBe(2);


### PR DESCRIPTION
Three related review-header / summary layout tweaks.

## 1. CI check status next to the PR title
The PR-head CI rollup (green / amber / red) sat at the far right of the list card's meta row, lost among the signal badges. It now sits **next to the title** — in the list card's title row and on the review header (which didn't show it before). Extracted into a shared **`Check.svelte`** so both render identically.

## 2. PR link → meta trailer, as an icon
The link out to the PR sat as `#<n>` text right after the title. It now sits at the **end of the header's meta trailer** (beside the last-rendered time) as the **PR-glyph icon** — no `#<n>` text (the number stays in its tooltip), matching the icon-only link the list rows use. Retired the dead `.review-title > .forge-link` rules; updated stale layout comments.

## 3. Summary grid fills the pane
The four overview columns (render failures, cautions, blast radius, image changes) carried `max-width: 1280px`, leaving **dead space to the right** of the image-changes column on a wide pane. Dropped the cap — the columns and their content now widen with the viewport, matching the full-width diff below. The 4 / 2 / 1 container-query breakpoints are unchanged.

> All UI-only; displays the **forge's** CI status — independent of #218 (konflate *posting* a Check Run). Disjoint code, mergeable in any order.

## Tests
Playwright: check is in `.card-top` (gone from `.card-meta`); review header shows the check by the title and the PR link as an icon in `.rt-meta` (href + tooltip intact, no `#142`, not a title child); the summary grid fills the pane at an ultrawide viewport (≥98% of the pane, no 1280 cap) while keeping the 4 / 2 / 1 track counts. Full suite green (70 passed), typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)