### PR TITLE
feat: caution on Helm values the bumped chart no longer defines (flate v0.4.6 stale values)

### DIFF
--- a/internal/engine/blast.go
+++ b/internal/engine/blast.go
@@ -170,3 +170,55 @@ func danglingDependsOn(
 	slices.SortFunc(out, func(a, b api.Warning) int { return cmp.Compare(a.Resource, b.Resource) })
 	return out
 }
+
+// staleValues surfaces flate's WarnStaleValues advisories as cautions: a
+// HelmRelease sets top-level values the chart's templates no longer read — a key
+// the chart removed or renamed, whose override now silently does nothing. It diffs
+// head against base so only values *this PR* newly strands are flagged, not a
+// pre-existing dead override (flate renders changed-only, so the advisories are
+// already scoped to the PR's closure). flate v0.4.6+.
+func staleValues(base, head []manifest.Warning) []api.Warning {
+	wasStale := map[manifest.NamedResource]map[string]bool{}
+	for _, w := range base {
+		if w.Category != manifest.WarnStaleValues {
+			continue
+		}
+		keys := wasStale[w.Resource]
+		if keys == nil {
+			keys = map[string]bool{}
+			wasStale[w.Resource] = keys
+		}
+		for _, k := range w.Detail {
+			keys[k] = true
+		}
+	}
+	var out []api.Warning
+	for _, w := range head {
+		if w.Category != manifest.WarnStaleValues {
+			continue
+		}
+		fresh := make([]string, 0, len(w.Detail))
+		for _, k := range w.Detail {
+			if !wasStale[w.Resource][k] {
+				fresh = append(fresh, k)
+			}
+		}
+		if len(fresh) == 0 {
+			continue // every stale key here was already stale at the base — not this PR's doing
+		}
+		slices.Sort(fresh)
+		noun := "values"
+		if len(fresh) == 1 {
+			noun = "a value"
+		}
+		out = append(out, api.Warning{
+			Level:    api.LevelCaution,
+			Rule:     "stale-helm-values",
+			Resource: parentLabel(w.Resource),
+			Detail: fmt.Sprintf("sets %s the chart no longer defines (%s) — the override has no effect",
+				noun, strings.Join(fresh, ", ")),
+		})
+	}
+	slices.SortFunc(out, func(a, b api.Warning) int { return cmp.Compare(a.Resource, b.Resource) })
+	return out
+}

--- a/internal/engine/blast_test.go
+++ b/internal/engine/blast_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 
+	"github.com/home-operations/konflate/internal/api"
 	"github.com/home-operations/konflate/internal/diff"
 )
 
@@ -114,5 +115,48 @@ func TestDanglingDependsOn_Quiet(t *testing.T) {
 	)
 	if never != nil {
 		t.Errorf("never-rendered target must not warn: %+v", never)
+	}
+}
+
+func TestStaleValues(t *testing.T) {
+	hr := func(n string) manifest.NamedResource {
+		return manifest.NamedResource{Kind: "HelmRelease", Namespace: "apps", Name: n}
+	}
+	stale := func(nr manifest.NamedResource, keys ...string) manifest.Warning {
+		return manifest.Warning{Category: manifest.WarnStaleValues, Resource: nr, Detail: keys}
+	}
+
+	// Newly stale: head strands two keys the base render didn't.
+	got := staleValues(nil, []manifest.Warning{stale(hr("plex"), "ingress.enabled", "foo")})
+	if len(got) != 1 {
+		t.Fatalf("warnings = %d, want 1: %+v", len(got), got)
+	}
+	if w := got[0]; w.Level != api.LevelCaution || w.Rule != "stale-helm-values" || w.Resource != parentLabel(hr("plex")) {
+		t.Errorf("warning = %+v, want a stale-helm-values caution on plex", w)
+	}
+	if !strings.Contains(got[0].Detail, "ingress.enabled") || !strings.Contains(got[0].Detail, "foo") {
+		t.Errorf("detail must list both stranded keys: %q", got[0].Detail)
+	}
+
+	// Only the newly-stranded key is flagged; one already stale at the base is not.
+	got = staleValues(
+		[]manifest.Warning{stale(hr("plex"), "old")},
+		[]manifest.Warning{stale(hr("plex"), "old", "new")},
+	)
+	if len(got) != 1 || !strings.Contains(got[0].Detail, "new") || strings.Contains(got[0].Detail, "old") {
+		t.Errorf("want only the newly-stale key 'new', not pre-existing 'old': %+v", got)
+	}
+
+	// Staleness present on both sides → pre-existing, not this PR's doing → no caution.
+	if got := staleValues(
+		[]manifest.Warning{stale(hr("plex"), "old")},
+		[]manifest.Warning{stale(hr("plex"), "old")},
+	); got != nil {
+		t.Errorf("pre-existing staleness must not warn: %+v", got)
+	}
+
+	// Other flate warning categories are ignored.
+	if got := staleValues(nil, []manifest.Warning{{Category: "EmptyScan", Resource: hr("plex")}}); got != nil {
+		t.Errorf("non-StaleValues categories must be ignored: %+v", got)
 	}
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -189,6 +189,9 @@ func (e *flateEngine) Diff(ctx context.Context, pr api.PR) (api.DiffResult, erro
 	result.BlastRadius = blastRadius(seeds, head.Result.DependsOn)
 	result.Warnings = append(result.Warnings, danglingDependsOn(
 		parentSet(base.Result.Manifests), parentSet(head.Result.Manifests), head.Result.DependsOn)...)
+	// Surface HelmReleases whose values the bumped chart no longer defines (flate's
+	// WarnStaleValues), newly stranded by this PR — see staleValues.
+	result.Warnings = append(result.Warnings, staleValues(base.Result.Warnings, head.Result.Warnings)...)
 	return result, nil
 }
 


### PR DESCRIPTION
## Why

flate **v0.4.6** added a `WarnStaleValues` advisory: a `HelmRelease` sets top-level values the chart's templates no longer read — a key the chart **removed or renamed** in the bump, whose override now **silently does nothing**. Classic chart-bump footgun (you set `ingress.enabled`, the chart renamed it to `ingress.main.enabled`, and your override is dead and unnoticed). Surface it as a konflate **caution**.

## What

The engine appends a `stale-helm-values` caution for each HelmRelease whose values went stale, right next to the existing `danglingDependsOn` caution — both derive from facts only the engine's two flate `Result`s hold. It rides the existing signal / summary-pane / MCP plumbing, so it shows as a caution in the UI and the PR summary with **no UI change**.

`staleValues()` **diffs base vs head** so only values *this PR* newly strands are flagged — a key already stale at the merge-base is a pre-existing dead override, not this PR's doing. (flate renders changed-only, so the advisories are already scoped to the PR's closure to begin with.)

## How

- `staleValues(base, head []manifest.Warning) []api.Warning` in `blast.go`: filter `manifest.WarnStaleValues`, subtract the keys already stale at base, emit one caution per HelmRelease listing the newly-stranded dotted key paths.
- Wired into `engine.Diff` after `danglingDependsOn`.

## Tests

`TestStaleValues` — newly-stranded keys are flagged; a partially-pre-existing set flags only the new key; entirely pre-existing staleness is silent; non-`StaleValues` categories are ignored.

Local: `go test ./...`, `lint` (0 issues), `vet`, `fmt-check`, `tidy-check` all green. Go-only; automatic (no config gate, matching the other cautions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
