### PR TITLE
refactor(lint): tiered warning severity (caution + blocking)

### DIFF
--- a/internal/api/diff.go
+++ b/internal/api/diff.go
@@ -56,9 +56,10 @@ type DiffResult struct {
 	// surfaces here, before merge, instead of failing in-cluster.
 	Failures []RenderFailure `json:"failures"`
 
-	// Warnings are heuristic danger flags over the rendered diff (data-loss,
-	// privilege, RBAC, availability). Advisory; never block — konflate is a
-	// reviewer aid, not a gate.
+	// Warnings are heuristic flags over the rendered diff (data-loss, privilege,
+	// RBAC, availability). Advisory by default (LevelCaution → a neutral check);
+	// a LevelBlocking warning escalates the check to a failure. Every rule is a
+	// caution today, so konflate stays a reviewer aid, not a gate.
 	Warnings []Warning `json:"warnings"`
 
 	// Routine is true when every changed resource differs only in container
@@ -137,20 +138,41 @@ type RenderFailure struct {
 	Message string `json:"message"` // the render/reconcile error
 }
 
-// LevelCaution is the sole warning severity — every heuristic flag over the
-// rendered diff is a caution (rendered red in the UI). Kept as a named value of
-// [Warning.Level] so the contract is explicit and a future severity tier is a
-// small change.
-const LevelCaution = "caution"
+// Level is a warning's severity tier. It is a string type so the JSON contract
+// (and the generated TypeScript union) stays the plain value.
+type Level string
 
-// Warning is one heuristic flag over the rendered diff. Level is always
-// [LevelCaution]; Rule is a stable machine id (e.g. "removed-statefulset",
-// "privileged", "rbac-widened", "replicas-zero", "removed-crd").
+const (
+	// LevelCaution is advisory: the reviewer should look, but it does not block —
+	// cautions map the PR's check to a neutral conclusion (see checkConclusion).
+	// Every heuristic diff flag is a caution today.
+	LevelCaution Level = "caution"
+	// LevelBlocking escalates the PR's check to a failing conclusion — for a
+	// finding that means the change would not deploy (e.g. an image tag missing
+	// upstream). No rule emits it yet; it is the promotion target for such a rule.
+	LevelBlocking Level = "blocking"
+)
+
+// Warning is one heuristic flag over the rendered diff. Rule is a stable machine
+// id (e.g. "removed-statefulset", "privileged", "rbac-widened", "replicas-zero").
 type Warning struct {
-	Level    string `json:"level"`
+	Level    Level  `json:"level"`
 	Rule     string `json:"rule"`
 	Resource string `json:"resource"` // "Kind ns/name" the warning concerns
 	Detail   string `json:"detail"`   // human-readable explanation
+}
+
+// WarningsByLevel returns the subset of ws at the given severity level,
+// preserving order — used to render each tier in its own summary block and to
+// count the per-tier [Signals].
+func WarningsByLevel(ws []Warning, l Level) []Warning {
+	out := make([]Warning, 0, len(ws))
+	for _, w := range ws {
+		if w.Level == l {
+			out = append(out, w)
+		}
+	}
+	return out
 }
 
 // DiffTreeParent is the top level of the sidebar tree: a Flux object

--- a/internal/api/diff_test.go
+++ b/internal/api/diff_test.go
@@ -1,0 +1,23 @@
+package api
+
+import "testing"
+
+func TestWarningsByLevel(t *testing.T) {
+	t.Parallel()
+	ws := []Warning{
+		{Level: LevelCaution, Rule: "a"},
+		{Level: LevelBlocking, Rule: "b"},
+		{Level: LevelCaution, Rule: "c"},
+	}
+	// Filters to the requested tier, preserving input order.
+	if got := WarningsByLevel(ws, LevelCaution); len(got) != 2 || got[0].Rule != "a" || got[1].Rule != "c" {
+		t.Errorf("caution filter = %+v, want rules a,c in order", got)
+	}
+	if got := WarningsByLevel(ws, LevelBlocking); len(got) != 1 || got[0].Rule != "b" {
+		t.Errorf("blocking filter = %+v, want rule b", got)
+	}
+	// Empty and nil inputs yield no matches, not a panic.
+	if got := WarningsByLevel(nil, LevelCaution); len(got) != 0 {
+		t.Errorf("nil input = %+v, want empty", got)
+	}
+}

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -47,7 +47,8 @@ type PRStatus struct {
 // Signals is the at-a-glance review summary for one PR's rendered diff.
 type Signals struct {
 	Resources int  `json:"resources"` // changed/added/removed resources
-	Caution   int  `json:"caution"`   // caution warnings (the sole severity)
+	Caution   int  `json:"caution"`   // caution-tier warnings (advisory → neutral check)
+	Blocking  int  `json:"blocking"`  // blocking-tier warnings (fail the check); 0 today
 	Images    int  `json:"images"`    // container-image changes
 	Failures  int  `json:"failures"`  // resources flate could not render
 	Routine   bool `json:"routine"`   // only image/chart-version changed, nothing flagged

--- a/internal/diff/lint.go
+++ b/internal/diff/lint.go
@@ -36,12 +36,12 @@ const (
 	statusRemoved = "removed"
 )
 
-// Lint runs the danger-lint rules over the changed resources (and the diff's
-// image changes) and returns the warnings, most-severe first (all dangers
-// before all cautions). parents carries the Flux-semantic facts about each
-// producing Kustomization/HelmRelease (suspend/prune — see ParentInfo); nil
-// is fine and simply mutes the parent-aware rules. Advisory only — konflate
-// never blocks on these; they are a reviewer aid.
+// Lint runs the diff-lint rules over the changed resources (and the diff's image
+// changes) and returns the warnings in rule order. parents carries the
+// Flux-semantic facts about each producing Kustomization/HelmRelease
+// (suspend/prune — see ParentInfo); nil is fine and simply mutes the
+// parent-aware rules. Every rule is api.LevelCaution today (advisory → a neutral
+// check); the summary groups warnings by tier (see api.WarningsByLevel).
 func Lint(changes []Change, images []api.ImageChange, parents map[string]ParentInfo) []api.Warning {
 	var warnings []api.Warning
 	add := func(rule, detail string, c Change) {

--- a/internal/server/markdown.go
+++ b/internal/server/markdown.go
@@ -105,6 +105,7 @@ func summaryMarkdownBody(env api.DiffEnvelope, reviewURL string, admonitions boo
 	appendSection(sec.Routine)
 	writeRefreshNote()
 	appendSection(sec.BlastRadius)
+	appendSection(sec.Blocking)
 	appendSection(sec.Cautions)
 	appendSection(sec.Failures)
 	appendSection(sec.Images)
@@ -121,7 +122,8 @@ type summarySections struct {
 	Impact      string // headline counts: +added · changed · −removed — N resources · …
 	Routine     string // image/chart-version-only bump, nothing flagged (green [!TIP])
 	BlastRadius string // downstream apps transitively depending on the changed ones
-	Cautions    string // danger-lint warnings
+	Blocking    string // blocking-tier warnings — fail the check (red [!CAUTION])
+	Cautions    string // caution-tier warnings — advisory (amber [!WARNING])
 	Failures    string // resources that failed to render
 	Images      string // container image changes (a Markdown table)
 }
@@ -136,6 +138,7 @@ func summarySectionsFor(d *api.DiffResult, admonitions bool) summarySections {
 		Impact:      sectionImpact(d, admonitions),
 		Routine:     sectionRoutine(d, admonitions),
 		BlastRadius: sectionBlastRadius(d),
+		Blocking:    sectionBlocking(d, admonitions),
 		Cautions:    sectionCautions(d, admonitions),
 		Failures:    sectionFailures(d, admonitions),
 		Images:      sectionImages(d),
@@ -179,22 +182,47 @@ func sectionRoutine(d *api.DiffResult, admonitions bool) string {
 	return msg
 }
 
+// sectionBlocking renders the blocking-tier warnings — findings that fail the
+// check (see checkConclusion). Red [!CAUTION], the top of the ramp, above the
+// amber cautions. Empty unless a rule emitted a LevelBlocking warning (none do
+// yet).
+func sectionBlocking(d *api.DiffResult, admonitions bool) string {
+	ws := api.WarningsByLevel(d.Warnings, api.LevelBlocking)
+	if len(ws) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	if admonitions {
+		fmt.Fprintf(&b, "> [!CAUTION]\n> **⛔ %s**\n", plural(len(ws), "Blocker", "Blockers"))
+		for _, wn := range ws {
+			fmt.Fprintf(&b, "> - `%s` — %s\n", mdCode(wn.Resource), mdInline(wn.Detail))
+		}
+	} else {
+		fmt.Fprintf(&b, "**⛔ %s**\n", plural(len(ws), "Blocker", "Blockers"))
+		for _, wn := range ws {
+			fmt.Fprintf(&b, "- `%s` — %s\n", mdCode(wn.Resource), mdInline(wn.Detail))
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
 func sectionCautions(d *api.DiffResult, admonitions bool) string {
-	if len(d.Warnings) == 0 {
+	ws := api.WarningsByLevel(d.Warnings, api.LevelCaution)
+	if len(ws) == 0 {
 		return ""
 	}
 	var b strings.Builder
 	if admonitions {
 		// Amber [!WARNING] to match the caution list pill's colour (a notch below
-		// the red [!CAUTION] of a render failure). The alert header reads "Warning",
-		// so the block names itself.
-		fmt.Fprintf(&b, "> [!WARNING]\n> **⚠ %s**\n", plural(len(d.Warnings), "Caution", "Cautions"))
-		for _, wn := range d.Warnings {
+		// the red [!CAUTION] of a blocker or render failure). The alert header
+		// reads "Warning", so the block names itself.
+		fmt.Fprintf(&b, "> [!WARNING]\n> **⚠ %s**\n", plural(len(ws), "Caution", "Cautions"))
+		for _, wn := range ws {
 			fmt.Fprintf(&b, "> - `%s` — %s\n", mdCode(wn.Resource), mdInline(wn.Detail))
 		}
 	} else {
-		fmt.Fprintf(&b, "**⚠ %s**\n", plural(len(d.Warnings), "Caution", "Cautions"))
-		for _, wn := range d.Warnings {
+		fmt.Fprintf(&b, "**⚠ %s**\n", plural(len(ws), "Caution", "Cautions"))
+		for _, wn := range ws {
 			fmt.Fprintf(&b, "- `%s` — %s\n", mdCode(wn.Resource), mdInline(wn.Detail))
 		}
 	}

--- a/internal/server/markdown_test.go
+++ b/internal/server/markdown_test.go
@@ -30,6 +30,44 @@ func sampleSummaryEnv() api.DiffEnvelope {
 	}
 }
 
+func TestSummaryMarkdown_BlockingTierSeparateFromCaution(t *testing.T) {
+	t.Parallel()
+	env := api.DiffEnvelope{
+		Status: api.JobReady,
+		PR:     api.PR{Number: 7},
+		Diff: &api.DiffResult{
+			HeadSHA: "abc1234",
+			Summary: api.DiffSummary{Changed: 1},
+			Impact:  api.Impact{Resources: 1},
+			Warnings: []api.Warning{
+				{Level: api.LevelBlocking, Rule: "image-not-found", Resource: "Deployment web/api", Detail: "image ghcr.io/x:9.9.9 not found upstream"},
+				{Level: api.LevelCaution, Rule: "replicas-zero", Resource: "Deployment web/api", Detail: "replicas set to 0"},
+			},
+		},
+	}
+	// Blocking → red [!CAUTION] "Blocker"; caution → amber [!WARNING], its own block.
+	md := summaryMarkdown(env, "", true)
+	for _, want := range []string{
+		"> [!CAUTION]\n> **⛔ Blocker**",
+		"> - `Deployment web/api` — image ghcr.io/x:9.9.9 not found upstream",
+		"> [!WARNING]\n> **⚠ Caution**",
+		"> - `Deployment web/api` — replicas set to 0",
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("blocking markdown missing %q\n---\n%s", want, md)
+		}
+	}
+	// The blocking finding must not be double-counted into the caution block — with
+	// one caution the header stays singular ("Caution", never plural "Cautions").
+	if strings.Contains(md, "**⚠ Cautions**") {
+		t.Errorf("blocking warning leaked into the caution count:\n%s", md)
+	}
+	// Blocking (higher severity) renders before the caution block.
+	if bi, ci := strings.Index(md, "⛔ Blocker"), strings.Index(md, "⚠ Caution"); bi < 0 || ci < 0 || bi > ci {
+		t.Errorf("blocking block should render before caution (blocking=%d caution=%d)\n%s", bi, ci, md)
+	}
+}
+
 func TestSummaryMarkdown_GitHubAdmonitions(t *testing.T) {
 	t.Parallel()
 	md := summaryMarkdown(sampleSummaryEnv(), "https://k.example/#/pr/142", true)

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -188,7 +188,7 @@ func writePRLine(b *strings.Builder, p api.PRStatus) {
 }
 
 // signalSummary joins the non-zero rendered-diff signals (omitting any that are
-// zero), e.g. "11 resources, 1 caution, 1 image change, 1 render failure".
+// zero), e.g. "11 resources, 1 blocker, 1 caution, 1 image change, 1 render failure".
 func signalSummary(s *api.Signals) string {
 	if s == nil {
 		return ""
@@ -196,6 +196,9 @@ func signalSummary(s *api.Signals) string {
 	var parts []string
 	if s.Resources > 0 {
 		parts = append(parts, fmt.Sprintf("%d %s", s.Resources, plural(s.Resources, "resource", "resources")))
+	}
+	if s.Blocking > 0 {
+		parts = append(parts, fmt.Sprintf("%d %s", s.Blocking, plural(s.Blocking, "blocker", "blockers")))
 	}
 	if s.Caution > 0 {
 		parts = append(parts, fmt.Sprintf("%d %s", s.Caution, plural(s.Caution, "caution", "cautions")))

--- a/internal/server/queue.go
+++ b/internal/server/queue.go
@@ -191,7 +191,7 @@ func (q *queue) run(pr api.PR) {
 				sig = computeSignals(&res) // PR closed mid-render; nothing stored
 			}
 			q.log.Info("diff rendered", "pr", pr.Number, "duration", time.Since(start).Round(time.Millisecond),
-				"resources", sig.Resources, "caution", sig.Caution, "images", sig.Images, "failures", sig.Failures)
+				"resources", sig.Resources, "blocking", sig.Blocking, "caution", sig.Caution, "images", sig.Images, "failures", sig.Failures)
 			q.emit(pr.Number, api.JobReady, "")
 			if q.report != nil {
 				q.report(pr, api.JobReady, sig, "")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -341,12 +341,12 @@ func (s *Server) checkResult(pr api.PR, st api.JobStatus, sig *api.Signals, errM
 	return res
 }
 
-// checkConclusion maps a render verdict to a Check Run conclusion: a render error
-// or any render failure fails the check; cautions are a non-blocking neutral; an
-// otherwise-clean render passes.
+// checkConclusion maps a render verdict to a Check Run conclusion: a render error,
+// any render failure, or a blocking-tier warning fails the check; cautions are a
+// non-blocking neutral; an otherwise-clean render passes.
 func checkConclusion(st api.JobStatus, sig *api.Signals) string {
 	switch {
-	case st == api.JobError, sig != nil && sig.Failures > 0:
+	case st == api.JobError, sig != nil && sig.Failures > 0, sig != nil && sig.Blocking > 0:
 		return provider.CheckFailure
 	case sig != nil && sig.Caution > 0:
 		return provider.CheckNeutral
@@ -390,6 +390,9 @@ func renderedStatusDescription(sig *api.Signals) string {
 		return "Rendered the diff"
 	}
 	d := fmt.Sprintf("%d %s changed", sig.Resources, plural(sig.Resources, "resource", "resources"))
+	if sig.Blocking > 0 {
+		d += fmt.Sprintf(", %d %s", sig.Blocking, plural(sig.Blocking, "blocker", "blockers"))
+	}
 	if sig.Caution > 0 {
 		d += fmt.Sprintf(", %d %s", sig.Caution, plural(sig.Caution, "caution", "cautions"))
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1273,7 +1273,7 @@ func TestServer_SignalsInList(t *testing.T) {
 			Resources: []api.DiffResource{{ID: "r0"}, {ID: "r1"}},
 			Images:    []api.ImageChange{{Name: "ghcr.io/x"}},
 			Failures:  []api.RenderFailure{{Parent: "HR a/b"}},
-			Warnings:  []api.Warning{{Level: "danger"}, {Level: "caution"}, {Level: "caution"}},
+			Warnings:  []api.Warning{{Level: api.LevelBlocking}, {Level: api.LevelCaution}, {Level: api.LevelCaution}},
 		}, nil
 	}}
 	pr := api.PR{Number: 3, HeadRef: "f", BaseRef: "main"}
@@ -1289,7 +1289,7 @@ func TestServer_SignalsInList(t *testing.T) {
 		t.Fatalf("expected signals on the ready PR: %+v", list)
 	}
 	got := *list[0].Signals
-	want := api.Signals{Resources: 2, Caution: 3, Images: 1, Failures: 1}
+	want := api.Signals{Resources: 2, Caution: 2, Blocking: 1, Images: 1, Failures: 1}
 	if got != want {
 		t.Errorf("signals = %+v, want %+v", got, want)
 	}

--- a/internal/server/status_test.go
+++ b/internal/server/status_test.go
@@ -24,6 +24,11 @@ func TestRenderedStatusDescription(t *testing.T) {
 			&api.Signals{Resources: 12, Caution: 2, Failures: 1},
 			"12 resources changed, 2 cautions, 1 render failure",
 		},
+		{
+			"blocking ranks before caution",
+			&api.Signals{Resources: 5, Blocking: 1, Caution: 2},
+			"5 resources changed, 1 blocker, 2 cautions",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -300,7 +300,8 @@ func (s *store) persistRecord(number int, rec persist.Record, prev uint64) {
 func computeSignals(d *api.DiffResult) *api.Signals {
 	return &api.Signals{
 		Resources: len(d.Resources),
-		Caution:   len(d.Warnings), // every warning is a caution (the sole severity)
+		Caution:   len(api.WarningsByLevel(d.Warnings, api.LevelCaution)),
+		Blocking:  len(api.WarningsByLevel(d.Warnings, api.LevelBlocking)),
 		Images:    len(d.Images),
 		Failures:  len(d.Failures),
 		Routine:   d.Routine,

--- a/internal/server/store_persist_test.go
+++ b/internal/server/store_persist_test.go
@@ -31,7 +31,7 @@ func TestStore_PersistsAcrossRestart(t *testing.T) {
 	// First process: render an open PR (#1) and render-then-merge another (#2).
 	s1 := open()
 	s1.upsertPR(api.PR{Number: 1, HeadSHA: "a", Open: true}, false)
-	s1.setResult(1, api.DiffResult{PRNumber: 1, HeadSHA: "a", Warnings: []api.Warning{{}}})
+	s1.setResult(1, api.DiffResult{PRNumber: 1, HeadSHA: "a", Warnings: []api.Warning{{Level: api.LevelCaution}}})
 	s1.upsertPR(api.PR{Number: 2, HeadSHA: "b", Open: true}, false)
 	s1.setResult(2, api.DiffResult{PRNumber: 2, HeadSHA: "b"})
 	s1.markClosed(2, s1.now())

--- a/internal/server/writeback_test.go
+++ b/internal/server/writeback_test.go
@@ -54,6 +54,7 @@ func TestCheckConclusion(t *testing.T) {
 	}{
 		{"render error fails", api.JobError, nil, provider.CheckFailure},
 		{"render failures fail", api.JobReady, &api.Signals{Failures: 1, Caution: 2}, provider.CheckFailure},
+		{"blocking warning fails", api.JobReady, &api.Signals{Blocking: 1, Caution: 2}, provider.CheckFailure},
 		{"cautions are neutral (non-blocking)", api.JobReady, &api.Signals{Caution: 1}, provider.CheckNeutral},
 		{"a clean render passes", api.JobReady, &api.Signals{Resources: 3}, provider.CheckSuccess},
 		{"a ready render with no signals passes", api.JobReady, nil, provider.CheckSuccess},

--- a/internal/web/src/lib/types.ts
+++ b/internal/web/src/lib/types.ts
@@ -27,7 +27,8 @@ export interface PR {
 
 export interface Signals {
   resources: number;
-  caution: number; // caution warnings (the sole severity)
+  caution: number; // caution-tier warnings (advisory → neutral check)
+  blocking: number; // blocking-tier warnings (fail the check); 0 today
   images: number;
   failures: number;
   routine: boolean; // only image/chart-version changed, nothing flagged
@@ -82,7 +83,7 @@ export interface RenderFailure {
 }
 
 export interface Warning {
-  level: 'caution'; // the sole severity
+  level: 'caution' | 'blocking';
   rule: string;
   resource: string;
   detail: string;


### PR DESCRIPTION
## What

Turns konflate's single warning severity into an ordered **tier system** — `caution` (advisory → neutral check) and a new `blocking` (fails the check) — as a **behavior-preserving prep**. It's the groundwork so an upcoming rule (image-tag-missing-upstream) can start as an advisory `caution` and later be promoted to `blocking` with a **one-line change**, without reworking any plumbing.

## Changes
- **`api`** — `Level` is now a typed string (`LevelCaution`, new `LevelBlocking`) + a `WarningsByLevel` helper. `Signals` gains a `Blocking` count.
- **`server`** — `checkConclusion` fails the check on a blocking-tier warning (alongside render errors/failures); cautions stay a non-blocking neutral. Blocking is also surfaced in the one-line status description, the render-complete log, and the MCP signal summary — so the backend is wired **end-to-end**, not half-way.
- **`markdown`** — a blocking finding renders in its own red `[!CAUTION]` **"Blocker"** block above the amber cautions; `sectionCautions` filters to the caution tier.
- **`ui`** — types carry `Signals.blocking` + a `'caution' | 'blocking'` level union.

## Behavior-preserving
**No rule emits `LevelBlocking` yet**, so `Blocking` is always `0` and every real diff is byte-identical to before — the check conclusion, signal counts, and rendered summary are unchanged. An adversarial review confirmed no output drift for the all-caution case; the existing suite (which is all-caution) stays green.

## Deferred to the follow-up (the image-existence check PR)
- The blocking tier's **UI surfacing** — list badge, command-palette scoring/badge, and the red CSS treatment — lands with the first rule that actually emits it, where it can be designed against a real example.
- The image-existence check itself, which ships as a `caution` first (per the earlier decision) and is the natural place to exercise/promote the blocking tier.

## Notes
- Corrects two pre-existing test fixtures that predated the type: a bare `{Level: "danger"}` (never a real level) and an empty `{}` warning now use the proper `LevelCaution`/`LevelBlocking` constants.
- Verified locally: `go test ./...`, `vet`, `lint` (0 issues), `fmt-check`, `tidy-check`, `ui-typecheck`, `ui-build`, Playwright (76 passed).

PR 1 of 2 (tier refactor → image check).
