### PR TITLE
feat(server): keep the anonymous forge poll under its rate budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,13 @@ auth — it authenticates both the API calls and the renderer's `git` clone/fetc
 raising the API rate limit and unlocking private repositories. It gates no
 behaviour: konflate works the same with or without it.
 
+Without it, an unauthenticated GitHub instance shares the low anonymous rate
+limit (60 req/hour). konflate protects the PR list first: when the remaining
+budget runs low it defers the per-PR CI-status pass — the list stays current and
+the red/amber/green pills keep their last value — rather than exhausting the
+limit and failing the list outright. A token raises the limit so the pills stay
+fresh too.
+
 On GitHub, configuring a **GitHub App** (`KONFLATE_APP_CLIENT_ID` +
 `KONFLATE_APP_PRIVATE_KEY`) authenticates reads too — its installation token is
 konflate's forge identity for the API, the renderer's `git` clone/fetch, and
@@ -539,6 +546,7 @@ Served on the separate operational port (keep it off your public ingress):
 | `konflate_forge_list_errors_total`                  | counter   | Failed PR-list polls, by `reason` (`rate_limited`/`error`). |
 | `konflate_forge_rate_limited`                       | gauge     | `1` when the last PR-list poll hit a rate limit, else `0`.  |
 | `konflate_forge_rate_limit_reset_timestamp_seconds` | gauge     | Unix time the rate limit resets (`0` when not limited).     |
+| `konflate_forge_checks_skipped_total`               | counter   | CI-checks passes skipped to preserve the forge rate budget. |
 
 Plus the standard Go runtime and process collectors.
 

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/google/go-github/v88/github"
@@ -38,6 +39,10 @@ func RateLimit(err error) (resetAt time.Time, ok bool) {
 type githubProvider struct {
 	client      *github.Client
 	owner, repo string
+
+	mu       sync.Mutex
+	rate     github.Rate // budget from the most recent response (see noteRate/RateBudget)
+	rateSeen bool
 }
 
 func newGitHub(cfg *config.Config) (*githubProvider, error) {
@@ -47,6 +52,32 @@ func newGitHub(cfg *config.Config) (*githubProvider, error) {
 	}
 	owner, repo := ownerRepo(cfg.Forge.RepoPath)
 	return &githubProvider{client: client, owner: owner, repo: repo}, nil
+}
+
+// noteRate records the forge rate budget reported on a response, so RateBudget
+// can answer "how many requests are left?" without spending one. go-github puts
+// the X-RateLimit headers on every response (including a 403 rate-limit reply,
+// where Remaining is 0); the latest wins. Safe for the concurrent callers — the
+// periodic poll and the webhook handlers.
+func (p *githubProvider) noteRate(resp *github.Response) {
+	if resp == nil {
+		return
+	}
+	p.mu.Lock()
+	p.rate = resp.Rate
+	p.rateSeen = true
+	p.mu.Unlock()
+}
+
+// RateBudget implements [RateBudgeter]: the requests remaining before the rate
+// limit as of the last call, and whether any response has been observed yet.
+func (p *githubProvider) RateBudget() (remaining int, ok bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.rateSeen {
+		return 0, false
+	}
+	return p.rate.Remaining, true
 }
 
 // newGitHubReadClient builds the read API client by credential precedence,
@@ -92,6 +123,7 @@ func (p *githubProvider) ListPRs(ctx context.Context) ([]api.PR, error) {
 	var out []api.PR
 	for {
 		prs, resp, err := p.client.PullRequests.List(ctx, p.owner, p.repo, opts)
+		p.noteRate(resp)
 		if err != nil {
 			return nil, fmt.Errorf("github: list PRs: %w", err)
 		}
@@ -108,6 +140,7 @@ func (p *githubProvider) ListPRs(ctx context.Context) ([]api.PR, error) {
 
 func (p *githubProvider) GetPR(ctx context.Context, number int) (api.PR, error) {
 	pr, resp, err := p.client.PullRequests.Get(ctx, p.owner, p.repo, number)
+	p.noteRate(resp)
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return api.PR{}, fmt.Errorf("github: get PR #%d: %w", number, ErrPRNotFound)
@@ -127,7 +160,8 @@ func (p *githubProvider) Checks(ctx context.Context, pr api.PR) (api.CheckRollup
 	}
 	var passed, failed, pending int
 
-	cs, _, err := p.client.Repositories.GetCombinedStatus(ctx, p.owner, p.repo, pr.HeadSHA, &github.ListOptions{PerPage: 100})
+	cs, resp, err := p.client.Repositories.GetCombinedStatus(ctx, p.owner, p.repo, pr.HeadSHA, &github.ListOptions{PerPage: 100})
+	p.noteRate(resp)
 	if err != nil {
 		return api.CheckRollup{}, fmt.Errorf("github: combined status #%d: %w", pr.Number, err)
 	}
@@ -142,8 +176,9 @@ func (p *githubProvider) Checks(ctx context.Context, pr api.PR) (api.CheckRollup
 		}
 	}
 
-	runs, _, err := p.client.Checks.ListCheckRunsForRef(ctx, p.owner, p.repo, pr.HeadSHA,
+	runs, resp, err := p.client.Checks.ListCheckRunsForRef(ctx, p.owner, p.repo, pr.HeadSHA,
 		&github.ListCheckRunsOptions{ListOptions: github.ListOptions{PerPage: 100}})
+	p.noteRate(resp)
 	if err != nil {
 		return api.CheckRollup{}, fmt.Errorf("github: check runs #%d: %w", pr.Number, err)
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -39,6 +39,19 @@ type Provider interface {
 	Checks(ctx context.Context, pr api.PR) (api.CheckRollup, error)
 }
 
+// RateBudgeter is an optional Provider capability: it reports the forge request
+// budget observed on the most recent call. The poll uses it to skip the costly
+// per-PR checks pass before that pass would exhaust the budget and start failing
+// the cheaper, more important PR list. Only the GitHub provider implements it —
+// GitHub's 60 req/hour unauthenticated ceiling is where this bites; GitLab and
+// Forgejo don't, so the guard is simply inert there (and, once authenticated,
+// the budget is large enough that it never fires).
+type RateBudgeter interface {
+	// RateBudget returns the requests remaining before the forge rate limit and
+	// whether any budget has been observed yet — false before the first call.
+	RateBudget() (remaining int, ok bool)
+}
+
 // New builds the provider for the configured forge.
 func New(cfg *config.Config) (Provider, error) {
 	switch cfg.Forge.Kind {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -525,6 +525,10 @@ func (s *Server) authorizedPush(r *http.Request) bool {
 // have left the open set. Runs at startup and once per RefreshInterval; a
 // verified webhook also calls it when the open-PR set may have changed.
 func (s *Server) refreshList(ctx context.Context) {
+	if reset, blocked := s.rateLimitedUntil(); blocked {
+		s.log.Debug("refresh: skipping list while rate-limited", "until", reset)
+		return
+	}
 	prs, err := s.prov.ListPRs(ctx)
 	s.noteSyncResult(err) // record forge-polling health (raises/clears the UI banner + metrics)
 	if err != nil {
@@ -579,6 +583,11 @@ func (s *Server) refreshList(ctx context.Context) {
 // the refresh — a forge that rate-limits the checks endpoint must not stop PRs
 // from listing.
 func (s *Server) refreshChecks(ctx context.Context, prs []api.PR) {
+	if s.checksWouldExhaustBudget(len(prs)) {
+		s.log.Info("refresh: skipping checks pass to preserve forge rate budget", "prs", len(prs))
+		s.metrics.checksSkipped.Inc()
+		return
+	}
 	for _, pr := range prs {
 		rollup, err := s.prov.Checks(ctx, pr)
 		if err != nil {
@@ -598,6 +607,9 @@ func (s *Server) refreshChecks(ctx context.Context, prs []api.PR) {
 // don't track) is a no-op — deliberately no relist, so a chatty CI can't trigger
 // a forge re-list per delivered event.
 func (s *Server) refreshChecksForSHA(ctx context.Context, sha string) {
+	if _, blocked := s.rateLimitedUntil(); blocked {
+		return // in a rate-limit cooldown — a chatty CI must not draw more 403s
+	}
 	pr, ok := s.store.prByHeadSHA(sha)
 	if !ok {
 		return
@@ -611,6 +623,53 @@ func (s *Server) refreshChecksForSHA(ctx context.Context, sha string) {
 		r := rollup
 		s.hub.broadcast(api.Event{Type: "checks", Number: pr.Number, Checks: &r})
 	}
+}
+
+// rateLimitedUntil reports whether the last forge poll hit a rate limit that has
+// not yet reset, and when it resets. While it holds, the poll skips the forge
+// entirely: a periodic tick or a webhook-triggered relist during the cooldown can
+// only draw more 403s and can't succeed before the reset. A rate limit with no
+// known reset time (RetryAt == 0) does not block, so konflate never wedges
+// forever on a forge that didn't say when the limit clears.
+func (s *Server) rateLimitedUntil() (reset time.Time, blocked bool) {
+	st := s.sync.status()
+	if st.OK || st.Reason != api.SyncRateLimited || st.RetryAt == 0 {
+		return time.Time{}, false
+	}
+	reset = time.Unix(st.RetryAt, 0)
+	if !s.store.now().Before(reset) {
+		return time.Time{}, false // already past the reset — let the next poll try
+	}
+	return reset, true
+}
+
+// checksReserve is the request headroom checksWouldExhaustBudget keeps unspent:
+// enough for the next poll's PR list and a few closed-PR reconciliations, so a
+// full checks pass never consumes the budget the cheaper, more important list
+// depends on.
+const checksReserve = 10
+
+// checksWouldExhaustBudget reports whether fetching every PR's CI rollup — two
+// forge calls each — would draw the remaining request budget below checksReserve.
+// It fires only when the provider can report a budget (GitHub) and that budget is
+// known; otherwise it returns false and the checks pass runs unchanged. This is
+// what lets an unauthenticated GitHub poll keep listing PRs rather than spend its
+// whole 60/hour allowance on check rollups: the list stays fresh and each PR's CI
+// pill simply keeps its last value until the budget recovers.
+func (s *Server) checksWouldExhaustBudget(n int) bool {
+	if n <= 0 {
+		return false
+	}
+	rb, ok := s.prov.(provider.RateBudgeter)
+	if !ok {
+		return false
+	}
+	remaining, known := rb.RateBudget()
+	if !known {
+		return false
+	}
+	const callsPerPR = 2 // GetCombinedStatus + ListCheckRunsForRef
+	return remaining < n*callsPerPR+checksReserve
 }
 
 // reconcileClosed handles PRs that have left the forge's open set. Each is

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -24,6 +24,10 @@ type metrics struct {
 	listErrors     *prometheus.CounterVec // reason: rate_limited|error
 	rateLimited    prometheus.Gauge
 	rateLimitReset prometheus.Gauge
+	// checksSkipped counts CI-checks passes skipped to stay within the forge rate
+	// budget (see checksWouldExhaustBudget). A rising count on an unauthenticated
+	// instance is the signal that a token would let the CI pills stay current.
+	checksSkipped prometheus.Counter
 }
 
 // metricNamespace prefixes every konflate metric name.
@@ -66,12 +70,16 @@ func newMetrics() *metrics {
 			Namespace: metricNamespace, Name: "forge_rate_limit_reset_timestamp_seconds",
 			Help: "Unix time the forge rate limit resets (0 when not rate-limited or unknown).",
 		}),
+		checksSkipped: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricNamespace, Name: "forge_checks_skipped_total",
+			Help: "CI-checks passes skipped to preserve the forge rate budget.",
+		}),
 	}
 	reg.MustRegister(
 		collectors.NewGoCollector(),
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 		m.diffTotal, m.diffDuration, m.queueDepth, m.prsKnown, m.httpReqs,
-		m.listErrors, m.rateLimited, m.rateLimitReset,
+		m.listErrors, m.rateLimited, m.rateLimitReset, m.checksSkipped,
 	)
 	return m
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -39,11 +39,17 @@ type fakeProvider struct {
 	listErr  error
 	listHook func()                  // optional seam invoked at the start of each ListPRs (set before use)
 	checks   map[int]api.CheckRollup // per-PR CI rollup Checks returns (zero value → none)
+
+	listCalls     int  // ListPRs invocations (read via callCounts)
+	checksCalls   int  // Checks invocations (read via callCounts)
+	rateRemaining int  // budget RateBudget reports — only when rateKnown
+	rateKnown     bool // false by default → budget-unaware, leaving the poll's guard inert
 }
 
 func (f *fakeProvider) Checks(_ context.Context, pr api.PR) (api.CheckRollup, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.checksCalls++
 	return f.checks[pr.Number], nil
 }
 
@@ -53,6 +59,7 @@ func (f *fakeProvider) ListPRs(context.Context) ([]api.PR, error) {
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.listCalls++
 	return f.prs, f.listErr
 }
 
@@ -100,6 +107,30 @@ func (f *fakeProvider) setDetail(pr api.PR) {
 		f.details = map[int]api.PR{}
 	}
 	f.details[pr.Number] = pr
+}
+
+// RateBudget implements provider.RateBudgeter. It reports a budget only after
+// setBudget; by default (rateKnown false) the fake is budget-unaware, so the
+// poll's budget guard stays inert and every other test's behaviour is unchanged.
+func (f *fakeProvider) RateBudget() (int, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.rateRemaining, f.rateKnown
+}
+
+// setBudget makes the fake report a known remaining request budget — turning on
+// the RateBudgeter capability for the budget-gate test.
+func (f *fakeProvider) setBudget(remaining int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rateRemaining, f.rateKnown = remaining, true
+}
+
+// callCounts returns how many times ListPRs and Checks have run.
+func (f *fakeProvider) callCounts() (list, checks int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.listCalls, f.checksCalls
 }
 
 type fakeEngine struct {
@@ -1391,5 +1422,76 @@ func mustJSON(t *testing.T, rec *httptest.ResponseRecorder, v any) {
 	t.Helper()
 	if err := json.Unmarshal(rec.Body.Bytes(), v); err != nil {
 		t.Fatalf("decode %T: %v (body=%s)", v, err, rec.Body.String())
+	}
+}
+
+// TestRefreshChecks_RateBudgetGate verifies the per-PR checks pass is skipped only
+// when the forge's remaining request budget couldn't cover it (two calls per PR
+// plus a reserve) — so a nearly-exhausted anonymous GitHub poll keeps listing PRs,
+// and their filter pills keep their last value, instead of failing the list. When
+// the budget is unknown (no token) or ample, every PR is checked as before.
+func TestRefreshChecks_RateBudgetGate(t *testing.T) {
+	prs := []api.PR{{Number: 1, HeadSHA: "a"}, {Number: 2, HeadSHA: "b"}}
+	const cost = 2 * 2 // 2 PRs × (GetCombinedStatus + ListCheckRunsForRef)
+
+	cases := []struct {
+		name       string
+		budget     func(*fakeProvider)
+		wantChecks int
+	}{
+		{"budget unknown (no token) → runs", func(*fakeProvider) {}, 2},
+		{"budget ample → runs", func(f *fakeProvider) { f.setBudget(5000) }, 2},
+		{"budget exactly covers it → runs", func(f *fakeProvider) { f.setBudget(cost + checksReserve) }, 2},
+		{"budget one short → skipped", func(f *fakeProvider) { f.setBudget(cost + checksReserve - 1) }, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prov := &fakeProvider{prs: prs}
+			tc.budget(prov)
+			s := newTestServer(t, ghCfg("tok"), prov, okEngine())
+
+			s.refreshList(s.runCtx)
+
+			if _, checks := prov.callCounts(); checks != tc.wantChecks {
+				t.Errorf("Checks calls = %d, want %d", checks, tc.wantChecks)
+			}
+			// The list always lands — the gate only ever sheds the checks pass.
+			if _, ok := s.store.get(1); !ok {
+				t.Error("PR #1 must be tracked: the list must run even when checks are skipped")
+			}
+		})
+	}
+}
+
+// TestRefreshList_RateLimitCircuitBreaker verifies the poll skips the forge while
+// a rate-limit cooldown is in effect (a periodic tick or a webhook-driven relist
+// during the window could only draw more 403s) and resumes once the reset has
+// passed. A rate limit with no known reset time, or a generic non-rate-limit
+// failure, must not wedge the poll.
+func TestRefreshList_RateLimitCircuitBreaker(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name     string
+		status   api.SyncStatus
+		wantList int
+	}{
+		{"healthy → polls", api.SyncStatus{OK: true}, 1},
+		{"rate-limited, resets in future → skipped", api.SyncStatus{OK: false, Reason: api.SyncRateLimited, RetryAt: now.Add(time.Hour).Unix()}, 0},
+		{"rate-limited, reset passed → polls", api.SyncStatus{OK: false, Reason: api.SyncRateLimited, RetryAt: now.Add(-time.Minute).Unix()}, 1},
+		{"rate-limited, no reset time → polls (never wedge)", api.SyncStatus{OK: false, Reason: api.SyncRateLimited}, 1},
+		{"generic error → polls", api.SyncStatus{OK: false, Reason: api.SyncError}, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prov := &fakeProvider{prs: []api.PR{{Number: 1, HeadSHA: "a"}}}
+			s := newTestServer(t, ghCfg("tok"), prov, okEngine())
+			s.sync.set(tc.status)
+
+			s.refreshList(s.runCtx)
+
+			if list, _ := prov.callCounts(); list != tc.wantList {
+				t.Fatalf("ListPRs calls = %d, want %d", list, tc.wantList)
+			}
+		})
 	}
 }

--- a/internal/server/sync_test.go
+++ b/internal/server/sync_test.go
@@ -121,11 +121,14 @@ func TestServer_SyncStatusSurfacing(t *testing.T) {
 		t.Errorf("forge_rate_limit_reset = %v, want %d", got, reset.Unix())
 	}
 
-	// The forge recovers: the next list succeeds, clearing the banner and gauge.
+	// The forge recovers: once the cooldown has passed, the next list succeeds and
+	// clears the banner and gauges. The rate-limit circuit breaker holds the poll
+	// during the cooldown, so advance the store clock past the reset before re-polling.
 	prov.mu.Lock()
 	prov.listErr = nil
 	prov.prs = []api.PR{{Number: 7, Open: true, HeadRef: "a", BaseRef: "main"}}
 	prov.mu.Unlock()
+	s.store.now = func() time.Time { return reset.Add(time.Minute) }
 	s.refreshList(s.runCtx)
 
 	// Decode into a fresh value: sync is omitempty, and Unmarshal won't clear a


### PR DESCRIPTION
## Why

You asked whether we could cut the anonymous API requests behind the "forge API rate limit was exceeded" banner. Per poll, an unauthenticated GitHub instance spends **`1 + 2N`** requests (the PR list, plus `GetCombinedStatus` + `ListCheckRunsForRef` per open PR). At GitHub's anonymous ceiling of **60 req/hour**, ~14 open PRs on the default 30-min poll already trips it — and once tripped, the *PR list itself* (the core feature) starts failing, not just the CI pills.

(The usual first answer — conditional requests / ETags — doesn't help here: GitHub exempts `304`s from the rate limit **only when authenticated**. So the anonymous fix has to be about spending fewer requests, not cheaper ones.)

## What

Two complementary guards, both reusing the existing rate-limit plumbing (`provider.RateLimit`, the `syncTracker`). No new config — automatic with sensible defaults.

**Circuit breaker** (reactive). While a rate-limit cooldown is in effect (the sync tracker's `RetryAt` is still in the future), `refreshList` and the status-webhook path skip the forge entirely — a retry can't succeed before the reset and would only draw more `403`s. A rate limit with no known reset time, or a generic failure, never wedges the poll.

**Budget gate** (proactive). The GitHub provider now surfaces its remaining request budget via a new optional `provider.RateBudgeter` capability, fed from every response's `X-RateLimit` headers (zero extra calls). Before the per-PR checks pass, if the budget can't cover it plus a small reserve, the pass is skipped — **the list stays fresh and each PR's CI pill keeps its last value** until the budget recovers. This is the bit that keeps the `status:` filter pills working: in the normal (healthy-budget) case nothing changes, so every PR is still checked; the pass is shed only under genuine pressure.

When authenticated (5000/hour) the budget never gets low enough to fire, and GitLab/Forgejo don't implement `RateBudgeter`, so the gate is inert there. A new `konflate_forge_checks_skipped_total` counter surfaces how often the pass is shed (a rising count on an anon instance = configure a token).

## Tests

- `TestRefreshChecks_RateBudgetGate` — checks run when the budget is unknown (no token), ample, or exactly sufficient; skipped only when one short. The list always lands.
- `TestRefreshList_RateLimitCircuitBreaker` — the poll is skipped during a future-reset cooldown and resumes once the reset passes; no-reset and generic-error cases never wedge.
- `TestServer_SyncStatusSurfacing` updated: recovery now advances the clock past the reset (the breaker holds the poll during the cooldown).

Local: `go test ./...`, `lint` (0 issues), `vet`, `fmt-check`, `tidy-check` all green.

## Note

The deeper structural option (lazy / on-demand checks) was deliberately **not** taken — it would strand the `status:` filter pills, which you flagged you want kept. This degrades instead of removing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
