### PR TITLE
perf(server): skip the redundant per-record re-marshal at startup

### DIFF
--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -98,7 +98,12 @@ func (s *store) loadFrom(p *persist.Store, log *slog.Logger) {
 		if rec.Result != nil {
 			j.signals = computeSignals(rec.Result)
 		}
-		j.savedDigest = contentDigest(rec) // so an identical re-render after restart skips re-writing
+		// savedDigest is left zero (unknown) on load: seeding it would re-marshal
+		// every multi-MB record at startup — a second full pass on top of the decode
+		// persist.Load just did — purely to skip the first post-restart rewrite. Not
+		// worth it: leaving it zero costs at most one rewrite per PR on its first
+		// re-render after a restart, then it stabilises, whereas the marshal is paid
+		// for the whole shelf on every boot (the load path is the cold-start cost).
 		s.jobs[rec.PR.Number] = j
 	}
 }

--- a/internal/server/store_persist_test.go
+++ b/internal/server/store_persist_test.go
@@ -101,6 +101,44 @@ func TestStore_SkipsUnchangedWrites(t *testing.T) {
 	}
 }
 
+// TestStore_LoadDoesNotSeedDigest documents the cold-start trade: loadFrom
+// deliberately leaves savedDigest zero rather than re-marshal every multi-MB
+// record at boot just to seed it. The cost is that the FIRST re-render of a
+// restored PR rewrites even when the diff is identical (then it stabilises) —
+// the inverse of TestStore_SkipsUnchangedWrites, which is the in-process case.
+func TestStore_LoadDoesNotSeedDigest(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	newP := func() *persist.Store {
+		p, err := persist.New(dir, discardLog())
+		if err != nil {
+			t.Fatalf("persist.New: %v", err)
+		}
+		return p
+	}
+
+	// Process 1: render and persist an open PR.
+	s1 := newStore()
+	s1.loadFrom(newP(), discardLog())
+	s1.upsertPR(api.PR{Number: 1, HeadSHA: "a", Open: true}, false)
+	s1.setResult(1, api.DiffResult{PRNumber: 1, HeadSHA: "a"})
+
+	// Process 2: a fresh store loads it; savedDigest is intentionally not seeded.
+	s2 := newStore()
+	s2.loadFrom(newP(), discardLog())
+
+	file := filepath.Join(dir, "1.json.zst")
+	if err := os.Remove(file); err != nil { // delete behind the store's back
+		t.Fatalf("remove: %v", err)
+	}
+	// An identical re-render after the "restart" must rewrite — proving the digest
+	// was not seeded at load (contrast the in-process no-op above).
+	s2.setResult(1, api.DiffResult{PRNumber: 1, HeadSHA: "a"})
+	if _, err := os.Stat(file); err != nil {
+		t.Fatalf("first post-restart re-render should rewrite the file: %v", err)
+	}
+}
+
 // TestServer_DropsFilteredOnLoad verifies the persistence ⨯ PR-filter
 // interaction: a merged-shelf entry restored from disk that the *current* filter
 // excludes (a fork, after the operator tightens to !pr.fork) is dropped on load


### PR DESCRIPTION
## What

`loadFrom` seeded `savedDigest` by calling `contentDigest(rec)` for **every** restored PR — a second full `json.Marshal` of each multi-MB diff, on top of the zstd-decode + `json.Unmarshal` that `persist.Load` just did — purely to skip the *first* post-restart rewrite of an identical diff. Drop the seed; leave `savedDigest` zero on load.

## Why

On a warm-volume restart (the common cold start: incremental fetch is cheap, loading the persisted diffs dominates), this **doubled the heaviest part of startup** — a full marshal of the whole shelf — for a micro-optimization. `persist`'s own design notes that decode is what dominates boot; re-marshaling on top is the avoidable half.

## Cost of the change

At most **one rewrite per PR** on its first re-render after a restart (then `savedDigest` is set by that write and it stabilises) — trivial next to marshaling every record on every boot, and restarts are rare. The in-process identical-re-render no-op (`TestStore_SkipsUnchangedWrites`) is unchanged; only the cross-restart first render rewrites once.

## Test

`TestStore_LoadDoesNotSeedDigest` documents the trade: after a simulated restart, an identical re-render *does* rewrite (proving the digest wasn't seeded at load), the inverse of the in-process no-op.

## Verification

`go build` · `go test ./...` · `mise run lint` (0) · `vet` · `fmt-check` — all green. Go-only; no config/chart/UI surface.

---

Follow-up from the load-path review. The other candidate — deduping the per-PR `ChromaCSS` — I scoped and **do not recommend**: it's ~10 KB/record (~7% of a small diff, but zstd already compresses the duplication to ~1–2 KB/file on disk), and a correct dedup needs an `Engine`-interface change plus rewriting the diff package's CSS tests and the handler escaping/ETag tests — disproportionate churn for a sub-100 ms decode trim. Left as-is.