### PR TITLE
feat(chart): add deploymentAnnotations

### DIFF
--- a/charts/konflate/README.md
+++ b/charts/konflate/README.md
@@ -74,6 +74,7 @@ Kubernetes: `>=1.25.0-0`
 | config.sourceRetryAttempts | string | `""` | Advanced: tries per source fetch on transient network errors. Empty = default (3); "1" disables retry. |
 | config.statusCheckName | string | `""` | Name the commit status konflate posts under (the required-check name in branch-protection rules). Empty uses the default, "Konflate". |
 | config.statusChecks | bool | `false` | Opt-in: post a commit status on each rendered PR head. Needs a write credential (`secret.writeToken`, or the GitHub App) and stays off until both are set. |
+| deploymentAnnotations | object | `{}` | Annotations added to the Deployment object (e.g. `reloader.stakater.com/auto: "true"` to roll the pod when the mounted Secret / PR-comment-template ConfigMap changes). Pod-level annotations go in `podAnnotations`. |
 | fullnameOverride | string | `""` | Override the full release name. |
 | httpRoute.additionalRules | list | `[]` | Custom rules prepended before the default rule (templated). |
 | httpRoute.annotations | object | `{}` | HTTPRoute annotations. |

--- a/charts/konflate/templates/deployment.tpl
+++ b/charts/konflate/templates/deployment.tpl
@@ -15,6 +15,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "konflate.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   # konflate keeps PR/diff state in memory, so run a single instance and replace

--- a/charts/konflate/tests/deployment_test.yaml
+++ b/charts/konflate/tests/deployment_test.yaml
@@ -19,6 +19,20 @@ tests:
           path: spec.template.spec.containers[0].image
           value: ghcr.io/home-operations/konflate@sha256:deadbeef
 
+  - it: omits Deployment annotations by default
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: sets Deployment annotations from deploymentAnnotations
+    set:
+      deploymentAnnotations:
+        reloader.stakater.com/auto: "true"
+    asserts:
+      - equal:
+          path: metadata.annotations["reloader.stakater.com/auto"]
+          value: "true"
+
   - it: uses an explicit tag when no digest is set
     set:
       image.tag: v1.2.3

--- a/charts/konflate/values.schema.json
+++ b/charts/konflate/values.schema.json
@@ -191,6 +191,12 @@
       "title": "config",
       "type": "object"
     },
+    "deploymentAnnotations": {
+      "description": "Annotations added to the Deployment object (e.g. `reloader.stakater.com/auto: \"true\"` to roll the pod when the mounted Secret / PR-comment-template ConfigMap changes). Pod-level annotations go in `podAnnotations`.",
+      "required": [],
+      "title": "deploymentAnnotations",
+      "type": "object"
+    },
     "fullnameOverride": {
       "default": "",
       "description": "Override the full release name.",

--- a/charts/konflate/values.yaml
+++ b/charts/konflate/values.yaml
@@ -213,6 +213,9 @@ serviceAccount:
   # -- ServiceAccount name; generated from the release name if empty.
   name: ""
 
+# -- Annotations added to the Deployment object (e.g. `reloader.stakater.com/auto: "true"` to roll the pod when the mounted Secret / PR-comment-template ConfigMap changes). Pod-level annotations go in `podAnnotations`.
+deploymentAnnotations: {}
+
 # -- Annotations added to the pod.
 podAnnotations: {}
 # -- Labels added to the pod.


### PR DESCRIPTION
Adds a `deploymentAnnotations` value that renders onto the Deployment object's `metadata.annotations`, matching the pattern already in the sibling charts ([kromgo #247](https://github.com/home-operations/kromgo/pull/247), gatus-sidecar #83).

## Why

The chart already exposes `podAnnotations` (pod template) but had no way to annotate the **Deployment** itself. The motivating case is [Stakater Reloader](https://github.com/stakater/Reloader): `reloader.stakater.com/auto: "true"` on the Deployment rolls the pod when the mounted Secret (write credentials) or the PR-comment-template ConfigMap changes — without it, a `secret.*` or `config.prCommentTemplate` edit needs a manual restart to take effect.

## Change

- `deployment.tpl` — emit `metadata.annotations` via `{{- with .Values.deploymentAnnotations }}` (omitted entirely when empty, so no blank `annotations:` block).
- `values.yaml` — `deploymentAnnotations: {}` with a helm-docs `# --` comment distinguishing it from `podAnnotations`.
- Regenerated `values.schema.json` + `README.md`.
- helm-unittest: two cases — absent by default (`notExists`), present when set.

## Verify

- `helm-unittest` — 64 pass (incl. the 2 new cases)
- `helm-lint` — 0 failed
- `helm template` — annotation renders after `labels:` when set; no empty block when unset
- `generate-check` — schema/README in sync