### PR TITLE
fix(server): coalesce check-status webhooks per head SHA

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -498,7 +498,11 @@ func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	// change (opened/closed/...) or an opaque payload re-lists.
 	switch ev := webhook.Parse(s.cfg.Forge.Kind, r.Header, body); {
 	case ev.HeadSHA != "":
-		go s.refreshChecksForSHA(s.runCtx, ev.HeadSHA)
+		// Coalesce per head SHA: one CI cycle delivers a storm of
+		// check_run/check_suite events, so requestCheckRefresh folds them into at
+		// most one in-flight Checks poll plus one trailing poll instead of a
+		// goroutine + two forge calls per event (see requestCheckRefresh).
+		s.requestCheckRefresh(ev.HeadSHA)
 	case ev.PR > 0 && !ev.Relist:
 		go func() {
 			if err := s.refreshPR(s.runCtx, ev.PR, "webhook"); err != nil {
@@ -618,7 +622,10 @@ func (s *Server) refreshChecksForSHA(ctx context.Context, sha string) {
 	}
 	rollup, err := s.prov.Checks(ctx, pr)
 	if err != nil {
-		s.log.Debug("webhook checks fetch failed", "pr", pr.Number, "error", err)
+		// Warn, not Debug: a webhook-driven refresh is a targeted update for a head
+		// someone is watching, and on failure its rollup is stranded until the next
+		// list poll (KONFLATE_REFRESH_INTERVAL). Surface it rather than swallow it.
+		s.log.Warn("webhook checks fetch failed", "pr", pr.Number, "sha", sha, "error", err)
 		return
 	}
 	if s.store.setChecks(pr.Number, rollup) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -72,6 +72,21 @@ type Server struct {
 	// rather than a goroutine + forge ListPRs per event. Buffered, created in New.
 	relist chan struct{}
 
+	// checkRefresh coalesces webhook-triggered check-rollup refreshes per head
+	// SHA. One PR's CI cycle delivers a storm of check_run/check_suite events (a
+	// Renovate batch, many heads at once); fanning out a goroutine + two forge
+	// calls per event both hammered the forge — risking a secondary rate limit
+	// that silently dropped the refresh, stranding a mid-CI snapshot until the
+	// next list poll — and re-polled the same head dozens of times. checkWake
+	// (single-token, created in New) nudges checkRefreshWorker, which drains
+	// checkPending one SHA at a time: a burst for one head collapses to at most
+	// one in-flight Checks poll plus one trailing poll, and distinct heads are
+	// polled serially, never in a concurrent fan-out. checkPending is guarded by
+	// checkMu.
+	checkWake    chan struct{}
+	checkMu      sync.Mutex
+	checkPending map[string]struct{}
+
 	avatarKey   []byte             // HMAC key for signing the same-origin /api/avatar proxy URLs
 	mergeTmpl   *template.Template // renders the "copy to merge" command; nil disables it
 	commentTmpl *template.Template // renders a custom PR-comment body; nil uses the default summary
@@ -95,10 +110,12 @@ func New(cfg *config.Config, prov provider.Provider, eng Engine, ui fs.FS, log *
 	s := &Server{
 		cfg: cfg, prov: prov, writer: writer, engine: eng, ui: ui, log: log,
 		store: newStore(), hub: newHub(log), metrics: newMetrics(), sync: newSyncTracker(),
-		avatarKey:   avatarKey,
-		mergeTmpl:   newMergeTemplate(cfg, log),
-		commentTmpl: newCommentTemplate(cfg, log),
-		relist:      make(chan struct{}, 1),
+		avatarKey:    avatarKey,
+		mergeTmpl:    newMergeTemplate(cfg, log),
+		commentTmpl:  newCommentTemplate(cfg, log),
+		relist:       make(chan struct{}, 1),
+		checkWake:    make(chan struct{}, 1),
+		checkPending: make(map[string]struct{}),
 	}
 
 	// Durability: persist rendered diffs under the (operator-persisted) cache
@@ -527,6 +544,7 @@ func (s *Server) Run(ctx context.Context) error {
 	go s.refreshList(gctx)
 	go s.refreshLoop(gctx)
 	go s.relistWorker(gctx)
+	go s.checkRefreshWorker(gctx)
 
 	g.Go(func() error { return serve(mainSrv, "main", s.log) })
 	g.Go(func() error { return serve(metricsSrv, "metrics", s.log) })
@@ -578,6 +596,57 @@ func (s *Server) relistWorker(ctx context.Context) {
 			return
 		case <-s.relist:
 			s.refreshList(ctx)
+		}
+	}
+}
+
+// requestCheckRefresh queues a check-rollup refresh for the open PR whose head is
+// sha, coalescing per SHA (see the checkRefresh fields): repeated triggers for
+// the same head — the storm of check_run/check_suite events one CI cycle delivers
+// — fold into a single pending entry, and one arriving while that head's refresh
+// is in flight schedules exactly one trailing poll. Never blocks the caller (the
+// webhook handler): checkRefreshWorker does the forge I/O.
+func (s *Server) requestCheckRefresh(sha string) {
+	if sha == "" {
+		return
+	}
+	s.checkMu.Lock()
+	s.checkPending[sha] = struct{}{}
+	s.checkMu.Unlock()
+	select {
+	case s.checkWake <- struct{}{}:
+	default: // worker already nudged; it drains every pending SHA before sleeping
+	}
+}
+
+// checkRefreshWorker serializes webhook-triggered check refreshes: on each wake it
+// drains the pending-SHA set one head at a time through refreshChecksForSHA, so a
+// burst of check events can't fan out into a swarm of concurrent forge calls. A
+// trigger that arrives while a head's refresh runs re-adds it, yielding exactly
+// one trailing poll — which lands after the storm settles, i.e. once the checks
+// have actually completed, rather than capturing a mid-CI snapshot. Returns when
+// ctx is cancelled.
+func (s *Server) checkRefreshWorker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.checkWake:
+		}
+		for ctx.Err() == nil {
+			s.checkMu.Lock()
+			sha := ""
+			for k := range s.checkPending {
+				sha = k
+				break
+			}
+			if sha == "" {
+				s.checkMu.Unlock()
+				break // drained; wait for the next wake
+			}
+			delete(s.checkPending, sha)
+			s.checkMu.Unlock()
+			s.refreshChecksForSHA(ctx, sha)
 		}
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -32,19 +32,23 @@ import (
 // --- fakes ---------------------------------------------------------------
 
 type fakeProvider struct {
-	mu       sync.Mutex
-	prs      []api.PR       // the open list ListPRs returns
-	details  map[int]api.PR // GetPR overrides (e.g. a departed PR's merged/closed state)
-	notFound map[int]bool   // numbers GetPR reports as deleted (provider.ErrPRNotFound)
-	listErr  error
-	listHook func()                  // optional seam invoked at the start of each ListPRs (set before use)
-	checks   map[int]api.CheckRollup // per-PR CI rollup Checks returns (zero value → none)
+	mu         sync.Mutex
+	prs        []api.PR       // the open list ListPRs returns
+	details    map[int]api.PR // GetPR overrides (e.g. a departed PR's merged/closed state)
+	notFound   map[int]bool   // numbers GetPR reports as deleted (provider.ErrPRNotFound)
+	listErr    error
+	listHook   func()                  // optional seam invoked at the start of each ListPRs (set before use)
+	checksHook func()                  // optional seam invoked at the start of each Checks (set before use)
+	checks     map[int]api.CheckRollup // per-PR CI rollup Checks returns (zero value → none)
 
 	listCalls   int // ListPRs invocations (read via callCounts)
 	checksCalls int // Checks invocations (read via callCounts)
 }
 
 func (f *fakeProvider) Checks(_ context.Context, pr api.PR) (api.CheckRollup, error) {
+	if f.checksHook != nil {
+		f.checksHook() // outside the lock so a hook may block without wedging the fake
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.checksCalls++
@@ -212,6 +216,54 @@ func TestServer_WebhookRelistCoalesces(t *testing.T) {
 	time.Sleep(50 * time.Millisecond) // let any erroneous extra run surface
 	if got := calls.Load(); got != 2 {
 		t.Fatalf("ListPRs calls = %d, want 2 (one in-flight + one coalesced trailing run)", got)
+	}
+}
+
+// TestServer_CheckRefreshCoalesces verifies a burst of check-status webhooks for
+// one head SHA collapses to one in-flight Checks poll plus one trailing poll,
+// rather than a forge call per event — the fix for a CI cycle (or a Renovate
+// batch) delivering dozens of check_run/check_suite deliveries that otherwise fan
+// out into a concurrent burst of forge calls.
+func TestServer_CheckRefreshCoalesces(t *testing.T) {
+	t.Parallel()
+	const sha = "deadbeefcafe"
+	var calls atomic.Int32
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	prov := &fakeProvider{}
+	prov.checksHook = func() {
+		if calls.Add(1) == 1 {
+			entered <- struct{}{} // the first refresh is now in flight
+			<-release             // hold it so a burst can pile up behind it
+		}
+	}
+	s := newTestServer(t, ghCfg("tok"), prov, okEngine())
+	s.store.upsertPR(api.PR{Number: 7, HeadSHA: sha, Open: true}, false) // so prByHeadSHA(sha) resolves
+	go s.checkRefreshWorker(t.Context())
+
+	// First trigger: the worker enters Checks and blocks there.
+	s.requestCheckRefresh(sha)
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("check-refresh worker never started the first run")
+	}
+
+	// A burst for the same head arrives while that refresh is in flight; it must
+	// coalesce, not fan out into a Checks call per event.
+	for range 5 {
+		s.requestCheckRefresh(sha)
+	}
+	close(release) // let the in-flight refresh finish; the worker then drains one trailing entry
+
+	// Exactly two Checks calls: the in-flight refresh + one coalesced trailing poll.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && calls.Load() < 2 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	time.Sleep(50 * time.Millisecond) // let any erroneous extra run surface
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("Checks calls = %d, want 2 (one in-flight + one coalesced trailing poll)", got)
 	}
 }
 


### PR DESCRIPTION
## What

Collapse the per-event goroutine fan-out on inbound check-status webhooks into a single, per-head-SHA coalescing worker — mirroring the existing `requestRelist`/`relistWorker` pattern.

## Why

Diagnosed from a live authenticated instance (onedr0p/home-ops): check rollups would sit at a stale **`pending` mid-CI snapshot** while GitHub showed all checks green, then self-correct only at the 30m list poll.

home-ops (and most home-ops repos) run **check-runs-based CI** (GitHub Actions) — every PR's legacy combined status is empty (`pending`/0 statuses) and all real CI lives in check runs. GitHub fires a `check_run`/`check_suite` webhook for **each run's each state change** (queued → in_progress → completed) plus the suite, so one PR's CI cycle delivers ~15–20 deliveries, and a **Renovate batch multiplies that across many heads at once** (~hundreds in under a minute).

The handler did `go s.refreshChecksForSHA(...)` per event — an unbounded goroutine doing **two forge calls each**. A batch therefore fanned out into hundreds of near-concurrent GitHub calls, which:

1. **risks GitHub's secondary (concurrent-request) rate limit** — on which `Checks()` errors, and the refresh was silently dropped (logged at `Debug`), leaving whatever the last successful poll wrote: a mid-CI `pending` snapshot captured by the relist that ran right after the force-push. Nothing corrects it until the 30m backstop; and
2. **re-polls the same head dozens of times** for no benefit.

The decisive evidence: PRs whose CI completed in a tight burst stayed stale, while PRs that completed *in isolation* (and later) refreshed within seconds — i.e. check webhooks work; only the **burst** failed.

## How

- **`requestCheckRefresh(sha)`** marks the SHA pending (dedup map) and nudges a single-token wake channel — never blocks the webhook handler.
- **`checkRefreshWorker`** drains pending heads **one at a time** through `refreshChecksForSHA`. A burst for one head collapses to **one in-flight `Checks` poll + one trailing poll** (the trailing poll lands *after* the storm settles — once the checks have actually completed — rather than capturing a mid-CI snapshot), and distinct heads are polled **serially**, never in a concurrent fan-out.
- Surface a webhook check-fetch failure at **`Warn`** instead of `Debug`: on failure the rollup is stranded until the next list poll, so it shouldn't be swallowed silently.

No config, metric, endpoint, UI, or chart changes — purely an internal robustness fix.

## Test

`TestServer_CheckRefreshCoalesces` fires a burst of 5 triggers for one head while the first refresh is held in flight, and asserts exactly **2** `Checks` calls (in-flight + one coalesced trailing), not 6 — mirroring `TestServer_WebhookRelistCoalesces`.

## Verification

`go build` · `go test ./...` · `go test -race ./internal/server/ ./internal/gitclone/` · `mise run lint` (0 issues) · `vet` · `fmt-check` · `tidy-check` — all green.