### PR TITLE
refactor(engine): single-source caution sort-by-resource

### DIFF
--- a/internal/engine/blast.go
+++ b/internal/engine/blast.go
@@ -125,6 +125,12 @@ func blastRadius(
 	return out
 }
 
+// sortByResource orders cautions by their "Kind ns/name" resource label so a
+// render's warnings are deterministic regardless of map iteration order.
+func sortByResource(w []api.Warning) {
+	slices.SortFunc(w, func(a, b api.Warning) int { return cmp.Compare(a.Resource, b.Resource) })
+}
+
 // danglingDependsOn flags parents the PR REMOVES (a key in the base render's
 // parent set, absent from the head's) that surviving resources still declare a
 // spec.dependsOn on — a reconciliation those dependents will wedge on after
@@ -167,7 +173,7 @@ func danglingDependsOn(
 				strings.Join(labels, ", ")),
 		})
 	}
-	slices.SortFunc(out, func(a, b api.Warning) int { return cmp.Compare(a.Resource, b.Resource) })
+	sortByResource(out)
 	return out
 }
 
@@ -219,6 +225,6 @@ func staleValues(base, head []manifest.Warning) []api.Warning {
 				noun, strings.Join(fresh, ", ")),
 		})
 	}
-	slices.SortFunc(out, func(a, b api.Warning) int { return cmp.Compare(a.Resource, b.Resource) })
+	sortByResource(out)
 	return out
 }


### PR DESCRIPTION
## Why

The combined "typical checks" review of the last four merged PRs (#226 flate bump, #228 syntax highlighting, #229 egress guard, #230 stale-values caution) surfaced exactly one nit: `danglingDependsOn` and `staleValues` in `internal/engine/blast.go` each ended with the **identical** tail —

```go
slices.SortFunc(out, func(a, b api.Warning) int { return cmp.Compare(a.Resource, b.Resource) })
```

Both builders return `[]api.Warning` assembled from a Go map, so the sort is what makes a render's cautions deterministic. Two copies of that contract is two places to forget it: the next caution builder that ranges a map and forgets to sort ships non-deterministic output.

## What

Extract a one-line `sortByResource(w []api.Warning)` helper and call it from both sites. No behavior change — same comparator, same order. New caution builders get the deterministic-ordering contract for free.

## Tests

No new tests — pure extraction, covered by the existing `TestDanglingDependsOn` / `TestStaleValues` (which assert resource-sorted output).

Local: `go build ./...`, `go test ./internal/engine/`, `lint` (0 issues), `vet`, `fmt-check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
