### PR TITLE
fix(provider): resend check-run started_at so GitHub stops inflating its duration

### DIFF
--- a/internal/provider/writer.go
+++ b/internal/provider/writer.go
@@ -398,6 +398,10 @@ func (w *githubWriter) ChecksSupported() bool { return w.app }
 // CheckRun creates konflate's Check Run on the PR head, or updates the existing one
 // for that head SHA in place (found by the check name) so a re-render of the same
 // commit refreshes a single check rather than stacking duplicates.
+//
+// Both posts pin started_at = completed_at = now: konflate renders and then posts a
+// single terminal result (there is no in_progress phase), so the run has no real
+// elapsed time and GitHub should display none.
 func (w *githubWriter) CheckRun(ctx context.Context, pr api.PR, res CheckResult) error {
 	completed, now := "completed", github.Timestamp{Time: time.Now()}
 	output := &github.CheckRunOutput{Title: &res.Title, Summary: &res.Summary}
@@ -407,14 +411,32 @@ func (w *githubWriter) CheckRun(ctx context.Context, pr api.PR, res CheckResult)
 		return err
 	}
 	if id != 0 {
-		_, resp, err := w.client.Checks.UpdateCheckRun(ctx, w.owner, w.repo, id, github.UpdateCheckRunOptions{
-			Name:        res.Name,
-			Status:      &completed,
-			Conclusion:  &res.Conclusion,
-			CompletedAt: &now,
-			DetailsURL:  strOrNil(res.DetailsURL),
-			Output:      output,
-		})
+		// go-github's UpdateCheckRunOptions can't carry started_at, but the REST API
+		// accepts it and we must resend it: otherwise GitHub keeps the run's original
+		// started_at while completed_at advances on each re-render, showing a bogus,
+		// ever-growing "Completed in Nm". Hand-build the PATCH the typed helper would
+		// send (same URL and preview Accept header), plus started_at.
+		body := struct {
+			github.UpdateCheckRunOptions
+			StartedAt *github.Timestamp `json:"started_at,omitempty"`
+		}{
+			UpdateCheckRunOptions: github.UpdateCheckRunOptions{
+				Name:        res.Name,
+				Status:      &completed,
+				Conclusion:  &res.Conclusion,
+				CompletedAt: &now,
+				DetailsURL:  strOrNil(res.DetailsURL),
+				Output:      output,
+			},
+			StartedAt: &now,
+		}
+		req, err := w.client.NewRequest(ctx, http.MethodPatch,
+			fmt.Sprintf("repos/%s/%s/check-runs/%d", w.owner, w.repo, id), body)
+		if err != nil {
+			return fmt.Errorf("github: update check run #%d: %w", pr.Number, err)
+		}
+		req.Header.Set("Accept", "application/vnd.github.antiope-preview+json")
+		resp, err := w.client.Do(req, nil)
 		if err != nil {
 			return rejectedIf(githubStatus(resp, err), fmt.Errorf("github: update check run #%d: %w", pr.Number, err))
 		}
@@ -425,6 +447,7 @@ func (w *githubWriter) CheckRun(ctx context.Context, pr api.PR, res CheckResult)
 		HeadSHA:     pr.HeadSHA,
 		Status:      &completed,
 		Conclusion:  &res.Conclusion,
+		StartedAt:   &now,
 		CompletedAt: &now,
 		DetailsURL:  strOrNil(res.DetailsURL),
 		Output:      output,

--- a/internal/provider/writer_test.go
+++ b/internal/provider/writer_test.go
@@ -76,12 +76,14 @@ func TestGitHubWriter_CheckRun(t *testing.T) {
 	t.Run("creates a check run when none exists", func(t *testing.T) {
 		t.Parallel()
 		var created struct {
-			Name       string `json:"name"`
-			HeadSHA    string `json:"head_sha"`
-			Status     string `json:"status"`
-			Conclusion string `json:"conclusion"`
-			DetailsURL string `json:"details_url"`
-			Output     struct {
+			Name        string `json:"name"`
+			HeadSHA     string `json:"head_sha"`
+			Status      string `json:"status"`
+			Conclusion  string `json:"conclusion"`
+			StartedAt   string `json:"started_at"`
+			CompletedAt string `json:"completed_at"`
+			DetailsURL  string `json:"details_url"`
+			Output      struct {
 				Title, Summary string
 			} `json:"output"`
 		}
@@ -109,23 +111,28 @@ func TestGitHubWriter_CheckRun(t *testing.T) {
 			created.Output.Title != "1 caution" || created.Output.Summary != "### konflate — summary" {
 			t.Errorf("create payload = %+v", created)
 		}
+		if created.StartedAt == "" || created.StartedAt != created.CompletedAt {
+			t.Errorf("create started_at=%q completed_at=%q, want equal and non-empty", created.StartedAt, created.CompletedAt)
+		}
 	})
 
 	t.Run("updates the existing run for the head SHA", func(t *testing.T) {
 		t.Parallel()
-		var patched string
-		var conclusion string
+		var patched, method string
+		var conclusion, startedAt, completedAt string
 		mux := http.NewServeMux()
 		mux.HandleFunc("/repos/acme/web/commits/"+sha+"/check-runs", func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = w.Write([]byte(`{"total_count":1,"check_runs":[{"id":42,"name":"konflate"}]}`))
 		})
 		mux.HandleFunc("/repos/acme/web/check-runs/42", func(w http.ResponseWriter, r *http.Request) {
-			patched = r.URL.Path
+			patched, method = r.URL.Path, r.Method
 			var body struct {
-				Conclusion string `json:"conclusion"`
+				Conclusion  string `json:"conclusion"`
+				StartedAt   string `json:"started_at"`
+				CompletedAt string `json:"completed_at"`
 			}
 			_ = json.NewDecoder(r.Body).Decode(&body)
-			conclusion = body.Conclusion
+			conclusion, startedAt, completedAt = body.Conclusion, body.StartedAt, body.CompletedAt
 			_, _ = w.Write([]byte(`{"id":42}`))
 		})
 		mux.HandleFunc("/repos/acme/web/check-runs", func(w http.ResponseWriter, _ *http.Request) {
@@ -142,8 +149,13 @@ func TestGitHubWriter_CheckRun(t *testing.T) {
 		if err != nil {
 			t.Fatalf("CheckRun (update): %v", err)
 		}
-		if patched != "/repos/acme/web/check-runs/42" || conclusion != "success" {
-			t.Errorf("update path=%q conclusion=%q, want .../check-runs/42 + success", patched, conclusion)
+		if patched != "/repos/acme/web/check-runs/42" || method != http.MethodPatch || conclusion != "success" {
+			t.Errorf("update path=%q method=%q conclusion=%q, want PATCH .../check-runs/42 + success", patched, method, conclusion)
+		}
+		// started_at must be resent on update and equal completed_at, else GitHub shows
+		// an ever-growing "Completed in Nm" as completed_at advances each re-render.
+		if startedAt == "" || startedAt != completedAt {
+			t.Errorf("update started_at=%q completed_at=%q, want equal and non-empty", startedAt, completedAt)
 		}
 	})
 


### PR DESCRIPTION
GitHub was showing konflate's commit check as e.g. **"Konflate — Completed in 694m"** — a wildly wrong duration.

## Root cause

A GitHub Check Run's displayed duration is `completed_at − started_at`. [`CheckRun`](internal/provider/writer.go) posts the run as already `completed` with `CompletedAt: now` but never set `started_at`:

- **Create** — fine: GitHub defaults `started_at` to creation time, so the first post shows ~0s.
- **Update** — broken: GitHub **preserves the run's original `started_at`** and only advances `completed_at`. konflate updates the same run in place (matched by head SHA) on every refresh — the periodic re-render *and* every webhook-triggered `requestCheckRefresh` (which fires whenever another CI check reports on that commit). So `started_at` stays frozen at "first seen" while `completed_at` marches forward. **694m was just how long that head SHA had been tracked**, not render time.

## Fix

konflate renders and then posts a single terminal result (no `in_progress` phase), so the run has no real elapsed time — `started_at` should equal `completed_at`. Both are now pinned to `now`.

The catch: go-github's `UpdateCheckRunOptions` has no `StartedAt` field (only `CreateCheckRunOptions` does), though the REST API accepts `started_at` on `PATCH .../check-runs/{id}`. So the update path hand-builds the PATCH the typed helper would send (same URL + preview `Accept` header) with `started_at` added. Create just sets the existing field.

## Verify

- `go test ./...`, `-race` on provider + server — pass
- `writer_test.go` update case now asserts the request is a `PATCH` and `started_at == completed_at` (non-empty); create case asserts the same
- `lint` 0 issues, `vet` / `fmt-check` / `tidy-check` clean
- No UI/chart changes