### PR TITLE
feat: paginate the PR list (default 10/page, configurable, deep-linkable)

### DIFF
--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -530,6 +530,76 @@ a.repo:focus-visible .repo-ext {
   flex-direction: column;
   gap: 8px;
 }
+/* Pager below the cards: the count readout, the per-page size picker, and (when
+   there's more than one page) prev/next. Shares the cards' 960px column and the
+   toolbar's muted, borderless-control aesthetic. */
+.pager {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  max-width: 960px;
+  margin: 0 auto 12px;
+  padding: 0 12px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.pager-count,
+.pager-page {
+  font-variant-numeric: tabular-nums; /* digits don't reflow as the page changes */
+}
+.page-size {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.page-size select {
+  border: none;
+  background: none;
+  color: var(--muted);
+  font: inherit;
+  font-size: 12px;
+  padding: 4px 0;
+  cursor: pointer;
+}
+.page-size select:hover {
+  color: var(--text);
+}
+.page-size select:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+/* prev/next + the page indicator, pushed to the right edge of the column. */
+.pager-nav {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.pager-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  color: var(--muted);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 6px;
+}
+.pager-btn:hover:not(:disabled) {
+  color: var(--text);
+  background: var(--panel-alt);
+}
+.pager-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.pager-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
 /* A card is a shell (the bordered, tinted box) wrapping the clickable content
    button and a disclosure chevron. A <button> can't nest in a <button>, so the
    two sit side by side inside the shell. */

--- a/internal/web/src/lib/List.svelte
+++ b/internal/web/src/lib/List.svelte
@@ -11,7 +11,7 @@
     type StatusFilter,
   } from './store.svelte';
   import { router, navigate, replace } from './router.svelte';
-  import { paging, setPageSize, PAGE_SIZES, type PageSize } from './paging.svelte';
+  import { paging, setPageSize, parsePageSize, PAGE_SIZES, DEFAULT_PAGE_SIZE, type PageSize } from './paging.svelte';
   import { clock, timeAgo, absolute } from './time.svelte';
   import { slide } from 'svelte/transition';
   import Icon from './Icon.svelte';
@@ -76,9 +76,9 @@
   // The 1-based [from, to] of the visible window, for the "A–B of N" readout.
   const from = $derived(shown.length === 0 ? 0 : size === 'all' ? 1 : (page - 1) * size + 1);
   const to = $derived(size === 'all' ? shown.length : Math.min(page * size, shown.length));
-  // The pager only earns its space once there's more than the smallest page holds;
+  // The pager only earns its space once the list outgrows the smallest page size;
   // below that every size shows the same rows, so the controls would be inert.
-  const paginated = $derived(shown.length > 10);
+  const paginated = $derived(shown.length > DEFAULT_PAGE_SIZE);
 
   // Keep the page in range as the set shrinks under it — a live update dropping
   // rows, or a deep link past the end — instead of stranding the user on a blank
@@ -104,9 +104,6 @@
     setPageSize(s);
     resetPage();
   }
-  // Map the size <select>'s string value back to a PageSize via the known set, so
-  // no cast is needed and a stray value falls back to the default.
-  const parseSize = (v: string): PageSize => PAGE_SIZES.find((s) => String(s) === v) ?? 10;
 
   // At-a-glance health, shown above the list — each pill is also a toggle that
   // filters the list to that status. merged and hidden are pill-only (kept out
@@ -248,7 +245,7 @@
       <span>per page</span>
       <select
         value={String(size)}
-        onchange={(e) => changePageSize(parseSize(e.currentTarget.value))}
+        onchange={(e) => changePageSize(parsePageSize(e.currentTarget.value))}
         aria-label="Pull requests per page"
       >
         {#each PAGE_SIZES as s}

--- a/internal/web/src/lib/List.svelte
+++ b/internal/web/src/lib/List.svelte
@@ -10,6 +10,8 @@
     ensurePreview,
     type StatusFilter,
   } from './store.svelte';
+  import { router, navigate, replace } from './router.svelte';
+  import { paging, setPageSize, PAGE_SIZES, type PageSize } from './paging.svelte';
   import { clock, timeAgo, absolute } from './time.svelte';
   import { slide } from 'svelte/transition';
   import Icon from './Icon.svelte';
@@ -36,6 +38,8 @@
     mdiSortDescending,
     mdiChevronDown,
     mdiChevronUp,
+    mdiChevronLeft,
+    mdiChevronRight,
     mdiCheckCircleOutline,
     mdiTrayFull,
     mdiUnfoldMoreHorizontal,
@@ -59,6 +63,51 @@
   const openPrs = $derived(prs.filter((p) => p.open && !p.hidden));
   const filterActive = $derived(store.query.trim() !== '' || store.statusFilter !== '');
 
+  // ---- pagination ---------------------------------------------------------
+  // Page size is a persisted display preference (paging.size); the page number is
+  // deep-linked in the URL (router '#/page/N'). Both apply to `shown` — the
+  // already-filtered, pill-narrowed, sorted set — so the pager's "of N" always
+  // equals the active pill's count, and a pill / sort / size change resets to page
+  // 1 (resetPage), while a live data update only clamps (the $effect below).
+  const size = $derived(paging.size);
+  const page = $derived(router.route.name === 'list' ? (router.route.page ?? 1) : 1);
+  const totalPages = $derived(size === 'all' ? 1 : Math.max(1, Math.ceil(shown.length / size)));
+  const paged = $derived(size === 'all' ? shown : shown.slice((page - 1) * size, page * size));
+  // The 1-based [from, to] of the visible window, for the "A–B of N" readout.
+  const from = $derived(shown.length === 0 ? 0 : size === 'all' ? 1 : (page - 1) * size + 1);
+  const to = $derived(size === 'all' ? shown.length : Math.min(page * size, shown.length));
+  // The pager only earns its space once there's more than the smallest page holds;
+  // below that every size shows the same rows, so the controls would be inert.
+  const paginated = $derived(shown.length > 10);
+
+  // Keep the page in range as the set shrinks under it — a live update dropping
+  // rows, or a deep link past the end — instead of stranding the user on a blank
+  // page. replace(), so the correction leaves no history entry. Guarded on
+  // `loaded`: before the first list fetch resolves, shown is empty and totalPages
+  // is 1, which would otherwise clobber a deep-linked #/page/N before its data
+  // even arrives.
+  $effect(() => {
+    if (store.loaded && page > totalPages) replace({ name: 'list', page: totalPages });
+  });
+
+  // gotoPage moves to a page (a history entry, so Back walks pages) and returns to
+  // the top of the list. resetPage drops to page 1 with no history entry — for
+  // filter / sort / size changes, where the prior page no longer means anything.
+  function gotoPage(p: number): void {
+    navigate({ name: 'list', page: p });
+    screenEl?.scrollTo({ top: 0 });
+  }
+  function resetPage(): void {
+    if (page !== 1) replace({ name: 'list', page: 1 });
+  }
+  function changePageSize(s: PageSize): void {
+    setPageSize(s);
+    resetPage();
+  }
+  // Map the size <select>'s string value back to a PageSize via the known set, so
+  // no cast is needed and a stray value falls back to the default.
+  const parseSize = (v: string): PageSize => PAGE_SIZES.find((s) => String(s) === v) ?? 10;
+
   // At-a-glance health, shown above the list — each pill is also a toggle that
   // filters the list to that status. merged and hidden are pill-only (kept out
   // of the default open view); hidden = excluded by the PR filter, not rendered.
@@ -71,6 +120,7 @@
 
   function toggleFilter(f: StatusFilter): void {
     store.statusFilter = store.statusFilter === f ? '' : f;
+    resetPage(); // a different subset — restart it at page 1
   }
   // A pill renders while it counts something — or while it's the active
   // filter, so it can't strand itself unclickable when its count hits zero.
@@ -80,9 +130,11 @@
   // name A→Z); the direction button then flips it.
   function onSortKeyChange(): void {
     store.sortDir = store.sort === 'name' ? 'asc' : 'desc';
+    resetPage();
   }
   function toggleSortDir(): void {
     store.sortDir = store.sortDir === 'asc' ? 'desc' : 'asc';
+    resetPage();
   }
   const sortDirLabel = $derived.by(() => {
     if (store.sort === 'name') return store.sortDir === 'asc' ? 'A → Z' : 'Z → A';
@@ -120,8 +172,10 @@
     return !!p && p.state !== 'loading';
   };
 
-  // The visible rows that have a summary to toggle. Drives the expand/collapse-all control.
-  const expandableRows = $derived(shown.filter((p) => p.signals));
+  // The visible rows that have a summary to toggle. Drives the expand/collapse-all
+  // control — scoped to the current page, so "expand all" expands what's on screen
+  // and never lazy-loads previews for rows sitting on other pages.
+  const expandableRows = $derived(paged.filter((p) => p.signals));
   const allExpanded = $derived(expandableRows.length > 0 && expandableRows.every((p) => expanded[p.number]));
   function toggleExpandAll(): void {
     const next = !allExpanded;
@@ -175,6 +229,57 @@
     <Icon path={mdiCheckCircleOutline} size={36} />
     <p>All caught up — no open pull requests.</p>
   </div>
+{/snippet}
+
+<!-- The pager sits below the cards once the list outgrows the smallest page. Its
+     "of N" counts the active view (the same set the active pill counts), the size
+     picker is the persisted per-page preference, and prev/next appear only when
+     there's more than one page. -->
+{#snippet pager()}
+  <nav class="pager" aria-label="Pull request pages">
+    <span class="pager-count">
+      {#if size === 'all'}
+        {shown.length} pull {shown.length === 1 ? 'request' : 'requests'}
+      {:else}
+        {from}–{to} of {shown.length}
+      {/if}
+    </span>
+    <label class="page-size">
+      <span>per page</span>
+      <select
+        value={String(size)}
+        onchange={(e) => changePageSize(parseSize(e.currentTarget.value))}
+        aria-label="Pull requests per page"
+      >
+        {#each PAGE_SIZES as s}
+          <option value={String(s)}>{s === 'all' ? 'All' : s}</option>
+        {/each}
+      </select>
+    </label>
+    {#if totalPages > 1}
+      <div class="pager-nav">
+        <button
+          class="pager-btn"
+          onclick={() => gotoPage(page - 1)}
+          disabled={page <= 1}
+          aria-label="Previous page"
+          title="Previous page"
+        >
+          <Icon path={mdiChevronLeft} size={18} />
+        </button>
+        <span class="pager-page">Page {page} of {totalPages}</span>
+        <button
+          class="pager-btn"
+          onclick={() => gotoPage(page + 1)}
+          disabled={page >= totalPages}
+          aria-label="Next page"
+          title="Next page"
+        >
+          <Icon path={mdiChevronRight} size={18} />
+        </button>
+      </div>
+    {/if}
+  </nav>
 {/snippet}
 
 <!-- The inline row summary, lazy-loaded into store.previews. Read-only — the row
@@ -367,10 +472,18 @@
         class="pr-search"
         placeholder="Filter pull requests… (try status:caution or author:renovate)"
         bind:value={store.query}
+        oninput={resetPage}
         aria-label="Filter pull requests"
       />
       {#if store.query}
-        <button class="clear-btn" onclick={() => (store.query = '')} aria-label="Clear filter">
+        <button
+          class="clear-btn"
+          onclick={() => {
+            store.query = '';
+            resetPage();
+          }}
+          aria-label="Clear filter"
+        >
           <Icon path={mdiClose} size={13} />
         </button>
       {/if}
@@ -427,8 +540,9 @@
     {/if}
   {:else}
     <ul class="cards">
-      {#each shown as pr (pr.number)}{@render prCard(pr)}{/each}
+      {#each paged as pr (pr.number)}{@render prCard(pr)}{/each}
     </ul>
+    {#if paginated}{@render pager()}{/if}
   {/if}
 
   <Footer />

--- a/internal/web/src/lib/paging.svelte.ts
+++ b/internal/web/src/lib/paging.svelte.ts
@@ -5,20 +5,29 @@
 
 export type PageSize = 10 | 20 | 50 | 'all';
 
+// The default, and the smallest, page size: the list's pager appears once a list
+// outgrows it, and any unknown stored/selected value falls back to it. Typed as
+// the literal (via satisfies) so it stays usable in numeric comparisons.
+export const DEFAULT_PAGE_SIZE = 10 satisfies PageSize;
+
 // Offered in the size picker, smallest first; 'all' is the escape hatch back to
 // the un-paginated list (so Ctrl-F still finds every row).
-export const PAGE_SIZES: readonly PageSize[] = [10, 20, 50, 'all'];
+export const PAGE_SIZES: readonly PageSize[] = [DEFAULT_PAGE_SIZE, 20, 50, 'all'];
 
 const KEY = 'konflate-pagesize';
+
+// parsePageSize resolves a stored or <select>-supplied string to a known PageSize,
+// falling back to the default — the single home for "string → PageSize", shared by
+// the persisted load and the size picker.
+export function parsePageSize(v: string | null): PageSize {
+  return PAGE_SIZES.find((s) => String(s) === v) ?? DEFAULT_PAGE_SIZE;
+}
 
 // Guarded so importing this module never throws outside a browser (tests, a
 // future SSR build); there it falls back to the default until the UI runs.
 function load(): PageSize {
-  if (typeof localStorage === 'undefined') return 10;
-  const v = localStorage.getItem(KEY);
-  if (v === 'all') return 'all';
-  const n = Number(v);
-  return n === 10 || n === 20 || n === 50 ? n : 10;
+  if (typeof localStorage === 'undefined') return DEFAULT_PAGE_SIZE;
+  return parsePageSize(localStorage.getItem(KEY));
 }
 
 export const paging = $state<{ size: PageSize }>({ size: load() });

--- a/internal/web/src/lib/paging.svelte.ts
+++ b/internal/web/src/lib/paging.svelte.ts
@@ -1,0 +1,29 @@
+// PR-list page size: how many rows the list shows per page. A personal display
+// preference (not a shareable view coordinate, so it lives in localStorage rather
+// than the URL — the page *number* is the deep-linkable part, in the router). The
+// page number itself resets on a size change, since the windowing changes.
+
+export type PageSize = 10 | 20 | 50 | 'all';
+
+// Offered in the size picker, smallest first; 'all' is the escape hatch back to
+// the un-paginated list (so Ctrl-F still finds every row).
+export const PAGE_SIZES: readonly PageSize[] = [10, 20, 50, 'all'];
+
+const KEY = 'konflate-pagesize';
+
+// Guarded so importing this module never throws outside a browser (tests, a
+// future SSR build); there it falls back to the default until the UI runs.
+function load(): PageSize {
+  if (typeof localStorage === 'undefined') return 10;
+  const v = localStorage.getItem(KEY);
+  if (v === 'all') return 'all';
+  const n = Number(v);
+  return n === 10 || n === 20 || n === 50 ? n : 10;
+}
+
+export const paging = $state<{ size: PageSize }>({ size: load() });
+
+export function setPageSize(size: PageSize): void {
+  paging.size = size;
+  if (typeof localStorage !== 'undefined') localStorage.setItem(KEY, String(size));
+}

--- a/internal/web/src/lib/router.svelte.ts
+++ b/internal/web/src/lib/router.svelte.ts
@@ -1,16 +1,19 @@
 // A tiny hash router so reviews are deep-linkable and survive refresh / browser
 // back. Routes:
-//   #/                       the PR list
+//   #/                       the PR list (page 1)
+//   #/page/2                 the PR list, page 2 (page 1 stays the bare #/)
 //   #/pr/142                 review, default selection (the Summary)
 //   #/pr/142/summary         review, Summary panel (explicit)
 //   #/pr/142/r0              review, resource r0's diff
 //
 // `sel` is the selected tree node: 'summary', a resource id, or null. A bare
 // #/pr/142 (null) renders the Summary — the first tree node — so the default
-// URL stays clean.
+// URL stays clean. `page` is the list's 1-based page; omitted (page 1) keeps the
+// list URL clean too, so a deep link only carries a page once you've paged past
+// the first.
 
 export type Route =
-  | { name: 'list' }
+  | { name: 'list'; page?: number }
   | { name: 'review'; pr: number; sel: string | null };
 
 function parse(hash: string): Route {
@@ -23,11 +26,19 @@ function parse(hash: string): Route {
       return { name: 'review', pr, sel: parts[2] ?? null };
     }
   }
+  // #/page/N deep-links a list page. N≥2 only — page 1 is the canonical bare #/,
+  // so a stray #/page/1 (or a non-integer) normalizes back to it.
+  if (parts[0] === 'page' && parts[1]) {
+    const page = Number(parts[1]);
+    if (Number.isInteger(page) && page > 1) {
+      return { name: 'list', page };
+    }
+  }
   return { name: 'list' };
 }
 
 function toHash(r: Route): string {
-  if (r.name === 'list') return '#/';
+  if (r.name === 'list') return r.page && r.page > 1 ? `#/page/${r.page}` : '#/';
   return r.sel ? `#/pr/${r.pr}/${r.sel}` : `#/pr/${r.pr}`;
 }
 

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
 import { samplePRs, diffEnvelope } from './fixtures';
-import type { Meta } from '../src/lib/types';
+import type { Meta, PRStatus } from '../src/lib/types';
 
 const defaultMeta: Meta = {
   forge: 'github',
@@ -12,9 +12,9 @@ const defaultMeta: Meta = {
 
 // Stub the konflate API (and silence the websocket) so the UI renders
 // deterministically with no backend.
-async function stubApi(page: Page, meta: Meta = defaultMeta) {
+async function stubApi(page: Page, meta: Meta = defaultMeta, prs: PRStatus[] = samplePRs) {
   await page.route('**/api/meta', (route) => route.fulfill({ json: meta }));
-  await page.route('**/api/prs', (route) => route.fulfill({ json: samplePRs }));
+  await page.route('**/api/prs', (route) => route.fulfill({ json: prs }));
   await page.route('**/api/prs/142/diff', (route) => route.fulfill({ json: diffEnvelope }));
   // The row expander hits the lean summary endpoint; the fixture envelope serves
   // both (the UI reads the same headline fields).
@@ -231,6 +231,96 @@ test('filter-excluded PRs are hidden: a pill, a grey dot, out of the default vie
   await hiddenCard.locator('.card').click();
   await expect(page).toHaveURL(/#\/pr\/9$/);
   await expect(page.locator('.review-body')).toContainText('Excluded by the PR filter');
+});
+
+// bulkPRs builds `open` open PRs (highest numbers, newest) plus `merged` merged
+// ones below them — the real fixtures only carry three, under the smallest page
+// size. createdAt increases with the number so created-desc sorts highest first,
+// making the page contents deterministic.
+function bulkPRs({ open, merged = 0 }: { open: number; merged?: number }): PRStatus[] {
+  const total = open + merged;
+  return Array.from({ length: total }, (_, i) => {
+    const number = total - i; // newest (highest) first
+    const isOpen = i < open;
+    return {
+      number,
+      title: `chore(deps): bump dependency ${number}`,
+      author: 'renovate[bot]',
+      state: isOpen ? 'open' : 'closed',
+      open: isOpen,
+      draft: false,
+      headRef: `renovate/dep-${number}`,
+      headSha: `sha${number}`,
+      baseRef: 'main',
+      createdAt: new Date(Date.UTC(2026, 5, 1, 0, number)).toISOString(),
+      closedAt: isOpen ? undefined : new Date(Date.UTC(2026, 5, 2, 0, number)).toISOString(),
+      labels: [],
+      url: `https://github.com/acme/home-ops/pull/${number}`,
+      status: 'ready',
+      updatedAt: '2026-06-04T12:00:00Z',
+    } satisfies PRStatus;
+  });
+}
+
+test('list pagination: default 10 per page, prev/next, and a size picker', async ({ page }) => {
+  await stubApi(page, defaultMeta, bulkPRs({ open: 25 }));
+  await page.goto('/');
+
+  // Default page size is 10 (the lowest), newest first.
+  await expect(page.locator('.card')).toHaveCount(10);
+  await expect(page.locator('.pager-count')).toHaveText('1–10 of 25');
+  await expect(page.locator('.pager-page')).toHaveText('Page 1 of 3');
+  await expect(page.locator('.card-shell[data-pr="25"]')).toBeVisible();
+  await expect(page.locator('.card-shell[data-pr="15"]')).toHaveCount(0); // page 2's top
+
+  // Next → page 2: the URL carries the page, and the window slides.
+  await page.locator('.pager-btn[aria-label="Next page"]').click();
+  await expect(page).toHaveURL(/#\/page\/2$/);
+  await expect(page.locator('.pager-page')).toHaveText('Page 2 of 3');
+  await expect(page.locator('.pager-count')).toHaveText('11–20 of 25');
+  await expect(page.locator('.card-shell[data-pr="15"]')).toBeVisible();
+  await expect(page.locator('.card-shell[data-pr="25"]')).toHaveCount(0);
+
+  // Bumping the size to 50 shows all 25 on one page, drops the prev/next nav, and
+  // resets the URL to the canonical page 1.
+  await page.locator('.page-size select').selectOption('50');
+  await expect(page).toHaveURL(/#\/$/);
+  await expect(page.locator('.card')).toHaveCount(25);
+  await expect(page.locator('.pager-nav')).toHaveCount(0);
+  await expect(page.locator('.pager-count')).toHaveText('1–25 of 25');
+});
+
+test('list pagination: deep-links a page and clamps an out-of-range page', async ({ page }) => {
+  await stubApi(page, defaultMeta, bulkPRs({ open: 25 }));
+
+  await page.goto('/#/page/2');
+  await expect(page.locator('.pager-page')).toHaveText('Page 2 of 3');
+  await expect(page.locator('.card-shell[data-pr="15"]')).toBeVisible();
+
+  // A page past the end clamps to the last page (and rewrites the URL to match).
+  await page.goto('/#/page/99');
+  await expect(page.locator('.pager-page')).toHaveText('Page 3 of 3');
+  await expect(page).toHaveURL(/#\/page\/3$/);
+  await expect(page.locator('.card')).toHaveCount(5); // 25 → pages of 10/10/5
+});
+
+test('list pagination stays coherent with the filter pills', async ({ page }) => {
+  await stubApi(page, defaultMeta, bulkPRs({ open: 22, merged: 13 }));
+  await page.goto('/');
+
+  // Default (open) view: the pager counts the open set — the same total the open
+  // pill shows — not every tracked PR.
+  await expect(page.locator('.sum-pill.merged')).toContainText('13 merged');
+  await expect(page.locator('.pager-count')).toHaveText('1–10 of 22');
+
+  // Page in, then switch to the merged pill: the page resets to 1 and the count
+  // tracks the merged set, so "of N" matches the merged pill's count (cohesion).
+  await page.locator('.pager-btn[aria-label="Next page"]').click();
+  await expect(page.locator('.pager-page')).toHaveText('Page 2 of 3');
+  await page.locator('.sum-pill.merged').click();
+  await expect(page).toHaveURL(/#\/$/); // back to page 1
+  await expect(page.locator('.pager-count')).toHaveText('1–10 of 13');
+  await expect(page.locator('.pager-page')).toHaveText('Page 1 of 2');
 });
 
 test('split diff renders two balanced columns (regression)', async ({ page }) => {
@@ -862,6 +952,9 @@ test('a scroll-to-top button appears after scrolling and returns to the top', as
   await page.route('**/api/prs', (r) => r.fulfill({ json: many }));
   await page.routeWebSocket('**/ws', () => {});
   await page.goto('/');
+  // 24 PRs paginate (default 10); switch to "All" so the whole list renders and
+  // .list-screen overflows enough to exercise the FAB.
+  await page.locator('.page-size select').selectOption('all');
   await expect(page.locator('.card')).toHaveCount(24);
 
   const fab = page.locator('.scroll-top');


### PR DESCRIPTION
## Why

The PR list rendered every filtered pull request at once. On a busy repo (a wave of Renovate PRs) that's a long scroll and a lot of DOM. Page it, default 10 per page, with the page size configurable in the UI.

## What

- **Page size** is a persisted display preference (`paging.svelte.ts` → `localStorage`, key `konflate-pagesize`), **default 10**; the picker offers **10 / 20 / 50 / All**. *All* keeps the un-paginated list, so Ctrl-F still finds every row.
- **The page number is deep-linked in the URL** — `#/page/N` (page 1 stays the bare `#/`, so a link only carries a page once you've paged past the first). Refresh, browser **back/forward**, and shared links land on the right page. prev/next push history entries; a page change returns to the **top** of the list.
- The pager sits below the cards: a `1–10 of N` readout, the size picker, and prev/next + `Page X of Y` (the nav appears only when there's more than one page). It earns its space only once the list outgrows the smallest page (≤10 rows ⇒ no pager).

### Cohesion with the filter pills

Pagination applies to `shown` — the **already-filtered, pill-narrowed, sorted** set — so:
- the pager's **"of N" equals the active pill's count** (the pills still count the whole filtered set, steady while a pill is active);
- changing a **pill / the search / the sort / the size resets to page 1** (a different subset starts at the top);
- a **live update** (a PR opening/merging over the websocket) or a **stale deep link** only *clamps* the page into range — it never yanks you back to page 1;
- **Expand-all** is scoped to the visible page, so it never lazy-loads row previews for PRs sitting on other pages.

### Scope

Frontend-only. The whole list already arrives from `/api/prs` (one gzipped response, in-memory store), and the UI filters/sorts client-side — so this is a render/UX bound, not a data-fetch change. **No Go / API / chart change.** Independent of the MCP `list_pull_requests` paging (that's for agents; this is the browser).

## Files

- `paging.svelte.ts` (new) — the persisted `PageSize` pref (mirrors `theme.svelte.ts`).
- `router.svelte.ts` — `#/page/N` on the list route (page 1 ⇒ `#/`).
- `List.svelte` — page/size derivations, the clamp `$effect`, the pager snippet, reset-to-1 wiring.
- `app.css` — pager styles (toolbar-matching, muted controls).
- `tests/ui.spec.ts` — three new specs (default 10 + prev/next + size picker; deep-link + out-of-range clamp; pill cohesion) and the scroll-to-top test switched to "All" to keep its long list.

## Tests

`ui-typecheck` (0 errors), `ui-test` (73 passed), `ui-build` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
