### PR TITLE
fix(diff): make routine fire on real image/chart-version bumps

### DIFF
--- a/internal/diff/routine.go
+++ b/internal/diff/routine.go
@@ -3,19 +3,25 @@ package diff
 import (
 	"reflect"
 	"strconv"
+
+	"sigs.k8s.io/yaml"
 )
 
 // onlyImageOrVersionChanges reports whether every changed resource differs from
 // its prior render ONLY in container image references and/or chart-version
-// metadata — the "helm.sh/chart" / "app.kubernetes.io/version" labels and a Flux
-// source's version ref (OCIRepository/HelmRepository/GitRepository ref, or a
-// HelmRelease chart version). It is the structural half of the "routine" signal
-// (see api.DiffResult.Routine).
+// metadata — the "helm.sh/chart" / "app.kubernetes.io/version" labels, a Flux
+// source's version ref (OCIRepository/HelmRepository/GitRepository ref or a
+// HelmRelease chart version), and image refs pinned in values. It is the
+// structural half of the "routine" signal (see api.DiffResult.Routine).
+//
+// It compares the manifests in their marshaled (rendered) form — the same YAML
+// the diff shows — so a field that differs only in Go type/representation (e.g.
+// an int vs a float that marshal to identical text) is NOT counted: the reviewer
+// never sees it in the diff, so it must not flip a routine bump to non-routine.
 //
 // The bias is deliberately conservative: an added or removed resource, or any
-// single changed field outside the allowlist, makes the whole PR not routine.
-// A false "routine" must never hide a structural change, so when in doubt the
-// answer is no — at worst a genuinely-routine bump simply isn't flagged.
+// single *visible* changed field outside the allowlist, makes the whole PR not
+// routine. A false "routine" must never hide a structural change.
 func onlyImageOrVersionChanges(changes []Change) bool {
 	if len(changes) == 0 {
 		return false // nothing real changed — not a "routine bump" worth a pill
@@ -25,7 +31,10 @@ func onlyImageOrVersionChanges(changes []Change) bool {
 		if c.Status == statusAdded || c.Status == statusRemoved {
 			return false
 		}
-		paths := changedPaths(c.Old, c.New)
+		// Diff the normalized (marshal→reparse) manifests, not the raw maps: the
+		// raw values can differ only by Go type yet render identically, which would
+		// otherwise count as a phantom change the reviewer can't see.
+		paths := changedPaths(normalizeForDiff(c.Old), normalizeForDiff(c.New))
 		if len(paths) == 0 {
 			return false // marshaled-equal no-ops are dropped upstream; be safe
 		}
@@ -36,6 +45,26 @@ func onlyImageOrVersionChanges(changes []Change) bool {
 		}
 	}
 	return true
+}
+
+// normalizeForDiff round-trips a manifest through the same marshal the diff view
+// uses (sigs.k8s.io/yaml → JSON number/type rules), so both sides of a comparison
+// share one representation and only differences that actually render survive.
+// Returns the input unchanged if it can't be marshaled (changedPaths then falls
+// back to the raw values — no worse than before).
+func normalizeForDiff(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	b, err := yaml.Marshal(m)
+	if err != nil {
+		return m
+	}
+	var out map[string]any
+	if err := yaml.Unmarshal(b, &out); err != nil {
+		return m
+	}
+	return out
 }
 
 // changedPaths walks two manifests in parallel and returns the field paths whose
@@ -101,6 +130,12 @@ func routineField(kind string, path []string) bool {
 	// Any container's image ref: containers/initContainers/ephemeralContainers
 	// all expose it as an "image" leaf, as does a CR's single spec.image.
 	if path[len(path)-1] == "image" {
+		return true
+	}
+	// An image ref split across values — "<…>.image.tag" / "<…>.image.digest"
+	// (app-template / common-chart style, where a bump lands in a HelmRelease's
+	// spec.values rather than the rendered container's single image leaf).
+	if n := len(path); n >= 2 && path[n-2] == "image" && (path[n-1] == "tag" || path[n-1] == "digest") {
 		return true
 	}
 	// Chart-version metadata Helm/Flux stamp onto every rendered resource.

--- a/internal/diff/routine_test.go
+++ b/internal/diff/routine_test.go
@@ -122,6 +122,42 @@ func TestOnlyImageOrVersionChanges(t *testing.T) {
 				Old: podSpec(map[string]any{"name": "app", "image": "x:1"})}},
 			want: false,
 		},
+		{
+			// PR 11139: app-template HelmRelease pins the image in values as
+			// spec.values…image.tag — a routine digest/tag bump, not the rendered
+			// container's image leaf.
+			name: "image tag pinned in HelmRelease values",
+			changes: []Change{{Status: "changed", Kind: "HelmRelease",
+				Old: map[string]any{"spec": map[string]any{"values": map[string]any{"image": map[string]any{"repository": "ghcr.io/x", "tag": "1.0.0@sha256:aaa"}}}},
+				New: map[string]any{"spec": map[string]any{"values": map[string]any{"image": map[string]any{"repository": "ghcr.io/x", "tag": "1.0.0@sha256:bbb"}}}}}},
+			want: true,
+		},
+		{
+			name: "image digest pinned in values",
+			changes: []Change{{Status: "changed", Kind: "HelmRelease",
+				Old: map[string]any{"spec": map[string]any{"values": map[string]any{"image": map[string]any{"digest": "sha256:aaa"}}}},
+				New: map[string]any{"spec": map[string]any{"values": map[string]any{"image": map[string]any{"digest": "sha256:bbb"}}}}}},
+			want: true,
+		},
+		{
+			// PR 11140: a chart re-render leaves a field differing only by Go type
+			// (int vs float64) that marshals to identical YAML — invisible in the
+			// diff, so it must not defeat routine. The only shown change is the label.
+			name: "type-only field difference is ignored (phantom diff)",
+			changes: []Change{{Status: "changed", Kind: "ServiceMonitor",
+				Old: map[string]any{"metadata": map[string]any{"labels": map[string]any{"helm.sh/chart": "x-0.16.1"}}, "spec": map[string]any{"port": 9633}},
+				New: map[string]any{"metadata": map[string]any{"labels": map[string]any{"helm.sh/chart": "x-0.17.0"}}, "spec": map[string]any{"port": float64(9633)}}}},
+			want: true,
+		},
+		{
+			// Changing the image *repository* (not just tag/digest) is a source swap,
+			// not a routine version bump — negative control on the values rule.
+			name: "image repository change in values is not routine",
+			changes: []Change{{Status: "changed", Kind: "HelmRelease",
+				Old: map[string]any{"spec": map[string]any{"values": map[string]any{"image": map[string]any{"repository": "ghcr.io/x", "tag": "1.0"}}}},
+				New: map[string]any{"spec": map[string]any{"values": map[string]any{"image": map[string]any{"repository": "ghcr.io/y", "tag": "1.0"}}}}}},
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/web/src/app.css
+++ b/internal/web/src/app.css
@@ -1921,16 +1921,39 @@ td.gutter.sign {
 .row-del {
   background: var(--del-bg);
 }
-/* The 3px inset status bar sits inside the code cell's base 10px left padding,
-   so changed-row text stays column-aligned with context rows. An extra
-   padding-left here previously pushed every +/− line 3px to the right. */
+/* The 3px status bar sits inside the code cell's base 10px left padding, so
+   changed-row text stays column-aligned with context rows (an extra
+   padding-left here previously pushed every +/− line 3px to the right).
+   It's painted as a real ::before strip rather than an inset box-shadow: in a
+   border-collapse table every code cell shares one column, so the bars are at
+   the same x by layout — but inset shadows on stacked cells rasterize against
+   the (often fractional, on HiDPI) column edge independently, so the red (del)
+   and green (add) bars could land a device-pixel apart and read as a step at
+   their junction. A background fill pinned to left:0 shares one exact edge, so
+   the bars form a continuous red→green line. */
 tr.row-add td.code,
-td.code.row-add {
-  box-shadow: inset 3px 0 0 var(--add-bar);
-}
+td.code.row-add,
 tr.row-del td.code,
 td.code.row-del {
-  box-shadow: inset 3px 0 0 var(--del-bar);
+  position: relative;
+}
+tr.row-add td.code::before,
+td.code.row-add::before,
+tr.row-del td.code::before,
+td.code.row-del::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  pointer-events: none;
+}
+tr.row-add td.code::before,
+td.code.row-add::before {
+  background: var(--add-bar);
+}
+tr.row-del td.code::before,
+td.code.row-del::before {
+  background: var(--del-bar);
 }
 .row-add td.gutter.sign {
   color: var(--add-bar);


### PR DESCRIPTION
Follow-up to the routine filter (#273). On a live instance, two ordinary Renovate bumps that *should* have been routine weren't — both due to classifier shortcomings, not genuine non-routine changes.

## Bug 1 — phantom (type-only) diffs
The classifier diffed the **raw normalized manifests** with `reflect.DeepEqual`, which flags fields that differ only in Go type/representation (e.g. an `int` vs a `float64`) but **marshal to identical YAML** — so they never appear in the rendered diff. A chart re-render (e.g. `0.16→0.17`) commonly leaves one such field, which defeated routine on a `helm.sh/chart` + `OCIRepository` `tag` bump.
**Fix:** compare the **marshaled (rendered) form** — the same YAML the diff shows — so only visible changes count.

## Bug 2 — image refs pinned in values
The allowlist recognized a container `image:` leaf and a HelmRelease `spec.chart.spec.version`, but **not** an image ref pinned in values (app-template / common-chart `spec.values…image.tag` / `.digest`). So a digest bump landing in a HelmRelease's values was unrecognized.
**Fix:** recognize `tag`/`digest` under an `image` parent.

## Tests
Adds regression cases for both, plus a **negative control**: changing the image `repository` (a source swap, not a version bump) stays non-routine. All 18 classifier cases + full `go test` pass, `golangci-lint` 0 issues.

Net: `routine` now fires on the digest-in-values and chart-version bumps it was meant to catch, without loosening the conservative bias (any unrecognized *visible* change still makes a PR non-routine).

---

## Also bundled — diff status-bar alignment

The red (del) / green (add) status bars on the diff rows could read as a 1px step at their junction, most visible on HiDPI. The bars were `box-shadow: inset 3px 0 0` on `td.code`; in a `border-collapse` table every code cell shares one column, so the bars are at the same x **by layout** — but inset shadows on stacked cells rasterize against the (often fractional) column edge independently, so they could land a device-pixel apart. Now painted as an absolutely-positioned `::before` strip pinned to `left:0`, so both bars share one exact edge and form a continuous line. Text alignment is unchanged (the 3px bar still sits inside the existing 10px left padding). UI build clean; 76/76 Playwright e2e pass.
