### PR TITLE
build: standardize on the distroless/static:nonroot base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,14 @@ COPY internal/web/ ./
 RUN npm run build
 
 # ---- Go build -------------------------------------------------------------
-FROM golang:${GO_VERSION} AS builder
+FROM golang:${GO_VERSION}-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION=dev
 ARG REVISION=dev
+
+# upx (build stage only) compresses the final binary to shrink the image.
+RUN apk add --no-cache upx
 
 WORKDIR /workspace
 # Cache module downloads before copying source.
@@ -41,10 +44,11 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
     -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION}" \
     -o konflate ./cmd/konflate
 
+RUN upx --best --lzma konflate
+
 # ---- Runtime --------------------------------------------------------------
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/konflate /konflate
-USER 65532:65532
 EXPOSE 8080 9090
 ENTRYPOINT ["/konflate"]


### PR DESCRIPTION
Standardizes the image on the fleet base — **`gcr.io/distroless/static:nonroot`** runtime, built from a `golang-alpine` (+ `node-alpine` where the UI build needs it) builder with `upx` compression.

- **Runtime → `gcr.io/distroless/static:nonroot`** — it bundles CA certs, `/etc/passwd`, and a nonroot user (uid/gid **65532**), so the hand-rolled `COPY ca-certificates.crt` / `/etc/passwd` and the `USER` directive are dropped; the base provides them.
- **Builder → `golang:${GO_VERSION}-alpine`** (and `node:${NODE_VERSION}-alpine` where used), with `upx --best --lzma` on the binary — now consistent across the fleet.
- **Chart `podSecurityContext`** pins `runAsUser`/`runAsGroup`/`fsGroup: 65532` to match the base (where this repo ships a chart).

No behavior change — the static binary runs identically. Verified locally: the alpine-built, upx-compressed binary builds and serves on `distroless/static:nonroot`.
