### PR TITLE
refactor: remove the now-vestigial rate-budget gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,7 +549,6 @@ Served on the separate operational port (keep it off your public ingress):
 | `konflate_forge_list_errors_total`                  | counter   | Failed PR-list polls, by `reason` (`rate_limited`/`error`). |
 | `konflate_forge_rate_limited`                       | gauge     | `1` when the last PR-list poll hit a rate limit, else `0`.  |
 | `konflate_forge_rate_limit_reset_timestamp_seconds` | gauge     | Unix time the rate limit resets (`0` when not limited).     |
-| `konflate_forge_checks_skipped_total`               | counter   | CI-checks passes skipped to preserve the forge rate budget. |
 
 Plus the standard Go runtime and process collectors.
 

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/google/go-github/v88/github"
@@ -39,10 +38,6 @@ func RateLimit(err error) (resetAt time.Time, ok bool) {
 type githubProvider struct {
 	client      *github.Client
 	owner, repo string
-
-	mu       sync.Mutex
-	rate     github.Rate // budget from the most recent response (see noteRate/RateBudget)
-	rateSeen bool
 }
 
 func newGitHub(cfg *config.Config) (*githubProvider, error) {
@@ -52,32 +47,6 @@ func newGitHub(cfg *config.Config) (*githubProvider, error) {
 	}
 	owner, repo := ownerRepo(cfg.Forge.RepoPath)
 	return &githubProvider{client: client, owner: owner, repo: repo}, nil
-}
-
-// noteRate records the forge rate budget reported on a response, so RateBudget
-// can answer "how many requests are left?" without spending one. go-github puts
-// the X-RateLimit headers on every response (including a 403 rate-limit reply,
-// where Remaining is 0); the latest wins. Safe for the concurrent callers — the
-// periodic poll and the webhook handlers.
-func (p *githubProvider) noteRate(resp *github.Response) {
-	if resp == nil {
-		return
-	}
-	p.mu.Lock()
-	p.rate = resp.Rate
-	p.rateSeen = true
-	p.mu.Unlock()
-}
-
-// RateBudget implements [RateBudgeter]: the requests remaining before the rate
-// limit as of the last call, and whether any response has been observed yet.
-func (p *githubProvider) RateBudget() (remaining int, ok bool) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if !p.rateSeen {
-		return 0, false
-	}
-	return p.rate.Remaining, true
 }
 
 // newGitHubReadClient builds the read API client by credential precedence,
@@ -123,7 +92,6 @@ func (p *githubProvider) ListPRs(ctx context.Context) ([]api.PR, error) {
 	var out []api.PR
 	for {
 		prs, resp, err := p.client.PullRequests.List(ctx, p.owner, p.repo, opts)
-		p.noteRate(resp)
 		if err != nil {
 			return nil, fmt.Errorf("github: list PRs: %w", err)
 		}
@@ -140,7 +108,6 @@ func (p *githubProvider) ListPRs(ctx context.Context) ([]api.PR, error) {
 
 func (p *githubProvider) GetPR(ctx context.Context, number int) (api.PR, error) {
 	pr, resp, err := p.client.PullRequests.Get(ctx, p.owner, p.repo, number)
-	p.noteRate(resp)
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return api.PR{}, fmt.Errorf("github: get PR #%d: %w", number, ErrPRNotFound)
@@ -160,8 +127,7 @@ func (p *githubProvider) Checks(ctx context.Context, pr api.PR) (api.CheckRollup
 	}
 	var passed, failed, pending int
 
-	cs, resp, err := p.client.Repositories.GetCombinedStatus(ctx, p.owner, p.repo, pr.HeadSHA, &github.ListOptions{PerPage: 100})
-	p.noteRate(resp)
+	cs, _, err := p.client.Repositories.GetCombinedStatus(ctx, p.owner, p.repo, pr.HeadSHA, &github.ListOptions{PerPage: 100})
 	if err != nil {
 		return api.CheckRollup{}, fmt.Errorf("github: combined status #%d: %w", pr.Number, err)
 	}
@@ -176,9 +142,8 @@ func (p *githubProvider) Checks(ctx context.Context, pr api.PR) (api.CheckRollup
 		}
 	}
 
-	runs, resp, err := p.client.Checks.ListCheckRunsForRef(ctx, p.owner, p.repo, pr.HeadSHA,
+	runs, _, err := p.client.Checks.ListCheckRunsForRef(ctx, p.owner, p.repo, pr.HeadSHA,
 		&github.ListCheckRunsOptions{ListOptions: github.ListOptions{PerPage: 100}})
-	p.noteRate(resp)
 	if err != nil {
 		return api.CheckRollup{}, fmt.Errorf("github: check runs #%d: %w", pr.Number, err)
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -39,19 +39,6 @@ type Provider interface {
 	Checks(ctx context.Context, pr api.PR) (api.CheckRollup, error)
 }
 
-// RateBudgeter is an optional Provider capability: it reports the forge request
-// budget observed on the most recent call. The poll uses it to skip the costly
-// per-PR checks pass before that pass would exhaust the budget and start failing
-// the cheaper, more important PR list. Only the GitHub provider implements it —
-// GitHub's 60 req/hour unauthenticated ceiling is where this bites; GitLab and
-// Forgejo don't, so the guard is simply inert there (and, once authenticated,
-// the budget is large enough that it never fires).
-type RateBudgeter interface {
-	// RateBudget returns the requests remaining before the forge rate limit and
-	// whether any budget has been observed yet — false before the first call.
-	RateBudget() (remaining int, ok bool)
-}
-
 // New builds the provider for the configured forge.
 func New(cfg *config.Config) (Provider, error) {
 	switch cfg.Forge.Kind {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -587,11 +587,6 @@ func (s *Server) refreshChecks(ctx context.Context, prs []api.PR) {
 	if !s.cfg.ChecksEnabled() {
 		return // anonymous instance: CI-status polling is off (Config.ChecksEnabled)
 	}
-	if s.checksWouldExhaustBudget(len(prs)) {
-		s.log.Info("refresh: skipping checks pass to preserve forge rate budget", "prs", len(prs))
-		s.metrics.checksSkipped.Inc()
-		return
-	}
 	for _, pr := range prs {
 		rollup, err := s.prov.Checks(ctx, pr)
 		if err != nil {
@@ -648,36 +643,6 @@ func (s *Server) rateLimitedUntil() (reset time.Time, blocked bool) {
 		return time.Time{}, false // already past the reset — let the next poll try
 	}
 	return reset, true
-}
-
-// checksReserve is the request headroom checksWouldExhaustBudget keeps unspent:
-// enough for the next poll's PR list and a few closed-PR reconciliations, so a
-// full checks pass never consumes the budget the cheaper, more important list
-// depends on.
-const checksReserve = 10
-
-// checksWouldExhaustBudget reports whether fetching every PR's CI rollup — two
-// forge calls each — would draw the remaining request budget below checksReserve.
-// It fires only when the provider can report a budget (GitHub) and that budget is
-// known; otherwise it returns false and the checks pass runs unchanged. With
-// checks off entirely on an anonymous instance (refreshChecks returns early — see
-// Config.ChecksEnabled), this is a safety net for an authenticated instance with a
-// very large open-PR set: the list stays fresh and each PR's CI pill keeps its
-// last value rather than the list itself starting to fail.
-func (s *Server) checksWouldExhaustBudget(n int) bool {
-	if n <= 0 {
-		return false
-	}
-	rb, ok := s.prov.(provider.RateBudgeter)
-	if !ok {
-		return false
-	}
-	remaining, known := rb.RateBudget()
-	if !known {
-		return false
-	}
-	const callsPerPR = 2 // GetCombinedStatus + ListCheckRunsForRef
-	return remaining < n*callsPerPR+checksReserve
 }
 
 // reconcileClosed handles PRs that have left the forge's open set. Each is

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -24,10 +24,6 @@ type metrics struct {
 	listErrors     *prometheus.CounterVec // reason: rate_limited|error
 	rateLimited    prometheus.Gauge
 	rateLimitReset prometheus.Gauge
-	// checksSkipped counts CI-checks passes skipped to stay within the forge rate
-	// budget (see checksWouldExhaustBudget). A rising count on an unauthenticated
-	// instance is the signal that a token would let the CI pills stay current.
-	checksSkipped prometheus.Counter
 }
 
 // metricNamespace prefixes every konflate metric name.
@@ -70,16 +66,12 @@ func newMetrics() *metrics {
 			Namespace: metricNamespace, Name: "forge_rate_limit_reset_timestamp_seconds",
 			Help: "Unix time the forge rate limit resets (0 when not rate-limited or unknown).",
 		}),
-		checksSkipped: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: metricNamespace, Name: "forge_checks_skipped_total",
-			Help: "CI-checks passes skipped to preserve the forge rate budget.",
-		}),
 	}
 	reg.MustRegister(
 		collectors.NewGoCollector(),
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 		m.diffTotal, m.diffDuration, m.queueDepth, m.prsKnown, m.httpReqs,
-		m.listErrors, m.rateLimited, m.rateLimitReset, m.checksSkipped,
+		m.listErrors, m.rateLimited, m.rateLimitReset,
 	)
 	return m
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -40,10 +40,8 @@ type fakeProvider struct {
 	listHook func()                  // optional seam invoked at the start of each ListPRs (set before use)
 	checks   map[int]api.CheckRollup // per-PR CI rollup Checks returns (zero value → none)
 
-	listCalls     int  // ListPRs invocations (read via callCounts)
-	checksCalls   int  // Checks invocations (read via callCounts)
-	rateRemaining int  // budget RateBudget reports — only when rateKnown
-	rateKnown     bool // false by default → budget-unaware, leaving the poll's guard inert
+	listCalls   int // ListPRs invocations (read via callCounts)
+	checksCalls int // Checks invocations (read via callCounts)
 }
 
 func (f *fakeProvider) Checks(_ context.Context, pr api.PR) (api.CheckRollup, error) {
@@ -107,23 +105,6 @@ func (f *fakeProvider) setDetail(pr api.PR) {
 		f.details = map[int]api.PR{}
 	}
 	f.details[pr.Number] = pr
-}
-
-// RateBudget implements provider.RateBudgeter. It reports a budget only after
-// setBudget; by default (rateKnown false) the fake is budget-unaware, so the
-// poll's budget guard stays inert and every other test's behaviour is unchanged.
-func (f *fakeProvider) RateBudget() (int, bool) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	return f.rateRemaining, f.rateKnown
-}
-
-// setBudget makes the fake report a known remaining request budget — turning on
-// the RateBudgeter capability for the budget-gate test.
-func (f *fakeProvider) setBudget(remaining int) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.rateRemaining, f.rateKnown = remaining, true
 }
 
 // callCounts returns how many times ListPRs and Checks have run.
@@ -1422,44 +1403,6 @@ func mustJSON(t *testing.T, rec *httptest.ResponseRecorder, v any) {
 	t.Helper()
 	if err := json.Unmarshal(rec.Body.Bytes(), v); err != nil {
 		t.Fatalf("decode %T: %v (body=%s)", v, err, rec.Body.String())
-	}
-}
-
-// TestRefreshChecks_RateBudgetGate verifies the per-PR checks pass is skipped only
-// when the forge's remaining request budget couldn't cover it (two calls per PR
-// plus a reserve) — so a nearly-exhausted anonymous GitHub poll keeps listing PRs,
-// and their filter pills keep their last value, instead of failing the list. When
-// the budget is unknown (no token) or ample, every PR is checked as before.
-func TestRefreshChecks_RateBudgetGate(t *testing.T) {
-	prs := []api.PR{{Number: 1, HeadSHA: "a"}, {Number: 2, HeadSHA: "b"}}
-	const cost = 2 * 2 // 2 PRs × (GetCombinedStatus + ListCheckRunsForRef)
-
-	cases := []struct {
-		name       string
-		budget     func(*fakeProvider)
-		wantChecks int
-	}{
-		{"budget unknown (no token) → runs", func(*fakeProvider) {}, 2},
-		{"budget ample → runs", func(f *fakeProvider) { f.setBudget(5000) }, 2},
-		{"budget exactly covers it → runs", func(f *fakeProvider) { f.setBudget(cost + checksReserve) }, 2},
-		{"budget one short → skipped", func(f *fakeProvider) { f.setBudget(cost + checksReserve - 1) }, 0},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			prov := &fakeProvider{prs: prs}
-			tc.budget(prov)
-			s := newTestServer(t, ghCfg("tok"), prov, okEngine())
-
-			s.refreshList(s.runCtx)
-
-			if _, checks := prov.callCounts(); checks != tc.wantChecks {
-				t.Errorf("Checks calls = %d, want %d", checks, tc.wantChecks)
-			}
-			// The list always lands — the gate only ever sheds the checks pass.
-			if _, ok := s.store.get(1); !ok {
-				t.Error("PR #1 must be tracked: the list must run even when checks are skipped")
-			}
-		})
 	}
 }
 


### PR DESCRIPTION
## Why

A post-merge code review found that #233's rate-budget gate went **vestigial** when #237 landed:

- **Anonymous** instances now disable CI-status checks entirely — `refreshChecks` returns at `!ChecksEnabled()` **before** the budget gate — so the gate is unreachable for the only case it was built to protect.
- **Authenticated** GitHub has ~5,000 req/hr, so `remaining < 2N + reserve` only trips at **~2,500+ open PRs** — unrealistic for one tracked repo.
- **GitLab/Forgejo** never implement `RateBudgeter`, so the gate is a silent no-op there.

So it's ~80 lines (interface + per-response capture + gate + metric + test) guarding a case that can't occur on a real deployment.

## What

Remove the budget-gate machinery:
- `provider.RateBudgeter` interface.
- the GitHub provider's `noteRate` / `RateBudget` + the `mu`/`rate`/`rateSeen` capture fields and the four `noteRate` call sites.
- `checksWouldExhaustBudget` + `checksReserve` in the server, and the `konflate_forge_checks_skipped_total` metric (+ its README row).
- `TestRefreshChecks_RateBudgetGate` and the `fakeProvider` budget helpers (`callCounts` stays — the anon + circuit-breaker tests use it).

**Kept:** the orthogonal `rateLimitedUntil` **circuit breaker** (skip the forge during a known rate-limit cooldown) — independent of the budget machinery and still useful.

Pure deletion (~154 lines), **no behaviour change** on any real deployment.

Local: `go build ./...`, `go test ./...`, `lint` (0 issues), `vet`, `fmt-check`, `tidy-check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
