### PR TITLE
chore(renovate): inherit shared toolchain + chart-docs presets

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -2,36 +2,4 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["local>home-operations/renovate-config"],
   postUpdateOptions: ["gomodTidy", "gomodUpdateImportPaths"],
-  // Regenerate the chart's committed docs after an upgrade so a value bump
-  // doesn't leave README.md / values.schema.json stale and fail generate-check.
-  // Runs the helm-docs + helm-schema binaries shipped in the Renovate container
-  // (mirrors `mise run generate`).
-  postUpgradeTasks: {
-    commands: [
-      "helm-docs --chart-search-root=charts --log-level=warn",
-      "helm-schema --chart-search-root charts/konflate --skip-auto-generation required,additionalProperties --append-newline",
-    ],
-    fileFilters: ["charts/konflate/README.md", "charts/konflate/values.schema.json"],
-    executionMode: "branch",
-  },
-  packageRules: [
-    {
-      description: "Go Toolchain Group",
-      matchManagers: ["mise", "gomod"],
-      matchDepNames: ["go"],
-      matchFileNames: [".mise/config.toml", "go.mod"],
-      groupName: "Go toolchain",
-      groupSlug: "go-toolchain",
-      minimumGroupSize: 2,
-    },
-    {
-      description: "Node Toolchain Group",
-      matchManagers: ["mise"],
-      matchDepNames: ["node"],
-      matchFileNames: [".mise/config.toml"],
-      groupName: "Node toolchain",
-      groupSlug: "node-toolchain",
-      minimumGroupSize: 2,
-    },
-  ],
 }


### PR DESCRIPTION
Now that home-operations/renovate-config#25 is merged, `konflate` inherits the shared `groups.json5`
(toolchain grouping) and `helmPostUpgradeTasks.json5` (chart-doc regen) presets via its existing
`extends: ["local>home-operations/renovate-config"]`.

Removes the now-redundant local config:
- the local toolchain group packageRule(s)
- the local helm-docs/helm-schema `postUpgradeTasks` block

Pure deletion — behavior unchanged:
- `packageRules` merge additively, so the inherited toolchain group is identical to the removed local copy.
- the shared preset's `--chart-search-root .` reproduces this chart's committed README + values.schema.json byte-for-byte (verified).

Part of the org consolidation Tier-1 rollout.
