### PR TITLE
refactor: adopt Go 1.26 stdlib idioms (errors.AsType, strings, t.Context)

### DIFF
--- a/internal/gitclone/gitclone.go
+++ b/internal/gitclone/gitclone.go
@@ -301,8 +301,7 @@ func mirrorCorrupt(err error) bool {
 	}
 	// A network failure is transient, not damage — and a mid-fetch truncation can
 	// surface as a malformed pack. Exclude it first so a blip never re-clones.
-	var netErr net.Error
-	if errors.As(err, &netErr) {
+	if _, ok := errors.AsType[net.Error](err); ok {
 		return false
 	}
 	if errors.Is(err, plumbing.ErrObjectNotFound) ||

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -22,12 +22,10 @@ import (
 // matched through the wrapped error chain. Non-GitHub forges and non-rate-limit
 // errors report false.
 func RateLimit(err error) (resetAt time.Time, ok bool) {
-	var rl *github.RateLimitError
-	if errors.As(err, &rl) {
+	if rl, ok := errors.AsType[*github.RateLimitError](err); ok {
 		return rl.Rate.Reset.Time, true
 	}
-	var ab *github.AbuseRateLimitError
-	if errors.As(err, &ab) {
+	if ab, ok := errors.AsType[*github.AbuseRateLimitError](err); ok {
 		if ab.RetryAfter != nil {
 			return time.Now().Add(*ab.RetryAfter), true
 		}

--- a/internal/provider/writer.go
+++ b/internal/provider/writer.go
@@ -503,8 +503,7 @@ func githubStatus(resp *github.Response, err error) int {
 	if resp != nil {
 		return resp.StatusCode
 	}
-	var apiErr *github.ErrorResponse
-	if errors.As(err, &apiErr) && apiErr.Response != nil {
+	if apiErr, ok := errors.AsType[*github.ErrorResponse](err); ok && apiErr.Response != nil {
 		return apiErr.Response.StatusCode
 	}
 	return 0

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -171,7 +171,7 @@ func ifNoneMatch(r *http.Request, etag string) bool {
 	if strings.TrimSpace(inm) == "*" {
 		return true
 	}
-	for _, candidate := range strings.Split(inm, ",") {
+	for candidate := range strings.SplitSeq(inm, ",") {
 		if strings.TrimSpace(candidate) == etag {
 			return true
 		}

--- a/internal/server/markdown.go
+++ b/internal/server/markdown.go
@@ -319,7 +319,8 @@ func isHex(s string) bool {
 func reviewURLFromRequest(r *http.Request, number int) string {
 	scheme := schemeHTTPS
 	if p := r.Header.Get("X-Forwarded-Proto"); p != "" {
-		scheme = strings.TrimSpace(strings.Split(p, ",")[0])
+		first, _, _ := strings.Cut(p, ",")
+		scheme = strings.TrimSpace(first)
 	} else if r.TLS == nil {
 		scheme = "http"
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -161,10 +161,8 @@ func newTestServer(t *testing.T, cfg *config.Config, prov *fakeProvider, eng Eng
 	t.Helper()
 	ui := fstest.MapFS{"index.html": &fstest.MapFile{Data: []byte("<!doctype html><title>konflate</title>")}}
 	s := New(cfg, prov, eng, ui, discardLog())
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	s.runCtx = ctx
-	s.queue = newQueue(ctx, s.engine.Diff, s.store, s.hub.broadcast, s.reconcileHeadGone, s.metrics, s.log, cfg.MaxDiffConcurrency, nil)
+	s.runCtx = t.Context()
+	s.queue = newQueue(s.runCtx, s.engine.Diff, s.store, s.hub.broadcast, s.reconcileHeadGone, s.metrics, s.log, cfg.MaxDiffConcurrency, nil)
 	return s
 }
 
@@ -209,9 +207,7 @@ func TestServer_WebhookRelistCoalesces(t *testing.T) {
 		}
 	}
 	s := newTestServer(t, ghCfg("tok"), prov, okEngine())
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go s.relistWorker(ctx)
+	go s.relistWorker(t.Context())
 
 	// First trigger: the worker enters ListPRs and blocks there.
 	s.requestRelist()


### PR DESCRIPTION
## Why

Part of a post-merge code-review pass: apply the **Go 1.26** stdlib idioms gopls flags (the repo is on `go 1.26.4`; `errors.AsType` and `strings.SplitSeq` both exist). Pure mechanical modernization — no behaviour change.

## What

- **`errors.As(&t)` → `errors.AsType[T]`** (Go 1.26's generic form — drops the `var t T` declaration):
  - `provider/github.go` `RateLimit` (×2: `*github.RateLimitError`, `*github.AbuseRateLimitError`)
  - `gitclone/gitclone.go` `mirrorCorrupt` (the `net.Error` transient check)
  - `provider/writer.go` `githubStatus` (`*github.ErrorResponse`)
- **`strings.Split` → idiom**:
  - `server/handlers.go` `ifNoneMatch` → `strings.SplitSeq` (ranges without allocating the full slice)
  - `server/markdown.go` `reviewURLFromRequest` → `strings.Cut` (replacing `Split(…)[0]`)
- **`context.WithCancel(context.Background())` → `t.Context()`** in the server test harness (`newTestServer`) and the relist-worker test.

Deliberately **left** with explicit cancels: `engine/cachegc_test.go` (calls `cancel()` mid-test to stop the sweep before `<-done`) and `provider/writer.go`'s write-back test (pre-cancels to exercise the already-cancelled path) — `t.Context()` would change their behaviour.

Local: `go build ./...`, `go test ./...`, `go test -race ./internal/server/ ./internal/gitclone/`, `lint` (0 issues), `vet`, `fmt-check`, `tidy-check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
