### PR TITLE
fix(chart): set fsGroupChangePolicy OnRootMismatch (stateful cache volume)

### DIFF
--- a/charts/konflate/README.md
+++ b/charts/konflate/README.md
@@ -123,7 +123,7 @@ Kubernetes: `>=1.25.0-0`
 | podDisruptionBudget.maxUnavailable | string | `""` | Maximum pods that may be unavailable, as a count or percentage; takes precedence over `minAvailable` when set. @schema type: [integer, string] @schema |
 | podDisruptionBudget.minAvailable | int | `1` | Minimum pods that must stay available, as a count or percentage. Used unless `maxUnavailable` is set. @schema type: [integer, string] @schema |
 | podLabels | object | `{}` | Labels added to the pod. |
-| podSecurityContext | object | `{"fsGroup":65532,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod-level securityContext (runs as non-root uid/gid 65532 with the RuntimeDefault seccomp profile). |
+| podSecurityContext | object | `{"fsGroup":65532,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod-level securityContext (runs as non-root uid/gid 65532 with the RuntimeDefault seccomp profile). |
 | priorityClassName | string | `""` | PriorityClass for the pod, so konflate is less likely to be preempted/evicted under node pressure. Empty uses the cluster default. |
 | readinessProbe | object | `{"httpGet":{"path":"/readyz","port":"http"},"initialDelaySeconds":5,"periodSeconds":10}` | Readiness probe. |
 | replicaCount | int | `1` | Replica count; konflate is single-instance, so 0 or 1 only (a value >1 is rejected at render time). |

--- a/charts/konflate/values.schema.json
+++ b/charts/konflate/values.schema.json
@@ -693,6 +693,11 @@
           "title": "fsGroup",
           "type": "integer"
         },
+        "fsGroupChangePolicy": {
+          "default": "OnRootMismatch",
+          "title": "fsGroupChangePolicy",
+          "type": "string"
+        },
         "runAsGroup": {
           "default": 65532,
           "title": "runAsGroup",

--- a/charts/konflate/values.yaml
+++ b/charts/konflate/values.yaml
@@ -227,6 +227,7 @@ podSecurityContext:
   runAsUser: 65532
   runAsGroup: 65532
   fsGroup: 65532
+  fsGroupChangePolicy: OnRootMismatch
   seccompProfile:
     type: RuntimeDefault
 


### PR DESCRIPTION
konflate writes state to disk (the cache PVC), so its pod `fsGroup` (already 65532) gets an explicit ownership-fixup policy: **`fsGroupChangePolicy: OnRootMismatch`** — skip the recursive volume chown on startup when the root already matches the fsGroup (faster restarts on large caches). uid/gid/fsGroup remain the fleet-standard 65532.
