### PR TITLE
feat(ui): render-failure signals in the PR list + a top pager

### DIFF
--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -619,6 +619,11 @@ a.repo:focus-visible .repo-ext {
 .card-shell.caution {
   box-shadow: inset 3px 0 0 var(--caution);
 }
+/* A render failure outranks a caution — a red edge. Defined after the caution
+   rule so a card carrying both reads red (equal specificity, source order wins). */
+.card-shell.failure {
+  box-shadow: inset 3px 0 0 var(--danger);
+}
 /* Recently-merged cards are reference, not action — de-emphasized via a muted
    title (whole-card opacity would push the meta text below AA contrast). */
 .card-shell.merged .card-title {
@@ -834,9 +839,16 @@ a.repo:focus-visible .repo-ext {
   margin: 12px auto 4px;
   padding: 0 12px;
 }
-/* Expand/collapse every row summary — pushed to the far right of the pills. */
-.expand-all {
+/* The summary row's right-hand cluster — expand-all and the compact top pager —
+   pushed to the far right of the pills as one group. */
+.list-summary-end {
   margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+/* Expand/collapse every row summary. */
+.expand-all {
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -907,6 +919,23 @@ button.sum-pill:hover {
 }
 .sum-pill.caution strong {
   color: var(--caution);
+}
+/* The render-failure pill mirrors the caution pill a notch up the severity
+   scale — red (--danger), matching the card's red edge and the failures badge. */
+.sum-pill.failure {
+  color: var(--danger);
+  border-color: color-mix(in srgb, var(--danger) 40%, var(--border));
+}
+.sum-pill.failure strong {
+  color: var(--danger);
+}
+.sum-pill.failure.active {
+  border-color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 12%, var(--panel));
+  color: color-mix(in srgb, var(--danger) 75%, var(--text));
+}
+.sum-pill.failure:hover {
+  border-color: var(--danger);
 }
 .sum-pill.merged {
   color: var(--merged);
@@ -1398,6 +1427,9 @@ button.sum-pill:hover {
   font-size: 12px;
   line-height: 1.45;
   white-space: pre-wrap;
+  /* A render-failure message can carry a long unbroken URL/registry path; break
+     it within the column instead of letting it overflow into the next one. */
+  overflow-wrap: anywhere;
 }
 /* One row per changed app: the app, a quiet "N dependents" count, then the
    named direct dependents wrapping below. Same flat shape as a flag but a

--- a/internal/web/src/lib/List.svelte
+++ b/internal/web/src/lib/List.svelte
@@ -111,6 +111,7 @@
   const summary = $derived.by(() => ({
     open: openPrs.length,
     caution: openPrs.filter((p) => (p.signals?.caution ?? 0) > 0).length,
+    failure: openPrs.filter((p) => (p.signals?.failures ?? 0) > 0).length,
     merged: prs.filter((p) => !p.open).length,
     hidden: prs.filter((p) => p.hidden).length,
   }));
@@ -228,6 +229,33 @@
   </div>
 {/snippet}
 
+<!-- Prev / page indicator / next — shared by the bottom pager and the compact
+     top control beside expand-all, so paging a long list doesn't require scrolling
+     to its end. The caller guards on totalPages > 1. -->
+{#snippet pagerNav()}
+  <div class="pager-nav">
+    <button
+      class="pager-btn"
+      onclick={() => gotoPage(page - 1)}
+      disabled={page <= 1}
+      aria-label="Previous page"
+      title="Previous page"
+    >
+      <Icon path={mdiChevronLeft} size={18} />
+    </button>
+    <span class="pager-page">Page {page} of {totalPages}</span>
+    <button
+      class="pager-btn"
+      onclick={() => gotoPage(page + 1)}
+      disabled={page >= totalPages}
+      aria-label="Next page"
+      title="Next page"
+    >
+      <Icon path={mdiChevronRight} size={18} />
+    </button>
+  </div>
+{/snippet}
+
 <!-- The pager sits below the cards once the list outgrows the smallest page. Its
      "of N" counts the active view (the same set the active pill counts), the size
      picker is the persisted per-page preference, and prev/next appear only when
@@ -253,29 +281,7 @@
         {/each}
       </select>
     </label>
-    {#if totalPages > 1}
-      <div class="pager-nav">
-        <button
-          class="pager-btn"
-          onclick={() => gotoPage(page - 1)}
-          disabled={page <= 1}
-          aria-label="Previous page"
-          title="Previous page"
-        >
-          <Icon path={mdiChevronLeft} size={18} />
-        </button>
-        <span class="pager-page">Page {page} of {totalPages}</span>
-        <button
-          class="pager-btn"
-          onclick={() => gotoPage(page + 1)}
-          disabled={page >= totalPages}
-          aria-label="Next page"
-          title="Next page"
-        >
-          <Icon path={mdiChevronRight} size={18} />
-        </button>
-      </div>
-    {/if}
+    {#if totalPages > 1}{@render pagerNav()}{/if}
   </nav>
 {/snippet}
 
@@ -364,6 +370,7 @@
       data-pr={pr.number}
       class:merged={!pr.open}
       class:caution={pr.open && (pr.signals?.caution ?? 0) > 0}
+      class:failure={pr.open && (pr.signals?.failures ?? 0) > 0}
     >
       <button class="card" onclick={() => openPR(pr.number)}>
         <div class="card-top">
@@ -397,14 +404,14 @@
             {#if pr.refreshError}
               <span class="badge warn" title="Couldn't refresh — showing the last render"><Icon path={mdiRefresh} size={13} /></span>
             {/if}
+            {#if pr.signals.failures}
+              <span class="badge danger" title="render failures"><Icon path={mdiAlertCircleOutline} size={13} /> {pr.signals.failures}</span>
+            {/if}
             {#if pr.signals.caution}
               <span class="badge caution" title="cautions"><Icon path={mdiAlert} size={13} /> {pr.signals.caution}</span>
             {/if}
             {#if pr.signals.images}
               <span class="badge" title={`${pr.signals.images} image change${pr.signals.images === 1 ? '' : 's'}`}><Icon path={mdiPackageVariantClosed} size={13} /> {pr.signals.images}</span>
-            {/if}
-            {#if pr.signals.failures}
-              <span class="badge danger" title="render failures"><Icon path={mdiAlertCircleOutline} size={13} /> {pr.signals.failures}</span>
             {/if}
             <span class="badge muted" title={`${pr.signals.resources} resource change${pr.signals.resources === 1 ? '' : 's'}`}>
               <Icon path={mdiFileDocumentOutline} size={13} /> {pr.signals.resources}
@@ -504,6 +511,9 @@
   {#if store.loaded && (summary.open || summary.merged || summary.hidden)}
     <div class="list-summary">
       {@render pill('open', summary.open, '', 'Show open pull requests')}
+      {#if showPill(summary.failure, 'failure')}
+        {@render pill('failure', summary.failure, 'failure', 'Only PRs that failed to render')}
+      {/if}
       {#if showPill(summary.caution, 'caution')}
         {@render pill('caution', summary.caution, 'caution', 'Only PRs with cautions')}
       {/if}
@@ -513,16 +523,25 @@
       {#if showPill(summary.hidden, 'hidden')}
         {@render pill('hidden', summary.hidden, 'hidden', 'PRs excluded by the filter — listed but not rendered')}
       {/if}
-      {#if expandableRows.length}
-        <button
-          class="expand-all"
-          aria-expanded={allExpanded}
-          title={allExpanded ? 'Collapse every row summary' : 'Expand every row summary'}
-          onclick={toggleExpandAll}
-        >
-          <Icon path={allExpanded ? mdiUnfoldLessHorizontal : mdiUnfoldMoreHorizontal} size={14} />
-          {allExpanded ? 'Collapse all' : 'Expand all'}
-        </button>
+      {#if expandableRows.length || (paginated && totalPages > 1)}
+        <div class="list-summary-end">
+          {#if expandableRows.length}
+            <button
+              class="expand-all"
+              aria-expanded={allExpanded}
+              title={allExpanded ? 'Collapse every row summary' : 'Expand every row summary'}
+              onclick={toggleExpandAll}
+            >
+              <Icon path={allExpanded ? mdiUnfoldLessHorizontal : mdiUnfoldMoreHorizontal} size={14} />
+              {allExpanded ? 'Collapse all' : 'Expand all'}
+            </button>
+          {/if}
+          <!-- A compact prev/next beside expand-all so paging is reachable from the
+               top of a long list; the full pager (count + size) stays at the bottom. -->
+          {#if paginated && totalPages > 1}
+            {@render pagerNav()}
+          {/if}
+        </div>
       {/if}
     </div>
   {/if}

--- a/internal/web/src/lib/store.svelte.ts
+++ b/internal/web/src/lib/store.svelte.ts
@@ -19,7 +19,7 @@ import { router, navigate } from './router.svelte';
 
 // The status facets a summary pill can filter the list down to ('' = unfiltered;
 // 'open' narrows to just the open set, hiding the merged shelf).
-export type StatusFilter = '' | 'open' | 'caution' | 'merged' | 'hidden';
+export type StatusFilter = '' | 'open' | 'caution' | 'failure' | 'merged' | 'hidden';
 // List sort: the field to order by, and the direction. The comparator is
 // defined ascending (name A→Z, time oldest-first); 'desc' reverses it.
 export type SortKey = 'created' | 'refreshed' | 'name';
@@ -129,7 +129,7 @@ const FACETS = ['status', 'author', 'base', 'label'];
 // with matchesStatus again. ('hidden' was missing here, so `status:hidden` typed
 // in the filter or palette matched nothing — the pill worked only because it sets
 // statusFilter directly, bypassing this grammar.)
-const STATUS_VALUES = ['open', 'caution', 'merged', 'hidden'] as const satisfies readonly StatusFilter[];
+const STATUS_VALUES = ['open', 'caution', 'failure', 'merged', 'hidden'] as const satisfies readonly StatusFilter[];
 
 export function parseQuery(raw: string): ParsedQuery {
   const tokens: ParsedQuery['tokens'] = [];
@@ -209,6 +209,8 @@ export function matchesStatus(p: PRStatus, f: StatusFilter): boolean {
   switch (f) {
     case 'caution':
       return p.open && !p.hidden && (p.signals?.caution ?? 0) > 0;
+    case 'failure':
+      return p.open && !p.hidden && (p.signals?.failures ?? 0) > 0;
     case 'merged':
       return !p.open;
     case 'hidden':

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -269,14 +269,14 @@ test('list pagination: default 10 per page, prev/next, and a size picker', async
   // Default page size is 10 (the lowest), newest first.
   await expect(page.locator('.card')).toHaveCount(10);
   await expect(page.locator('.pager-count')).toHaveText('1–10 of 25');
-  await expect(page.locator('.pager-page')).toHaveText('Page 1 of 3');
+  await expect(page.locator('.pager .pager-page')).toHaveText('Page 1 of 3');
   await expect(page.locator('.card-shell[data-pr="25"]')).toBeVisible();
   await expect(page.locator('.card-shell[data-pr="15"]')).toHaveCount(0); // page 2's top
 
   // Next → page 2: the URL carries the page, and the window slides.
-  await page.locator('.pager-btn[aria-label="Next page"]').click();
+  await page.locator('.pager .pager-btn[aria-label="Next page"]').click();
   await expect(page).toHaveURL(/#\/page\/2$/);
-  await expect(page.locator('.pager-page')).toHaveText('Page 2 of 3');
+  await expect(page.locator('.pager .pager-page')).toHaveText('Page 2 of 3');
   await expect(page.locator('.pager-count')).toHaveText('11–20 of 25');
   await expect(page.locator('.card-shell[data-pr="15"]')).toBeVisible();
   await expect(page.locator('.card-shell[data-pr="25"]')).toHaveCount(0);
@@ -290,16 +290,56 @@ test('list pagination: default 10 per page, prev/next, and a size picker', async
   await expect(page.locator('.pager-count')).toHaveText('1–25 of 25');
 });
 
+test('list pagination: a compact pager beside expand-all pages from the top', async ({ page }) => {
+  await stubApi(page, defaultMeta, bulkPRs({ open: 25 }));
+  await page.goto('/');
+
+  // The top pager (in the summary row's right cluster) mirrors the bottom one and
+  // pages the list without scrolling to its end.
+  const topNav = page.locator('.list-summary-end .pager-nav');
+  await expect(topNav.locator('.pager-page')).toHaveText('Page 1 of 3');
+  await topNav.locator('.pager-btn[aria-label="Next page"]').click();
+  await expect(page).toHaveURL(/#\/page\/2$/);
+  await expect(topNav.locator('.pager-page')).toHaveText('Page 2 of 3');
+  await expect(page.locator('.pager .pager-page')).toHaveText('Page 2 of 3'); // bottom stays in sync
+});
+
+test('render-failure signals: a "failure" pill, a red card edge, and the badge left of images', async ({ page }) => {
+  await stubApi(page);
+  await page.goto('/');
+
+  // A red pill beside "open" counts PRs that failed to render and filters to them.
+  const failurePill = page.locator('.sum-pill.failure');
+  await expect(failurePill).toContainText('1 failure');
+  await failurePill.click();
+  await expect(page.locator('.card')).toHaveCount(1);
+  const card = page.locator('.card-shell[data-pr="142"]');
+  await expect(card).toBeVisible();
+
+  // The failing card carries a red edge (its own class), like a caution card's amber one.
+  await expect(card).toHaveClass(/failure/);
+
+  // The render-failure badge (danger) and the caution badge both sit LEFT of the
+  // image-changes badge (the bare `.badge`) — failures was previously to its right.
+  const classes = await card.locator('.badges .badge').evaluateAll((els) => els.map((el) => el.className.trim()));
+  const dangerIdx = classes.findIndex((c) => c.includes('danger'));
+  const cautionIdx = classes.findIndex((c) => c.includes('caution'));
+  const imagesIdx = classes.indexOf('badge');
+  expect(dangerIdx).toBeGreaterThanOrEqual(0);
+  expect(imagesIdx).toBeGreaterThan(dangerIdx);
+  expect(imagesIdx).toBeGreaterThan(cautionIdx);
+});
+
 test('list pagination: deep-links a page and clamps an out-of-range page', async ({ page }) => {
   await stubApi(page, defaultMeta, bulkPRs({ open: 25 }));
 
   await page.goto('/#/page/2');
-  await expect(page.locator('.pager-page')).toHaveText('Page 2 of 3');
+  await expect(page.locator('.pager .pager-page')).toHaveText('Page 2 of 3');
   await expect(page.locator('.card-shell[data-pr="15"]')).toBeVisible();
 
   // A page past the end clamps to the last page (and rewrites the URL to match).
   await page.goto('/#/page/99');
-  await expect(page.locator('.pager-page')).toHaveText('Page 3 of 3');
+  await expect(page.locator('.pager .pager-page')).toHaveText('Page 3 of 3');
   await expect(page).toHaveURL(/#\/page\/3$/);
   await expect(page.locator('.card')).toHaveCount(5); // 25 → pages of 10/10/5
 });
@@ -315,12 +355,12 @@ test('list pagination stays coherent with the filter pills', async ({ page }) =>
 
   // Page in, then switch to the merged pill: the page resets to 1 and the count
   // tracks the merged set, so "of N" matches the merged pill's count (cohesion).
-  await page.locator('.pager-btn[aria-label="Next page"]').click();
-  await expect(page.locator('.pager-page')).toHaveText('Page 2 of 3');
+  await page.locator('.pager .pager-btn[aria-label="Next page"]').click();
+  await expect(page.locator('.pager .pager-page')).toHaveText('Page 2 of 3');
   await page.locator('.sum-pill.merged').click();
   await expect(page).toHaveURL(/#\/$/); // back to page 1
   await expect(page.locator('.pager-count')).toHaveText('1–10 of 13');
-  await expect(page.locator('.pager-page')).toHaveText('Page 1 of 2');
+  await expect(page.locator('.pager .pager-page')).toHaveText('Page 1 of 2');
 });
 
 test('split diff renders two balanced columns (regression)', async ({ page }) => {


### PR DESCRIPTION
Four PR-list / summary-pane polish items, grouped as requested.

## 1 — Top pager beside expand-all

A compact prev/next + "Page X of Y" now sits at the top of the list, in the summary row's right cluster next to **expand all**, so paging a long list doesn't require scrolling to the bottom. It shares one `pagerNav` snippet with the bottom pager (which keeps the full count + per-page picker), so the two always stay in sync.

## 2 — Render-failure parity with cautions

Render failures were under-surfaced next to cautions. Now, for a PR that failed to render:

- **Filter pill** — a red `failure` pill beside `open` (and `status:failure` in the search box), counting PRs with render failures and filtering to them.
- **Red card edge** — a red left rule on the card, mirroring the amber caution edge. A card with both reads red (failure outranks caution).
- **Badge moved left of images** — the render-failure badge now sits left of the image-changes badge, where the caution badge sits, instead of stranded to its right.

## 3 — Summary-pane overflow fix

A long render-failure message (e.g. a `registry-auth…` URL) overflowed the **Render failures** column into **Cautions**. `.flag-detail` now breaks long unbreakable tokens within its column (`overflow-wrap: anywhere`), matching `.flag-title`.

## Tests

- New: the top pager pages from the top and stays in sync with the bottom; the `failure` pill counts/filters, the failing card carries the red `failure` class, and the failures + caution badges both sit left of the images badge.
- Existing pager assertions scoped to the bottom `.pager` (the nav markup is now shared top + bottom).

Local: `ui-typecheck` (0 errors), `ui-test` (75 passed, 1 skipped), `ui-build` all green.

> Note: the pill reads **failure** (singular, like `caution`) to stay compact next to the other pills; the tooltip and column header still say "render failure(s)". Easy to switch to "failures" if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
