### PR TITLE
feat(chart): expose the Deployment update strategy (defaults to Recreate)

### DIFF
--- a/charts/konflate/README.md
+++ b/charts/konflate/README.md
@@ -143,6 +143,7 @@ Kubernetes: `>=1.25.0-0`
 | serviceAccount.create | bool | `true` | Create a ServiceAccount. |
 | serviceAccount.name | string | `""` | ServiceAccount name; generated from the release name if empty. |
 | startupProbe | object | `{}` | Startup probe (optional). Gates liveness/readiness while konflate starts — useful when a large persisted store (see `persistence`) makes the cold start slow, since it loads before serving. Empty disables it. |
+| strategy | object | `{"type":"Recreate"}` | Deployment update strategy. **Keep `Recreate`** — konflate is a single instance with in-memory PR/diff state and a ReadWriteOnce cache PVC, so a RollingUpdate (which surges a second pod even at replicaCount 1) diverges the in-memory stores and/or wedges on the volume's Multi-Attach error. Exposed only for parity with the other charts; `RollingUpdate` is unsupported here. |
 | terminationGracePeriodSeconds | int | `30` | Grace period for a clean shutdown. konflate drains in-flight renders and closes the HTTP/websocket servers on SIGTERM (it caps its own shutdown near 15s), so the default is ample; raise it only if you expect longer drains. |
 | tests.image.pullPolicy | string | `"IfNotPresent"` | `helm test` image pull policy. |
 | tests.image.repository | string | `"mirror.gcr.io/curlimages/curl"` | `helm test` connection-pod image; a gcr-mirrored curl, so the test never pulls from Docker Hub. |

--- a/charts/konflate/templates/deployment.tpl
+++ b/charts/konflate/templates/deployment.tpl
@@ -1,6 +1,6 @@
 {{- /*
   konflate is single-instance: its PR/diff state lives in memory and is served
-  from one pod (strategy: Recreate below). Two replicas wedge on the RWO cache
+  from one pod (strategy defaults to Recreate below). Two replicas wedge on the RWO cache
   volume's Multi-Attach error with persistence, or round-robin between divergent
   in-memory stores without it. Reject >1 at render so the misconfiguration is a
   clear install error rather than a confusing runtime one; 0 is allowed (pause).
@@ -22,9 +22,12 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   # konflate keeps PR/diff state in memory, so run a single instance and replace
-  # (rather than overlap) on rollout.
+  # (rather than overlap) on rollout; Recreate is the only supported value (the
+  # `strategy` knob is exposed for parity, but RollingUpdate is unsupported).
+  {{- with .Values.strategy }}
   strategy:
-    type: Recreate
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "konflate.selectorLabels" . | nindent 6 }}

--- a/charts/konflate/tests/deployment_test.yaml
+++ b/charts/konflate/tests/deployment_test.yaml
@@ -10,6 +10,21 @@ tests:
           path: spec.template.spec.containers[0].image
           value: ghcr.io/home-operations/konflate:0.0.0
 
+  - it: defaults to the Recreate update strategy (in-memory singleton + RWO cache)
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+
+  - it: renders an overridden strategy (exposed for parity; RollingUpdate unsupported)
+    set:
+      strategy:
+        type: RollingUpdate
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+
   - it: prefers the digest over the tag when set
     set:
       image.digest: sha256:deadbeef

--- a/charts/konflate/values.schema.json
+++ b/charts/konflate/values.schema.json
@@ -957,6 +957,19 @@
       "title": "startupProbe",
       "type": "object"
     },
+    "strategy": {
+      "description": "Deployment update strategy. **Keep `Recreate`** — konflate is a single instance with in-memory PR/diff state and a ReadWriteOnce cache PVC, so a RollingUpdate (which surges a second pod even at replicaCount 1) diverges the in-memory stores and/or wedges on the volume's Multi-Attach error. Exposed only for parity with the other charts; `RollingUpdate` is unsupported here.",
+      "properties": {
+        "type": {
+          "default": "Recreate",
+          "title": "type",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "strategy",
+      "type": "object"
+    },
     "terminationGracePeriodSeconds": {
       "default": 30,
       "description": "Grace period for a clean shutdown. konflate drains in-flight renders and closes the HTTP/websocket servers on SIGTERM (it caps its own shutdown near 15s), so the default is ample; raise it only if you expect longer drains.",

--- a/charts/konflate/values.yaml
+++ b/charts/konflate/values.yaml
@@ -24,6 +24,10 @@
 # -- Replica count; konflate is single-instance, so 0 or 1 only (a value >1 is rejected at render time).
 replicaCount: 1
 
+# -- Deployment update strategy. **Keep `Recreate`** — konflate is a single instance with in-memory PR/diff state and a ReadWriteOnce cache PVC, so a RollingUpdate (which surges a second pod even at replicaCount 1) diverges the in-memory stores and/or wedges on the volume's Multi-Attach error. Exposed only for parity with the other charts; `RollingUpdate` is unsupported here.
+strategy:
+  type: Recreate
+
 image:
   # -- Image repository.
   repository: ghcr.io/home-operations/konflate


### PR DESCRIPTION
## What

Exposes the Deployment update `strategy` as a value, **still defaulting to `Recreate`** —
previously it was hardcoded. This is for parity with the other charts (gatus-sidecar,
drm-exporter, …), which expose the knob.

## Important: Recreate is the only supported value here

konflate is a hard single instance — PR/diff state lives **in memory** and the cache is
a **ReadWriteOnce** PVC (the chart already `fail`s on `replicaCount > 1`). A
`RollingUpdate` surges a second pod *even at replicaCount 1* (maxSurge rounds up), which:

- diverges the two in-memory stores (round-robin behind the Service), and
- with persistence, wedges on the cache volume's Multi-Attach error.

So the knob is exposed only for parity/consistency; the value docs + template comment
state plainly that `RollingUpdate` is unsupported. Default behavior is unchanged
(`Recreate`).

Verified: `helm lint` clean; `helm unittest` 66/66 (added default-Recreate + override
cases); README + values schema regenerated.
