### PR TITLE
fix(ui): centre the sync banner and name the repo in the document title

### DIFF
--- a/internal/web/src/App.svelte
+++ b/internal/web/src/App.svelte
@@ -37,6 +37,13 @@
     if (router.route.name === 'review') ensureDiff(router.route.pr);
   });
 
+  // Carry the reviewed repo in the browser tab, e.g. "Konflate -
+  // JJGadgets/Biohazard", so a pinned tab / bookmark names the cluster it
+  // tracks. Falls back to the bare wordmark until meta loads.
+  $effect(() => {
+    document.title = store.meta ? `Konflate - ${store.meta.repo}` : 'konflate';
+  });
+
   const themeIconPath = $derived(
     theme.pref === 'auto' ? mdiThemeLightDark : theme.pref === 'dark' ? mdiWeatherNight : mdiWhiteBalanceSunny,
   );

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -109,6 +109,7 @@ body {
 .sync-banner {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 8px;
   flex: 0 0 auto;
   padding: 8px 14px;
@@ -120,6 +121,7 @@ body {
 }
 .sync-banner-text {
   color: var(--text);
+  text-align: center;
 }
 .sync-banner-text strong {
   color: var(--caution);

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -45,6 +45,7 @@ test('list → review → single-page flow', async ({ page }) => {
   // Topbar shows the forge logo + repo (linked to its forge page) and the
   // auto-update indicator — there is no manual refresh button.
   await expect(page.locator('.repo')).toContainText('acme/home-ops');
+  await expect(page).toHaveTitle('Konflate - acme/home-ops'); // repo rides in the browser tab
   await expect(page.locator('.repo svg[role="img"]')).toBeVisible();
   await expect(page.locator('a.repo')).toHaveAttribute('href', 'https://github.com/acme/home-ops');
   await expect(page.locator('a.repo')).toHaveAttribute('target', '_blank');

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -1256,6 +1256,7 @@ test('a rate-limited forge poll shows a banner with a reset countdown, not a bar
 
   const banner = page.locator('.sync-banner');
   await expect(banner).toBeVisible();
+  await expect(banner).toHaveCSS('justify-content', 'center'); // content is centred, not left-hugged
   await expect(banner).toContainText('GitHub API rate limit exceeded.');
   await expect(banner).toContainText(/Resets in ~\d+ minutes?\./);
   await expect(banner).toContainText('Configure a forge token or GitHub App');


### PR DESCRIPTION
Two small topbar/UI polish items.

## 1 — Centre the sync banner content

The sync banner ("Couldn't list pull requests — …") rendered its icon and text hard against the left edge, leaving a lopsided empty gap on the right. It reads better centred.

- `.sync-banner` gains `justify-content: center` so the icon + message group sits in the middle of the full-width bar.
- `.sync-banner-text` gains `text-align: center` so the message stays balanced when it wraps onto multiple lines on a narrow viewport.

Pure CSS — no markup, copy, or behaviour change.

## 2 — Name the reviewed repo in the document title

The browser tab read a bare `konflate` for every cluster. It now reads `Konflate - <owner>/<repo>` (e.g. `Konflate - JJGadgets/Biohazard`) once `meta` loads, so a pinned tab or bookmark names the cluster it tracks.

- A reactive `$effect` in `App.svelte` sets `document.title` from `store.meta.repo` (the same value the topbar repo chip shows), falling back to the bare wordmark until meta loads.

## Tests

- Rate-limited-banner test gains `toHaveCSS('justify-content', 'center')` so the centring can't silently regress.
- Topbar test gains `toHaveTitle('Konflate - acme/home-ops')`.

Local: `ui-typecheck` (0 errors), `ui-test` (73 passed, 1 skipped), `ui-build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
