### PR TITLE
fix(gitclone): repack mirrors containing submodules without re-cloning

### DIFF
--- a/internal/gitclone/gitclone.go
+++ b/internal/gitclone/gitclone.go
@@ -25,9 +25,11 @@ import (
 	"github.com/go-git/go-git/v5"
 	gitconfig "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/filemode"
 	"github.com/go-git/go-git/v5/plumbing/format/idxfile"
 	"github.com/go-git/go-git/v5/plumbing/format/packfile"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/storer"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 )
 
@@ -322,12 +324,11 @@ func mirrorCorrupt(err error) bool {
 var repackPackThreshold = 50
 
 // maybeRepack folds the mirror's packfiles into one when they have piled up past
-// repackPackThreshold, reporting whether it did. go-git's RepackObjects writes a
-// single new pack holding every object reachable from the mirror's refs — so the
-// unreachable objects a force-push leaves behind are reclaimed too — then deletes
-// the superseded packs. That deletion invalidates the open handle's cached pack
-// set, so the caller must re-open the mirror before reading objects through it.
-// Caller holds the lock.
+// repackPackThreshold, reporting whether it did. repackMirror writes a single new
+// pack holding every object reachable from the mirror's refs — so the unreachable
+// objects a force-push leaves behind are reclaimed too — then deletes the superseded
+// packs. That deletion invalidates the open handle's cached pack set, so the caller
+// must re-open the mirror before reading objects through it. Caller holds the lock.
 func (m *Mirror) maybeRepack(repo *git.Repository) (bool, error) {
 	n, err := m.countPacks()
 	if err != nil {
@@ -336,12 +337,145 @@ func (m *Mirror) maybeRepack(repo *git.Repository) (bool, error) {
 	if n < repackPackThreshold {
 		return false, nil
 	}
-	// The zero RepackConfig uses OFS deltas and a zero OnlyDeletePacksOlderThan,
-	// which imposes no age floor — every superseded pack is removed.
-	if err := repo.RepackObjects(&git.RepackConfig{}); err != nil {
+	if err := repackMirror(repo); err != nil {
 		return false, fmt.Errorf("gitclone: repack mirror: %w", err)
 	}
 	return true, nil
+}
+
+// repackMirror consolidates every packfile into one holding the objects reachable
+// from the mirror's refs, then deletes the superseded packs — the `git gc` go-git
+// won't run on its own.
+//
+// It stands in for go-git's Repository.RepackObjects, whose object walker recurses
+// into gitlink (submodule) tree entries: it calls GetObject on a commit that lives
+// in the submodule's own repository, never this one, so any repack of a repo that
+// contains a submodule fails with "object not found". (konflate then misread that
+// as a damaged store and "healed" it with a pointless re-clone, every repack,
+// forever.) The walk here treats a submodule entry as a leaf, exactly as git does
+// at a submodule boundary. A genuinely missing object — real damage — still surfaces
+// from the walk or the encoder, and mirrorCorrupt classifies it as corruption.
+func repackMirror(repo *git.Repository) error {
+	pos, ok := repo.Storer.(storer.PackedObjectStorer)
+	if !ok {
+		return errors.New("gitclone: storer is not a PackedObjectStorer")
+	}
+	oldPacks, err := pos.ObjectPacks()
+	if err != nil {
+		return err
+	}
+
+	seen := make(map[plumbing.Hash]struct{})
+	refs, err := repo.References()
+	if err != nil {
+		return err
+	}
+	defer refs.Close()
+	if err := refs.ForEach(func(ref *plumbing.Reference) error {
+		if ref.Type() != plumbing.HashReference {
+			return nil
+		}
+		return walkReachable(repo.Storer, ref.Hash(), seen)
+	}); err != nil {
+		return err
+	}
+
+	newPack, err := writeObjectPack(repo, seen)
+	if err != nil {
+		return err
+	}
+
+	// Drop every pack the new one supersedes (no age floor); skip it if a no-op
+	// repack happened to reproduce the same hash.
+	for _, h := range oldPacks {
+		if h == newPack {
+			continue
+		}
+		if err := pos.DeleteOldObjectPackAndIndex(h, time.Time{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// walkReachable records h and every object reachable from it into seen, stopping at
+// gitlink (submodule) entries — their commit belongs to the submodule's repository,
+// not this one. Blobs are recorded by hash without being loaded; only commits,
+// trees, and tags are fetched, to follow their links.
+func walkReachable(s storer.EncodedObjectStorer, h plumbing.Hash, seen map[plumbing.Hash]struct{}) error {
+	if _, ok := seen[h]; ok {
+		return nil
+	}
+	obj, err := object.GetObject(s, h)
+	if err != nil {
+		return fmt.Errorf("walk %s: %w", h, err)
+	}
+	seen[h] = struct{}{}
+	switch o := obj.(type) {
+	case *object.Commit:
+		if err := walkReachable(s, o.TreeHash, seen); err != nil {
+			return err
+		}
+		for _, p := range o.ParentHashes {
+			if err := walkReachable(s, p, seen); err != nil {
+				return err
+			}
+		}
+	case *object.Tree:
+		for i := range o.Entries {
+			switch e := o.Entries[i]; e.Mode {
+			case filemode.Dir:
+				if err := walkReachable(s, e.Hash, seen); err != nil {
+					return err
+				}
+			case filemode.Submodule:
+				// A gitlink points at a commit in the submodule's repository, which
+				// this mirror never fetches. Recursing into it (as go-git's own
+				// walker does) would fail with "object not found"; skip it.
+			default:
+				seen[e.Hash] = struct{}{} // blob (regular/executable/symlink) — a leaf
+			}
+		}
+	case *object.Tag:
+		if err := walkReachable(s, o.Target, seen); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeObjectPack encodes objs into one new packfile in the repo's object store and
+// returns its hash, mirroring go-git's createNewObjectPack (OFS deltas, the
+// configured pack window). The writer must be closed before the caller deletes the
+// old packs, so the encode is scoped to this function. The mirror only ever holds
+// packed objects (clone and fetch both write packs, never loose), so there are no
+// loose copies to reclaim afterwards.
+func writeObjectPack(repo *git.Repository, objs map[plumbing.Hash]struct{}) (h plumbing.Hash, err error) {
+	pfw, ok := repo.Storer.(storer.PackfileWriter)
+	if !ok {
+		return h, errors.New("gitclone: storer is not a PackfileWriter")
+	}
+	wc, err := pfw.PackfileWriter()
+	if err != nil {
+		return h, err
+	}
+	defer func() {
+		if cerr := wc.Close(); err == nil {
+			err = cerr
+		}
+	}()
+
+	cfg, err := repo.Config()
+	if err != nil {
+		return h, err
+	}
+	hashes := make([]plumbing.Hash, 0, len(objs))
+	for hash := range objs {
+		hashes = append(hashes, hash)
+	}
+	// useRefDeltas=false → OFS deltas, matching go-git's zero RepackConfig.
+	enc := packfile.NewEncoder(wc, repo.Storer, false)
+	return enc.Encode(hashes, cfg.Pack.Window)
 }
 
 // countPacks returns the number of *.pack files in the mirror's object store. A

--- a/internal/gitclone/gitclone_test.go
+++ b/internal/gitclone/gitclone_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/filemode"
 	"github.com/go-git/go-git/v5/plumbing/format/idxfile"
 	"github.com/go-git/go-git/v5/plumbing/format/packfile"
 	"github.com/go-git/go-git/v5/plumbing/object"
@@ -202,6 +203,97 @@ func TestMirror_RebuildsOnCorruptObjectStore(t *testing.T) {
 	}
 	if _, err := rebuilt.Reference("refs/heads/ghost", false); err == nil {
 		t.Error("dangling ref survived the rebuild; mirror was not re-seeded")
+	}
+}
+
+// TestRepackMirror_SkipsSubmoduleGitlinks builds a repo whose tree carries a gitlink
+// (submodule) entry — its commit, by definition, lives in the submodule's own
+// repository and is absent here. go-git's RepackObjects walks into that commit and
+// fails with "object not found", which the mirror used to misread as corruption and
+// "heal" with a pointless re-clone on every repack. repackMirror must treat the
+// gitlink as a leaf, the way git does at a submodule boundary, and consolidate
+// cleanly. (The production case: JJGadgets/Biohazard's dots/k9s/.source submodule.)
+func TestRepackMirror_SkipsSubmoduleGitlinks(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, true) // bare, like the mirror
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := repo.Storer
+
+	store := func(o plumbing.EncodedObject) plumbing.Hash {
+		t.Helper()
+		h, err := s.SetEncodedObject(o)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return h
+	}
+
+	// A normal tracked blob.
+	blob := s.NewEncodedObject()
+	blob.SetType(plumbing.BlobObject)
+	bw, err := blob.Writer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = bw.Write([]byte("replicas: 3\n"))
+	_ = bw.Close()
+	blobHash := store(blob)
+
+	// A tree mixing that blob with a submodule gitlink whose commit is NOT present.
+	submodule := plumbing.NewHash("35893ce49b941c8a2b8706a50cfc35a449572231")
+	tree := &object.Tree{Entries: []object.TreeEntry{
+		{Name: "config.yaml", Mode: filemode.Regular, Hash: blobHash},
+		{Name: "vendored", Mode: filemode.Submodule, Hash: submodule},
+	}}
+	treeObj := s.NewEncodedObject()
+	if err := tree.Encode(treeObj); err != nil {
+		t.Fatal(err)
+	}
+	treeHash := store(treeObj)
+
+	when := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	commit := &object.Commit{
+		Author:    object.Signature{Name: "t", Email: "t@example.com", When: when},
+		Committer: object.Signature{Name: "t", Email: "t@example.com", When: when},
+		Message:   "repo with a submodule",
+		TreeHash:  treeHash,
+	}
+	commitObj := s.NewEncodedObject()
+	if err := commit.Encode(commitObj); err != nil {
+		t.Fatal(err)
+	}
+	commitHash := store(commitObj)
+	if err := s.SetReference(plumbing.NewHashReference("refs/heads/main", commitHash)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Documents the bug repackMirror works around: go-git's own RepackObjects walks
+	// into the gitlink and fails. A nil here would mean upstream fixed it.
+	if err := repo.RepackObjects(&git.RepackConfig{}); err == nil {
+		t.Log("go-git RepackObjects no longer fails on a gitlink — upstream may be fixed; repackMirror's workaround can be revisited")
+	}
+
+	if err := repackMirror(repo); err != nil {
+		t.Fatalf("repackMirror on a repo containing a submodule = %v, want success", err)
+	}
+
+	// The real objects survived the consolidation; the submodule commit was never
+	// needed and is (correctly) still absent.
+	reopened, err := git.PlainOpen(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reopened.CommitObject(commitHash); err != nil {
+		t.Errorf("commit missing after repack: %v", err)
+	}
+	if _, err := reopened.BlobObject(blobHash); err != nil {
+		t.Errorf("blob missing after repack: %v", err)
+	}
+	if _, err := reopened.Storer.EncodedObject(plumbing.AnyObject, submodule); !errors.Is(err, plumbing.ErrObjectNotFound) {
+		t.Errorf("submodule commit lookup = %v, want ErrObjectNotFound (it must never live in this repo)", err)
 	}
 }
 


### PR DESCRIPTION
Repos with a **git submodule** were logging `WARN rebuilding corrupt git mirror … repack mirror: getting object <sha> failed: object not found` and doing a full mirror re-clone on every repack — observed in production on `JJGadgets/Biohazard` (which vendors `dots/k9s/.source`).

## Root cause

The mirror was never corrupt. go-git's `Repository.RepackObjects` walks every object reachable from the refs, and its walker ([`object_walker.go`](https://github.com/go-git/go-git/blob/v5.19.1/object_walker.go)) recurses into **gitlink (submodule) tree entries** — it calls `GetObject` on the submodule's commit, which lives in the submodule's own repository and is never present in the parent. So every repack of a submodule repo fails with `object not found`. The real `git` CLI stops at submodule boundaries (`git fsck` reports the store healthy); go-git doesn't.

`mirrorCorrupt` then classified that `object not found` as a damaged store, so the mirror discarded itself and re-cloned — pointlessly, on **every** repack (~every 50 pack-adding renders), forever, since the re-clone still contains the submodule. The "Completed in 694m"-adjacent latency spikes were the re-clone head-of-line-blocking the render queue.

## Reproduction (deterministic)

A 50-fetch konflate-pattern loop (clone `main` single-branch → fetch `refs/pull/N/head` into one ref → `RepackObjects`) against the real repo hit the **exact** production object `35893ce…` at exactly 50 packs, on a fresh `/tmp` clone — ruling out disk corruption. `git ls-tree` confirmed `35893ce…` is the `dots/k9s/.source` gitlink.

## Fix

Replace `RepackObjects` with `repackMirror` — same consolidation (reachability walk → one OFS-delta pack at the configured window → delete superseded packs), but the walk treats a `filemode.Submodule` entry as a leaf, exactly as git does. No re-download, no behavior change for repos without submodules. `mirrorCorrupt` is unchanged: a genuinely missing object still surfaces (from the walk or the encoder) and still triggers a rebuild.

## Verification

- New `TestRepackMirror_SkipsSubmoduleGitlinks`: a repo whose tree carries a gitlink to an absent commit now repacks cleanly; the real objects survive and the submodule commit stays (correctly) absent.
- `TestMirror_RebuildsOnCorruptObjectStore` still passes — genuine corruption (a ghost ref) still self-heals.
- `TestMirror_RepacksWhenPacksAccumulate` still passes — non-submodule consolidation unchanged.
- Re-ran the reproduction with `repackMirror`: the repack at pr 5476 / 50 packs that previously failed now **succeeds** (50 packs → 1), all 72 PRs process clean.
- Full suite + `-race` on gitclone, `lint` (0 issues), `vet`, `fmt-check`, `tidy-check` — all green. No go.mod change (all imports are go-git subpackages already in the tree).

The underlying go-git walker bug (gitlinks in `walkObjectTree`) is worth reporting upstream; once fixed there, this can revert to `RepackObjects`.