### PR TITLE
feat(web): routine PR filter + diff-row alignment fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,21 @@ Turning the fork gate on also activates flate's **SSRF egress guard** by default
 
 Keep the fork gate off on any public or shared instance.
 
+### List pills
+
+Above the PR list, a row of pills summarises the open set and doubles as a one-click filter (click a pill to narrow the list, click again to clear — or type `status:<name>` in the search box). Each shows a count of matching open PRs:
+
+| Pill        | Colour | Shows                                                                                                                                                                                                                                |
+| ----------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **open**    | blue   | The default view — every open, non-hidden PR.                                                                                                                                                                                        |
+| **failure** | red    | PRs with at least one resource flate could not render (broken templating), surfaced before merge.                                                                                                                                    |
+| **caution** | amber  | PRs carrying a heuristic danger flag — data-loss, privilege, RBAC, availability, or a major version bump. Advisory only; konflate never blocks.                                                                                      |
+| **routine** | green  | PRs whose diff is **only** container-image and/or chart-version changes — the `helm.sh/chart` / `app.kubernetes.io/version` labels and Flux source version refs — with no cautions and no failures. The ordinary Renovate/Flux bump. |
+| **merged**  | purple | The collapsed _Recently merged_ shelf (each diff frozen at merge time).                                                                                                                                                              |
+| **hidden**  | grey   | PRs excluded by the render gates above — listed but never rendered.                                                                                                                                                                  |
+
+> **`routine` describes the _shape_ of the diff, not a safety verdict.** It means konflate saw nothing change except image tags and chart-version metadata — it does **not** inspect what the new image does at runtime, so a routine-looking bump can still ship a regression, a new CVE, or a changed default. Treat it as "this is the easy pile to triage," not "this is safe to merge unread." (A _major_ version bump raises a caution, so it surfaces under **caution**, not **routine**.)
+
 ### Multi-cluster monorepos
 
 A konflate instance tracks **one repository and renders one cluster** — the Flux

--- a/internal/api/diff.go
+++ b/internal/api/diff.go
@@ -61,6 +61,14 @@ type DiffResult struct {
 	// reviewer aid, not a gate.
 	Warnings []Warning `json:"warnings"`
 
+	// Routine is true when every changed resource differs only in container
+	// image references and/or chart-version metadata (the helm.sh/chart /
+	// app.kubernetes.io/version labels and Flux source version refs), with no
+	// warnings and no render failures — i.e. an ordinary image/chart-version
+	// bump. It is a property of the diff's *shape*, not a safety verdict:
+	// konflate does not inspect what the new image does at runtime.
+	Routine bool `json:"routine"`
+
 	// ChromaCSS is the combined light+dark chroma stylesheet. Injected
 	// once into a <style> tag on first diff load. Subsequent resource
 	// selections do not re-inject it. Contains both .chroma.light and

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -46,10 +46,11 @@ type PRStatus struct {
 
 // Signals is the at-a-glance review summary for one PR's rendered diff.
 type Signals struct {
-	Resources int `json:"resources"` // changed/added/removed resources
-	Caution   int `json:"caution"`   // caution warnings (the sole severity)
-	Images    int `json:"images"`    // container-image changes
-	Failures  int `json:"failures"`  // resources flate could not render
+	Resources int  `json:"resources"` // changed/added/removed resources
+	Caution   int  `json:"caution"`   // caution warnings (the sole severity)
+	Images    int  `json:"images"`    // container-image changes
+	Failures  int  `json:"failures"`  // resources flate could not render
+	Routine   bool `json:"routine"`   // only image/chart-version changed, nothing flagged
 }
 
 // DiffEnvelope is the GET /api/prs/{n}/diff response: the job status plus the

--- a/internal/diff/render.go
+++ b/internal/diff/render.go
@@ -94,6 +94,11 @@ func Render(in RenderInput) (api.DiffResult, error) {
 		Warnings:  Lint(changes, in.Images, in.Parents),
 	}
 
+	// A "routine" PR is purely an image/chart-version bump with nothing flagged —
+	// the fast-merge pile. Gated on no warnings/failures so a major bump (which
+	// raises its own caution) surfaces under that pill, not this one.
+	out.Routine = onlyImageOrVersionChanges(changes) && len(out.Warnings) == 0 && len(out.Failures) == 0
+
 	// Summary reflects the true totals across every (real) change, even when the
 	// per-resource render below is capped — so the topbar counts and the impact
 	// banner agree on the real blast radius regardless of truncation.

--- a/internal/diff/routine.go
+++ b/internal/diff/routine.go
@@ -1,0 +1,135 @@
+package diff
+
+import (
+	"reflect"
+	"strconv"
+)
+
+// onlyImageOrVersionChanges reports whether every changed resource differs from
+// its prior render ONLY in container image references and/or chart-version
+// metadata — the "helm.sh/chart" / "app.kubernetes.io/version" labels and a Flux
+// source's version ref (OCIRepository/HelmRepository/GitRepository ref, or a
+// HelmRelease chart version). It is the structural half of the "routine" signal
+// (see api.DiffResult.Routine).
+//
+// The bias is deliberately conservative: an added or removed resource, or any
+// single changed field outside the allowlist, makes the whole PR not routine.
+// A false "routine" must never hide a structural change, so when in doubt the
+// answer is no — at worst a genuinely-routine bump simply isn't flagged.
+func onlyImageOrVersionChanges(changes []Change) bool {
+	if len(changes) == 0 {
+		return false // nothing real changed — not a "routine bump" worth a pill
+	}
+	for _, c := range changes {
+		// A whole resource appearing or disappearing is structural, never routine.
+		if c.Status == statusAdded || c.Status == statusRemoved {
+			return false
+		}
+		paths := changedPaths(c.Old, c.New)
+		if len(paths) == 0 {
+			return false // marshaled-equal no-ops are dropped upstream; be safe
+		}
+		for _, p := range paths {
+			if !routineField(c.Kind, p) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// changedPaths walks two manifests in parallel and returns the field paths whose
+// leaf values differ (added, removed, or changed). Map keys and array indices
+// become path segments; an array whose length changed is reported at the array's
+// own path — a structural edit (a container/volume added or removed), not a leaf
+// tweak, so the allowlist rejects it.
+func changedPaths(oldV, newV any) [][]string {
+	var out [][]string
+	var walk func(o, n any, path []string)
+	walk = func(o, n any, path []string) {
+		om, omOK := o.(map[string]any)
+		nm, nmOK := n.(map[string]any)
+		if omOK && nmOK {
+			seen := make(map[string]struct{}, len(om)+len(nm))
+			for k := range om {
+				seen[k] = struct{}{}
+			}
+			for k := range nm {
+				seen[k] = struct{}{}
+			}
+			for k := range seen {
+				walk(om[k], nm[k], appendSeg(path, k))
+			}
+			return
+		}
+		os, osOK := o.([]any)
+		ns, nsOK := n.([]any)
+		if osOK && nsOK {
+			if len(os) != len(ns) {
+				out = append(out, path)
+				return
+			}
+			for i := range os {
+				walk(os[i], ns[i], appendSeg(path, strconv.Itoa(i)))
+			}
+			return
+		}
+		if !reflect.DeepEqual(o, n) {
+			out = append(out, path)
+		}
+	}
+	walk(oldV, newV, nil)
+	return out
+}
+
+// appendSeg returns prefix+seg as a fresh slice so sibling recursions never
+// clobber each other's stored paths through a shared backing array.
+func appendSeg(prefix []string, seg string) []string {
+	np := make([]string, len(prefix)+1)
+	copy(np, prefix)
+	np[len(prefix)] = seg
+	return np
+}
+
+// routineField reports whether one changed path is an image/version field
+// konflate treats as routine. Anything else — env, args, command, resources,
+// replicas, RBAC rules, ports, volumes, … — returns false.
+func routineField(kind string, path []string) bool {
+	if len(path) == 0 {
+		return false
+	}
+	// Any container's image ref: containers/initContainers/ephemeralContainers
+	// all expose it as an "image" leaf, as does a CR's single spec.image.
+	if path[len(path)-1] == "image" {
+		return true
+	}
+	// Chart-version metadata Helm/Flux stamp onto every rendered resource.
+	if pathEq(path, "metadata", "labels", "helm.sh/chart") ||
+		pathEq(path, "metadata", "labels", "app.kubernetes.io/version") {
+		return true
+	}
+	// A Flux source/release advancing its pinned version.
+	switch kind {
+	case "OCIRepository", "HelmRepository":
+		return pathEq(path, "spec", "ref", "tag") ||
+			pathEq(path, "spec", "ref", "digest") ||
+			pathEq(path, "spec", "ref", "semver")
+	case "GitRepository":
+		return pathEq(path, "spec", "ref", "tag")
+	case "HelmRelease":
+		return pathEq(path, "spec", "chart", "spec", "version")
+	}
+	return false
+}
+
+func pathEq(path []string, segs ...string) bool {
+	if len(path) != len(segs) {
+		return false
+	}
+	for i := range segs {
+		if path[i] != segs[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/diff/routine_test.go
+++ b/internal/diff/routine_test.go
@@ -1,0 +1,134 @@
+package diff
+
+import "testing"
+
+// podSpec wraps containers in the Deployment/StatefulSet pod-template path.
+func podSpec(containers ...map[string]any) map[string]any {
+	cs := make([]any, len(containers))
+	for i, c := range containers {
+		cs[i] = c
+	}
+	return map[string]any{"spec": map[string]any{"template": map[string]any{"spec": map[string]any{"containers": cs}}}}
+}
+
+func labels(l map[string]any) map[string]any {
+	return map[string]any{"metadata": map[string]any{"labels": l}}
+}
+
+func TestOnlyImageOrVersionChanges(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		changes []Change
+		want    bool
+	}{
+		{
+			name: "container image only",
+			changes: []Change{{Status: "changed", Kind: "Deployment",
+				Old: podSpec(map[string]any{"name": "app", "image": "ghcr.io/x:1.0"}),
+				New: podSpec(map[string]any{"name": "app", "image": "ghcr.io/x:1.1"})}},
+			want: true,
+		},
+		{
+			name: "helm.sh/chart label only",
+			changes: []Change{{Status: "changed", Kind: "ServiceMonitor",
+				Old: labels(map[string]any{"app.kubernetes.io/name": "x", "helm.sh/chart": "x-0.16.1"}),
+				New: labels(map[string]any{"app.kubernetes.io/name": "x", "helm.sh/chart": "x-0.17.0"})}},
+			want: true,
+		},
+		{
+			name: "OCIRepository ref tag only",
+			changes: []Change{{Status: "changed", Kind: "OCIRepository",
+				Old: map[string]any{"spec": map[string]any{"ref": map[string]any{"tag": "0.16.1"}}},
+				New: map[string]any{"spec": map[string]any{"ref": map[string]any{"tag": "0.17.0"}}}}},
+			want: true,
+		},
+		{
+			name: "chart label + OCI tag together (the common Renovate bump)",
+			changes: []Change{
+				{Status: "changed", Kind: "ServiceMonitor",
+					Old: labels(map[string]any{"helm.sh/chart": "x-0.16.1"}),
+					New: labels(map[string]any{"helm.sh/chart": "x-0.17.0"})},
+				{Status: "changed", Kind: "OCIRepository",
+					Old: map[string]any{"spec": map[string]any{"ref": map[string]any{"tag": "0.16.1"}}},
+					New: map[string]any{"spec": map[string]any{"ref": map[string]any{"tag": "0.17.0"}}}},
+			},
+			want: true,
+		},
+		{
+			name: "app.kubernetes.io/version label",
+			changes: []Change{{Status: "changed", Kind: "Deployment",
+				Old: labels(map[string]any{"app.kubernetes.io/version": "1.0.0"}),
+				New: labels(map[string]any{"app.kubernetes.io/version": "1.1.0"})}},
+			want: true,
+		},
+		{
+			name: "HelmRelease chart version",
+			changes: []Change{{Status: "changed", Kind: "HelmRelease",
+				Old: map[string]any{"spec": map[string]any{"chart": map[string]any{"spec": map[string]any{"version": "1.0.0"}}}},
+				New: map[string]any{"spec": map[string]any{"chart": map[string]any{"spec": map[string]any{"version": "1.1.0"}}}}}},
+			want: true,
+		},
+		{
+			name:    "no changes",
+			changes: nil,
+			want:    false,
+		},
+		{
+			name: "env var added is not routine",
+			changes: []Change{{Status: "changed", Kind: "Deployment",
+				Old: podSpec(map[string]any{"name": "app", "image": "x:1"}),
+				New: podSpec(map[string]any{"name": "app", "image": "x:1", "env": []any{map[string]any{"name": "FOO", "value": "bar"}}})}},
+			want: false,
+		},
+		{
+			name: "replicas change is not routine",
+			changes: []Change{{Status: "changed", Kind: "Deployment",
+				Old: map[string]any{"spec": map[string]any{"replicas": float64(1)}},
+				New: map[string]any{"spec": map[string]any{"replicas": float64(3)}}}},
+			want: false,
+		},
+		{
+			name: "resource-limit change is not routine",
+			changes: []Change{{Status: "changed", Kind: "Deployment",
+				Old: podSpec(map[string]any{"name": "app", "image": "x:1", "resources": map[string]any{"limits": map[string]any{"memory": "64Mi"}}}),
+				New: podSpec(map[string]any{"name": "app", "image": "x:1", "resources": map[string]any{"limits": map[string]any{"memory": "128Mi"}}})}},
+			want: false,
+		},
+		{
+			name: "image bump alongside a non-image change is not routine",
+			changes: []Change{{Status: "changed", Kind: "Deployment",
+				Old: podSpec(map[string]any{"name": "app", "image": "x:1", "args": []any{"--a"}}),
+				New: podSpec(map[string]any{"name": "app", "image": "x:2", "args": []any{"--b"}})}},
+			want: false,
+		},
+		{
+			name: "added container (count change) is not routine",
+			changes: []Change{{Status: "changed", Kind: "Deployment",
+				Old: podSpec(map[string]any{"name": "app", "image": "x:1"}),
+				New: podSpec(map[string]any{"name": "app", "image": "x:1"}, map[string]any{"name": "side", "image": "y:1"})}},
+			want: false,
+		},
+		{
+			name: "added resource is not routine",
+			changes: []Change{{Status: "added", Kind: "Deployment",
+				New: podSpec(map[string]any{"name": "app", "image": "x:1"})}},
+			want: false,
+		},
+		{
+			name: "removed resource is not routine",
+			changes: []Change{{Status: "removed", Kind: "Deployment",
+				Old: podSpec(map[string]any{"name": "app", "image": "x:1"})}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := onlyImageOrVersionChanges(tt.changes); got != tt.want {
+				t.Errorf("onlyImageOrVersionChanges = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/comment_test.go
+++ b/internal/server/comment_test.go
@@ -87,7 +87,7 @@ func TestCommentBody_SectionsPlacedIndividually(t *testing.T) {
 	if !strings.HasPrefix(body, konflateMarker(142)) {
 		t.Errorf("marker should be injected: %q", body)
 	}
-	if !strings.Contains(body, "[!CAUTION]") || !strings.Contains(body, "Deployment web/api") {
+	if !strings.Contains(body, "[!WARNING]") || !strings.Contains(body, "Deployment web/api") {
 		t.Errorf(".Sections.Cautions not rendered: %q", body)
 	}
 	if !strings.Contains(body, "Image changes") || !strings.Contains(body, "ghcr.io/rook/ceph") {

--- a/internal/server/markdown.go
+++ b/internal/server/markdown.go
@@ -25,7 +25,7 @@ func summaryMarkdown(env api.DiffEnvelope, reviewURL string, admonitions bool) s
 
 // summaryMarkdownBody is the marker-less summary body. It opens with an H3 title
 // (### konflate — summary); with admonitions=true the sections use GitHub-flavoured
-// alert blocks (> [!CAUTION] / > [!WARNING]), otherwise plain bold-subheading bullet
+// alert blocks (> [!TIP] / > [!CAUTION] / > [!WARNING]), otherwise plain bold-subheading bullet
 // lists that render anywhere. Every forge-controlled
 // value is escaped (see mdInline/mdCode) so a crafted resource name or a render
 // error can't break the table or inject HTML. Exposed to a custom comment
@@ -102,6 +102,7 @@ func summaryMarkdownBody(env api.DiffEnvelope, reviewURL string, admonitions boo
 		}
 	}
 	appendSection(sec.Impact)
+	appendSection(sec.Routine)
 	writeRefreshNote()
 	appendSection(sec.BlastRadius)
 	appendSection(sec.Cautions)
@@ -118,6 +119,7 @@ func summaryMarkdownBody(env api.DiffEnvelope, reviewURL string, admonitions boo
 // nothing to show. summaryMarkdownBody composes the same blocks for the default.
 type summarySections struct {
 	Impact      string // headline counts: +added · changed · −removed — N resources · …
+	Routine     string // image/chart-version-only bump, nothing flagged (green [!TIP])
 	BlastRadius string // downstream apps transitively depending on the changed ones
 	Cautions    string // danger-lint warnings
 	Failures    string // resources that failed to render
@@ -132,6 +134,7 @@ func summarySectionsFor(d *api.DiffResult, admonitions bool) summarySections {
 	}
 	return summarySections{
 		Impact:      sectionImpact(d, admonitions),
+		Routine:     sectionRoutine(d, admonitions),
 		BlastRadius: sectionBlastRadius(d),
 		Cautions:    sectionCautions(d, admonitions),
 		Failures:    sectionFailures(d, admonitions),
@@ -159,6 +162,21 @@ func sectionImpact(d *api.DiffResult, admonitions bool) string {
 		return "> [!NOTE]\n> " + impact.String()
 	}
 	return impact.String()
+}
+
+// sectionRoutine surfaces a routine PR — only container-image and chart-version
+// changes, with nothing flagged. The GitHub flavour uses a green [!TIP], matching
+// the routine list pill's colour; plain keeps a bold line. Empty unless the diff
+// is routine. Like the pill, it describes the diff's shape, not runtime safety.
+func sectionRoutine(d *api.DiffResult, admonitions bool) string {
+	if !d.Routine {
+		return ""
+	}
+	const msg = "**Routine** — only container-image and chart-version changes; nothing else changed."
+	if admonitions {
+		return "> [!TIP]\n> " + msg
+	}
+	return msg
 }
 
 func sectionCautions(d *api.DiffResult, admonitions bool) string {

--- a/internal/server/markdown.go
+++ b/internal/server/markdown.go
@@ -185,8 +185,10 @@ func sectionCautions(d *api.DiffResult, admonitions bool) string {
 	}
 	var b strings.Builder
 	if admonitions {
-		// [!CAUTION] renders its own "Caution" heading — no redundant title line.
-		b.WriteString("> [!CAUTION]\n")
+		// Amber [!WARNING] to match the caution list pill's colour (a notch below
+		// the red [!CAUTION] of a render failure). The alert header reads "Warning",
+		// so the block names itself.
+		fmt.Fprintf(&b, "> [!WARNING]\n> **⚠ %s**\n", plural(len(d.Warnings), "Caution", "Cautions"))
 		for _, wn := range d.Warnings {
 			fmt.Fprintf(&b, "> - `%s` — %s\n", mdCode(wn.Resource), mdInline(wn.Detail))
 		}
@@ -206,7 +208,8 @@ func sectionFailures(d *api.DiffResult, admonitions bool) string {
 	var b strings.Builder
 	title := fmt.Sprintf("%d render %s", len(d.Failures), plural(len(d.Failures), "failure", "failures"))
 	if admonitions {
-		fmt.Fprintf(&b, "> [!WARNING]\n> **%s**\n", title)
+		// Red [!CAUTION] to match the failure list pill — the top of the severity ramp.
+		fmt.Fprintf(&b, "> [!CAUTION]\n> **%s**\n", title)
 		for _, f := range d.Failures {
 			fmt.Fprintf(&b, "> - `%s` — %s\n", mdCode(f.Parent), mdInline(f.Message))
 		}

--- a/internal/server/markdown_test.go
+++ b/internal/server/markdown_test.go
@@ -38,9 +38,10 @@ func TestSummaryMarkdown_GitHubAdmonitions(t *testing.T) {
 		"### konflate — summary",
 		"> [!NOTE]",
 		"+2 added · 3 changed · −1 removed** — 6 resources · 2 apps · 1 CRD",
-		"> [!CAUTION]",
+		// Alert colours match the list pills: caution = amber [!WARNING], failure = red [!CAUTION].
+		"> [!WARNING]\n> **⚠ Caution**",
 		"> - `Deployment web/api` — replicas set to 0",
-		"> [!WARNING]",
+		"> [!CAUTION]\n> **1 render failure**",
 		"> - `HelmRelease media/plex` — values don't meet the schema",
 		"**Blast radius**",
 		// Sample capped at 3 direct names; count + sample reconcile to the headline.
@@ -55,10 +56,6 @@ func TestSummaryMarkdown_GitHubAdmonitions(t *testing.T) {
 		if !strings.Contains(md, want) {
 			t.Errorf("github markdown missing %q\n---\n%s", want, md)
 		}
-	}
-	// The [!CAUTION] block is its own heading; don't repeat the word in a title line.
-	if strings.Contains(md, "> **Caution") {
-		t.Errorf("caution admonition should not carry a redundant title:\n%s", md)
 	}
 }
 

--- a/internal/server/markdown_test.go
+++ b/internal/server/markdown_test.go
@@ -79,6 +79,40 @@ func TestSummaryMarkdown_PlainHasNoAdmonitions(t *testing.T) {
 	}
 }
 
+func TestSummaryMarkdown_Routine(t *testing.T) {
+	t.Parallel()
+	env := api.DiffEnvelope{
+		Status: api.JobReady,
+		PR:     api.PR{Number: 7},
+		Diff: &api.DiffResult{
+			HeadSHA: "abcdef1234567890",
+			Summary: api.DiffSummary{Changed: 2},
+			Impact:  api.Impact{Resources: 2, Parents: 1},
+			Images:  []api.ImageChange{{Name: "ghcr.io/x", From: "1.0", To: "1.1"}},
+			Routine: true,
+		},
+	}
+	// GitHub flavour: a green [!TIP] naming itself, and — being routine — no
+	// caution/failure blocks.
+	md := summaryMarkdown(env, "", true)
+	for _, want := range []string{"> [!TIP]", "**Routine**"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("routine PR github markdown missing %q\n---\n%s", want, md)
+		}
+	}
+	if strings.Contains(md, "[!CAUTION]") || strings.Contains(md, "[!WARNING]") {
+		t.Errorf("a routine PR carries no caution/failure blocks:\n%s", md)
+	}
+	// Plain flavour: the bold line, no admonition syntax.
+	plain := summaryMarkdown(env, "", false)
+	if strings.Contains(plain, "[!TIP]") {
+		t.Errorf("plain markdown must not use admonitions:\n%s", plain)
+	}
+	if !strings.Contains(plain, "**Routine**") {
+		t.Errorf("plain routine line missing:\n%s", plain)
+	}
+}
+
 func TestSummaryMarkdown_EscapesForgeText(t *testing.T) {
 	t.Parallel()
 	env := sampleSummaryEnv()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -629,7 +629,7 @@ func TestServer_SummaryMarkdown(t *testing.T) {
 		t.Errorf("content-type = %q, want text/markdown", ct)
 	}
 	body := rec.Body.String()
-	for _, want := range []string{"konflate — summary", "> [!NOTE]", "> [!CAUTION]", "`Deployment web/api`", "/#/pr/7"} {
+	for _, want := range []string{"konflate — summary", "> [!NOTE]", "> [!WARNING]", "`Deployment web/api`", "/#/pr/7"} {
 		if !strings.Contains(body, want) {
 			t.Errorf("markdown body missing %q\n%s", want, body)
 		}

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -303,6 +303,7 @@ func computeSignals(d *api.DiffResult) *api.Signals {
 		Caution:   len(d.Warnings), // every warning is a caution (the sole severity)
 		Images:    len(d.Images),
 		Failures:  len(d.Failures),
+		Routine:   d.Routine,
 	}
 }
 

--- a/internal/web/playwright.config.ts
+++ b/internal/web/playwright.config.ts
@@ -7,6 +7,11 @@ export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
+  // Retry in CI so a transient flake (a dropped keypress, a slow mount) doesn't
+  // fail the whole job: Playwright reruns only the failed test and marks it
+  // "flaky" if it then passes, so chronic failures still surface. This also
+  // activates the trace below — 'on-first-retry' is a no-op without retries.
+  retries: process.env.CI ? 2 : 0,
   reporter: process.env.CI ? 'github' : 'list',
   use: {
     baseURL: 'http://localhost:4173',

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -1903,15 +1903,16 @@ td.gutter.sign {
 .row-del {
   background: var(--del-bg);
 }
+/* The 3px inset status bar sits inside the code cell's base 10px left padding,
+   so changed-row text stays column-aligned with context rows. An extra
+   padding-left here previously pushed every +/− line 3px to the right. */
 tr.row-add td.code,
 td.code.row-add {
   box-shadow: inset 3px 0 0 var(--add-bar);
-  padding-left: 13px;
 }
 tr.row-del td.code,
 td.code.row-del {
   box-shadow: inset 3px 0 0 var(--del-bar);
-  padding-left: 13px;
 }
 .row-add td.gutter.sign {
   color: var(--add-bar);

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -939,6 +939,24 @@ button.sum-pill:hover {
 .sum-pill.failure:hover {
   border-color: var(--danger);
 }
+/* The routine pill reads green (--ok) — deliberately off the red→amber severity
+   ramp, so it signals "the easy pile" (image/chart-version bumps only), not a
+   milder warning. */
+.sum-pill.routine {
+  color: var(--ok);
+  border-color: color-mix(in srgb, var(--ok) 40%, var(--border));
+}
+.sum-pill.routine strong {
+  color: var(--ok);
+}
+.sum-pill.routine.active {
+  border-color: var(--ok);
+  background: color-mix(in srgb, var(--ok) 12%, var(--panel));
+  color: color-mix(in srgb, var(--ok) 75%, var(--text));
+}
+.sum-pill.routine:hover {
+  border-color: var(--ok);
+}
 .sum-pill.merged {
   color: var(--merged);
   border-color: color-mix(in srgb, var(--merged) 40%, var(--border));

--- a/internal/web/src/lib/List.svelte
+++ b/internal/web/src/lib/List.svelte
@@ -112,6 +112,7 @@
     open: openPrs.length,
     caution: openPrs.filter((p) => (p.signals?.caution ?? 0) > 0).length,
     failure: openPrs.filter((p) => (p.signals?.failures ?? 0) > 0).length,
+    routine: openPrs.filter((p) => !!p.signals?.routine).length,
     merged: prs.filter((p) => !p.open).length,
     hidden: prs.filter((p) => p.hidden).length,
   }));
@@ -516,6 +517,9 @@
       {/if}
       {#if showPill(summary.caution, 'caution')}
         {@render pill('caution', summary.caution, 'caution', 'Only PRs with cautions')}
+      {/if}
+      {#if showPill(summary.routine, 'routine')}
+        {@render pill('routine', summary.routine, 'routine', 'Only image / chart-version bumps — nothing else changed (a diff-shape signal, not a runtime guarantee)')}
       {/if}
       {#if showPill(summary.merged, 'merged')}
         {@render pill('merged', summary.merged, 'merged', 'Only recently merged PRs')}

--- a/internal/web/src/lib/store.svelte.ts
+++ b/internal/web/src/lib/store.svelte.ts
@@ -19,7 +19,7 @@ import { router, navigate } from './router.svelte';
 
 // The status facets a summary pill can filter the list down to ('' = unfiltered;
 // 'open' narrows to just the open set, hiding the merged shelf).
-export type StatusFilter = '' | 'open' | 'caution' | 'failure' | 'merged' | 'hidden';
+export type StatusFilter = '' | 'open' | 'caution' | 'failure' | 'routine' | 'merged' | 'hidden';
 // List sort: the field to order by, and the direction. The comparator is
 // defined ascending (name A→Z, time oldest-first); 'desc' reverses it.
 export type SortKey = 'created' | 'refreshed' | 'name';
@@ -129,7 +129,7 @@ const FACETS = ['status', 'author', 'base', 'label'];
 // with matchesStatus again. ('hidden' was missing here, so `status:hidden` typed
 // in the filter or palette matched nothing — the pill worked only because it sets
 // statusFilter directly, bypassing this grammar.)
-const STATUS_VALUES = ['open', 'caution', 'failure', 'merged', 'hidden'] as const satisfies readonly StatusFilter[];
+const STATUS_VALUES = ['open', 'caution', 'failure', 'routine', 'merged', 'hidden'] as const satisfies readonly StatusFilter[];
 
 export function parseQuery(raw: string): ParsedQuery {
   const tokens: ParsedQuery['tokens'] = [];
@@ -211,6 +211,11 @@ export function matchesStatus(p: PRStatus, f: StatusFilter): boolean {
       return p.open && !p.hidden && (p.signals?.caution ?? 0) > 0;
     case 'failure':
       return p.open && !p.hidden && (p.signals?.failures ?? 0) > 0;
+    case 'routine':
+      // Only image/chart-version fields changed, nothing flagged — the fast-merge
+      // pile. A diff-shape signal, not a runtime guarantee (see the server's
+      // DiffResult.Routine).
+      return p.open && !p.hidden && !!p.signals?.routine;
     case 'merged':
       return !p.open;
     case 'hidden':

--- a/internal/web/src/lib/types.ts
+++ b/internal/web/src/lib/types.ts
@@ -30,6 +30,7 @@ export interface Signals {
   caution: number; // caution warnings (the sole severity)
   images: number;
   failures: number;
+  routine: boolean; // only image/chart-version changed, nothing flagged
 }
 
 // CheckRollup is the PR head's rolled-up CI status (the forge's red/amber/green).

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -483,13 +483,18 @@ test('keyboard: j steps from Summary into resources, o returns to Summary', asyn
   await page.goto('/#/pr/142');
   // Navigation needs the diff loaded; the default landing is the Summary.
   await page.locator('.impact').waitFor();
-  await page.locator('body').press('j');
-  await expect(page).toHaveURL(/#\/pr\/142\/r0$/);
-  await page.locator('body').press('j');
-  await expect(page).toHaveURL(/#\/pr\/142\/r1$/);
+  // Re-send each keystroke until the route advances: a single press can be dropped
+  // if it lands while the previous panel is still mounting (the flake this hit).
+  // Each nav is single-step / idempotent, so re-pressing is safe.
+  const step = (key: string, url: RegExp) =>
+    expect(async () => {
+      await page.locator('body').press(key);
+      await expect(page).toHaveURL(url, { timeout: 1000 });
+    }).toPass();
+  await step('j', /#\/pr\/142\/r0$/);
+  await step('j', /#\/pr\/142\/r1$/);
   // o jumps straight back to the Summary panel.
-  await page.locator('body').press('o');
-  await expect(page).toHaveURL(/#\/pr\/142\/summary$/);
+  await step('o', /#\/pr\/142\/summary$/);
   await expect(page.locator('.impact')).toBeVisible();
 });
 


### PR DESCRIPTION
Three diff-viewer changes, bundled per request.

## Routine filter (new)
Surfaces PRs whose diff is *only* container-image and/or chart-version changes (`helm.sh/chart` + `app.kubernetes.io/version` labels, Flux source version refs), with no cautions and no failures — the ordinary Renovate/Flux bump.
- **Backend:** a conservative classifier (`internal/diff/onlyImageOrVersionChanges`) flags a PR routine only when *every* changed field across *every* resource is an allowlisted image/version field; any added/removed resource or other change makes it non-routine. `DiffResult.Routine` → `Signals.Routine`. A **major** bump raises a caution, so it lands under `caution`, not `routine`.
- **Frontend:** a green `routine` pill + `status:routine` search facet (`--ok`, off the red→amber severity ramp).
- **Forge comment:** when a PR is routine, the posted summary comment surfaces it as a green GitHub `[!TIP]` admonition (plain bold fallback on forges without alert syntax).
- **Docs:** a README "List pills" section documenting every pill, with the caveat that routine is a **diff-shape signal, not a runtime safety guarantee**.

## Diff gutter alignment (fix)
Changed (`-`/`+`) code cells overrode the base 10px left padding with 13px to clear the 3px status bar, shifting changed lines 3px right of context rows. The override is dropped — changed and context text align column-for-column again (unified + split).

Verified locally: `go test ./...`, `golangci-lint` (0 issues), `svelte-check` (0 errors), `vite build`.