### PR TITLE
feat: disable forge CI-status checks on an anonymous instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,12 +239,15 @@ auth — it authenticates both the API calls and the renderer's `git` clone/fetc
 raising the API rate limit and unlocking private repositories. It gates no
 behaviour: konflate works the same with or without it.
 
-Without it, an unauthenticated GitHub instance shares the low anonymous rate
-limit (60 req/hour). konflate protects the PR list first: when the remaining
-budget runs low it defers the per-PR CI-status pass — the list stays current and
-the red/amber/green pills keep their last value — rather than exhausting the
-limit and failing the list outright. A token raises the limit so the pills stay
-fresh too.
+Without it, an unauthenticated instance shares the forge's low anonymous rate
+limit (60 req/hour on GitHub). So an anonymous instance **disables forge CI-status
+checks** entirely — polling every open PR's status is two forge calls per PR per
+refresh, which would blow that limit and start failing the PR list itself — and
+the red/amber/green check pill is hidden in the UI. Everything else (rendered
+diffs, blast radius, image changes, cautions) is unaffected. Configure a token or
+GitHub App and the checks come back, on the raised rate limit. The active feature
+gates are surfaced on `/api/meta` (see `api.Features`) so the UI shows only what
+the backend feeds.
 
 On GitHub, configuring a **GitHub App** (`KONFLATE_APP_CLIENT_ID` +
 `KONFLATE_APP_PRIVATE_KEY`) authenticates reads too — its installation token is

--- a/cmd/konflate/main.go
+++ b/cmd/konflate/main.go
@@ -51,6 +51,7 @@ func run() error {
 		"repo", cfg.Repo,
 		"forge", cfg.Forge.Kind,
 		"authenticated", cfg.Authenticated(),
+		"checks", cfg.ChecksEnabled(),
 		"port", cfg.Port,
 		"metrics_addr", cfg.MetricsAddr,
 		"diff_concurrency", cfg.MaxDiffConcurrency,

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -100,6 +100,22 @@ type Meta struct {
 	// PR-list attempt failed, so the UI can show a banner instead of a misleading
 	// empty list. Omitted when healthy.
 	Sync *SyncStatus `json:"sync,omitempty"`
+	// Features reports which optional capabilities are active, so the UI gates the
+	// same features the backend has turned off (see [Features]).
+	Features Features `json:"features"`
+}
+
+// Features reports which optional, instance-dependent capabilities are active.
+// It rides on [Meta] so the front end gates the same features the backend does:
+// forge-cost read features auto-disable when konflate is anonymous (see the
+// config's Authenticated), and showing a control the backend won't feed is just
+// noise. To add a gate: a bool here, populate it from a config accessor where
+// Meta is built, and mirror it in the UI's Meta type.
+type Features struct {
+	// Checks is forge CI-status polling + display (the check pill). Off when
+	// anonymous — two forge calls per PR per poll would blow the unauthenticated
+	// rate limit.
+	Checks bool `json:"checks"`
 }
 
 // Event is a websocket message announcing a change to a PR's diff job, so the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -326,10 +326,20 @@ type Config struct {
 // Authenticated reports whether konflate has forge read auth — a read token or a
 // GitHub App, whose installation token authenticates reads (see the GitHub read
 // provider) as well as write-back. It raises the API rate limit and unlocks
-// private repositories. It gates no feature: inbound endpoints are governed solely
-// by their own secrets (see WebhookEnabled / PushEnabled), so konflate behaves the
-// same with or without it.
+// private repositories. It gates one read feature — CI-status checks, too costly
+// to poll on the anonymous rate limit (see ChecksEnabled); inbound endpoints are
+// otherwise governed solely by their own secrets (see WebhookEnabled /
+// PushEnabled).
 func (c *Config) Authenticated() bool { return c.Token != "" || c.AppConfigured() }
+
+// ChecksEnabled reports whether konflate polls and shows each PR's forge CI
+// status — the red/amber/green check pill in the list and review header. It
+// rides on Authenticated: polling every open PR's status costs two forge calls
+// per PR per refresh, which an anonymous instance can't afford on the low
+// unauthenticated rate limit, so checks stay off until a token (or App) is
+// configured. This is the read side — distinct from StatusChecksEnabled, which
+// writes a commit status back to the forge.
+func (c *Config) ChecksEnabled() bool { return c.Authenticated() }
 
 // WebhookEnabled reports whether POST /hooks should be served: gated solely by a
 // configured webhook secret. Without the secret the endpoint returns 501, so a

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -57,6 +57,7 @@ func (s *Server) handleMeta(w http.ResponseWriter, _ *http.Request) {
 		Version:                s.Version,
 		RefreshIntervalSeconds: int(s.cfg.RefreshInterval.Seconds()),
 		Sync:                   s.metaSync(),
+		Features:               api.Features{Checks: s.cfg.ChecksEnabled()},
 	})
 }
 
@@ -583,6 +584,9 @@ func (s *Server) refreshList(ctx context.Context) {
 // the refresh — a forge that rate-limits the checks endpoint must not stop PRs
 // from listing.
 func (s *Server) refreshChecks(ctx context.Context, prs []api.PR) {
+	if !s.cfg.ChecksEnabled() {
+		return // anonymous instance: CI-status polling is off (Config.ChecksEnabled)
+	}
 	if s.checksWouldExhaustBudget(len(prs)) {
 		s.log.Info("refresh: skipping checks pass to preserve forge rate budget", "prs", len(prs))
 		s.metrics.checksSkipped.Inc()
@@ -607,6 +611,9 @@ func (s *Server) refreshChecks(ctx context.Context, prs []api.PR) {
 // don't track) is a no-op — deliberately no relist, so a chatty CI can't trigger
 // a forge re-list per delivered event.
 func (s *Server) refreshChecksForSHA(ctx context.Context, sha string) {
+	if !s.cfg.ChecksEnabled() {
+		return // anonymous instance: CI-status polling is off (Config.ChecksEnabled)
+	}
 	if _, blocked := s.rateLimitedUntil(); blocked {
 		return // in a rate-limit cooldown — a chatty CI must not draw more 403s
 	}
@@ -652,10 +659,11 @@ const checksReserve = 10
 // checksWouldExhaustBudget reports whether fetching every PR's CI rollup — two
 // forge calls each — would draw the remaining request budget below checksReserve.
 // It fires only when the provider can report a budget (GitHub) and that budget is
-// known; otherwise it returns false and the checks pass runs unchanged. This is
-// what lets an unauthenticated GitHub poll keep listing PRs rather than spend its
-// whole 60/hour allowance on check rollups: the list stays fresh and each PR's CI
-// pill simply keeps its last value until the budget recovers.
+// known; otherwise it returns false and the checks pass runs unchanged. With
+// checks off entirely on an anonymous instance (refreshChecks returns early — see
+// Config.ChecksEnabled), this is a safety net for an authenticated instance with a
+// very large open-PR set: the list stays fresh and each PR's CI pill keeps its
+// last value rather than the list itself starting to fail.
 func (s *Server) checksWouldExhaustBudget(n int) bool {
 	if n <= 0 {
 		return false

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1495,3 +1495,44 @@ func TestRefreshList_RateLimitCircuitBreaker(t *testing.T) {
 		})
 	}
 }
+
+// TestRefreshChecks_DisabledWhenAnonymous verifies the read-side CI-status poll is
+// off on an anonymous instance (Config.ChecksEnabled) — the dominant per-poll forge
+// cost, two calls per PR — and runs as normal once a token is configured.
+func TestRefreshChecks_DisabledWhenAnonymous(t *testing.T) {
+	prs := []api.PR{{Number: 1, HeadSHA: "a"}, {Number: 2, HeadSHA: "b"}}
+
+	anon := &fakeProvider{prs: prs}
+	newTestServer(t, ghCfg(""), anon, okEngine()).refreshList(context.Background())
+	if _, checks := anon.callCounts(); checks != 0 {
+		t.Errorf("anonymous: Checks calls = %d, want 0 (CI-status polling must be off)", checks)
+	}
+
+	authed := &fakeProvider{prs: prs}
+	newTestServer(t, ghCfg("tok"), authed, okEngine()).refreshList(context.Background())
+	if _, checks := authed.callCounts(); checks != len(prs) {
+		t.Errorf("authenticated: Checks calls = %d, want %d (CI status polled per PR)", checks, len(prs))
+	}
+}
+
+// TestMeta_FeaturesReflectAuth verifies /api/meta surfaces the checks feature gate
+// so the UI hides what the backend won't feed: off when anonymous, on when authed.
+func TestMeta_FeaturesReflectAuth(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		token string
+		want  bool
+	}{
+		{"anonymous", "", false},
+		{"authenticated", "tok", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestServer(t, ghCfg(tc.token), &fakeProvider{}, okEngine())
+			var meta api.Meta
+			mustJSON(t, do(s.mainHandler(), "GET", "/api/meta", nil, nil), &meta)
+			if meta.Features.Checks != tc.want {
+				t.Errorf("meta.Features.Checks = %v, want %v", meta.Features.Checks, tc.want)
+			}
+		})
+	}
+}

--- a/internal/web/src/lib/List.svelte
+++ b/internal/web/src/lib/List.svelte
@@ -376,7 +376,7 @@
         <div class="card-top">
         <span class="dot {pr.hidden ? 'dot-hidden' : pr.open ? `dot-${pr.status}` : 'dot-merged'}"></span>
         <span class="card-title"><Breakable text={pr.title} /></span>
-        {#if pr.checks}<Check checks={pr.checks} />{/if}
+        {#if store.meta?.features?.checks && pr.checks}<Check checks={pr.checks} />{/if}
       </div>
       <div class="card-meta">
         <span class="card-author"><Avatar src={pr.authorAvatar} size={15} /> {pr.author || 'unknown'}</span>

--- a/internal/web/src/lib/Review.svelte
+++ b/internal/web/src/lib/Review.svelte
@@ -43,7 +43,7 @@
       </div>
       <div class="review-title">
         <span class="rt-name"><Breakable text={pr?.title ?? ''} /></span>
-        {#if pr?.checks}<Check checks={pr.checks} size={15} />{/if}
+        {#if store.meta?.features?.checks && pr?.checks}<Check checks={pr.checks} size={15} />{/if}
         <div class="rt-meta">
           {#if pr}
             <span class="rt-tag rt-author"><Avatar src={pr.authorAvatar} size={16} /> {pr.author}</span>

--- a/internal/web/src/lib/types.ts
+++ b/internal/web/src/lib/types.ts
@@ -198,6 +198,13 @@ export interface SyncStatus {
   retryAt?: number; // Unix seconds the rate limit resets (rate_limited only)
 }
 
+// Features mirrors the backend's api.Features — which optional capabilities are
+// active. Forge-cost read features turn off on an anonymous instance, so the UI
+// hides what the backend won't feed.
+export interface Features {
+  checks: boolean; // forge CI-status polling + the check pill (off when anonymous)
+}
+
 export interface Meta {
   forge: string;
   repo: string;
@@ -205,4 +212,5 @@ export interface Meta {
   version?: string; // konflate build version ("dev" for local builds)
   refreshIntervalSeconds: number;
   sync?: SyncStatus; // present (ok=false) only when the last forge poll failed
+  features: Features; // instance capability gates the UI honors (see api.Features)
 }

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -8,6 +8,7 @@ const defaultMeta: Meta = {
   repoUrl: 'https://github.com/acme/home-ops',
   version: '1.2.3',
   refreshIntervalSeconds: 1800,
+  features: { checks: true }, // authenticated instance: CI checks shown
 };
 
 // Stub the konflate API (and silence the websocket) so the UI renders
@@ -36,6 +37,19 @@ test('PR list shows the forge CI check status per PR (green / amber / red)', asy
   // meta row among the signal badges.
   await expect(card(142).locator('.card-top .check-success')).toBeVisible();
   await expect(card(142).locator('.card-meta .check')).toHaveCount(0);
+});
+
+test('anonymous instance hides forge CI checks (features.checks=false)', async ({ page }) => {
+  // No forge auth server-side ⇒ meta.features.checks is false ⇒ konflate doesn't
+  // poll CI status, and the UI hides the check pill it would otherwise show even
+  // if a rollup were present (see api.Features).
+  await stubApi(page, { ...defaultMeta, features: { checks: false } });
+  await page.goto('/');
+  const card = (n: number) => page.locator(`.card-shell[data-pr="${n}"]`);
+  await card(142).waitFor();
+  // The fixtures carry check rollups on these PRs, but with the feature off none
+  // of the pills render anywhere.
+  await expect(page.locator('.check')).toHaveCount(0);
 });
 
 test('list → review → single-page flow', async ({ page }) => {
@@ -480,7 +494,7 @@ test('keyboard: j steps from Summary into resources, o returns to Summary', asyn
 });
 
 test('auto-update indicator reflects the configured interval, no refresh button', async ({ page }) => {
-  await stubApi(page, { forge: 'forgejo', repo: 'me/home-ops', refreshIntervalSeconds: 600 });
+  await stubApi(page, { forge: 'forgejo', repo: 'me/home-ops', refreshIntervalSeconds: 600, features: { checks: true } });
   await page.goto('/');
   await expect(page.locator('.actions .auto')).toContainText('10m');
   await expect(page.locator('.actions .btn', { hasText: 'Refresh' })).toHaveCount(0);


### PR DESCRIPTION
## Why

On your anonymous instance, the CI-status poll is the dominant rate-limit cost: konflate fetches each open PR's rollup every refresh (two forge calls per PR — `GetCombinedStatus` + `ListCheckRunsForRef` on GitHub). With 72 PRs on GitHub's **60 req/hour** anonymous ceiling, that alone blows the budget and the PR list itself starts failing.

Per your request: **an anonymous instance now disables forge CI-status checks entirely** — no polling (all three forges), and the red/amber/green check pill is hidden in the UI. Everything else (rendered diffs, blast radius, image changes, cautions, the render-failure signals) is unaffected. Configure a token or GitHub App and checks come back, on the raised rate limit.

This supersedes the budget-gate degradation from #233 for the anon case (which now never runs there); that gate stays as a safety net for an authenticated instance with a very large open-PR set.

## What

**The feature (anon → no checks):**
- `config.ChecksEnabled()` = `Authenticated()` — the read-side CI poll gate (distinct from the write-back `StatusChecksEnabled()`).
- `refreshChecks` / `refreshChecksForSHA` return early when checks are off.
- The UI's check pill renders only when the feature is on (List + Review).
- Startup log gains a `checks` field.

**The reusable mechanism (your "make it easy via code" ask):**
- `api.Features{ Checks bool }` rides on `/api/meta`, populated from config accessors, mirrored as `Meta.features` in the UI types. To gate a new feature on anon (or any config): add a bool to `api.Features`, populate it where `Meta` is built, mirror it in the TS `Meta`, and gate the component. The UI reads it defensively (`store.meta?.features?.checks`) so a meta without the field never throws.

## Tests

- `TestRefreshChecks_DisabledWhenAnonymous` — anon polls zero checks; authed polls one per PR.
- `TestMeta_FeaturesReflectAuth` — `/api/meta` reports `features.checks` false (anon) / true (authed).
- Playwright `anonymous instance hides forge CI checks` — with `features.checks=false`, no check pill renders even though the fixtures carry rollups.

Local: `go test ./...`, `lint` (0 issues), `vet`, `fmt-check`, `tidy-check`, `ui-typecheck`, `ui-test` (76 passed, 1 skipped), `ui-build` all green. No new config knob, so no chart change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
