### PR TITLE
fix(server): close five PR-lifecycle state-machine races

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -530,6 +530,12 @@ func (s *Server) authorizedPush(r *http.Request) bool {
 // have left the open set. Runs at startup and once per RefreshInterval; a
 // verified webhook also calls it when the open-PR set may have changed.
 func (s *Server) refreshList(ctx context.Context) {
+	// Serialize list passes: the startup warm, the periodic tick, and a
+	// webhook-driven relist can otherwise overlap, and two lists carrying divergent
+	// open-set snapshots could interleave an un-shelve (markOpen) with a close
+	// (markClosed) for the same PR. One at a time also avoids a redundant double-list.
+	s.listMu.Lock()
+	defer s.listMu.Unlock()
 	if reset, blocked := s.rateLimitedUntil(); blocked {
 		s.log.Debug("refresh: skipping list while rate-limited", "until", reset)
 		return
@@ -550,19 +556,25 @@ func (s *Server) refreshList(ctx context.Context) {
 		allowed := s.prAllowed(pr)
 		open[pr.Number] = struct{}{}
 		prev, known := s.store.get(pr.Number)
-		s.store.upsertPR(pr, !allowed)
-		// Render a PR that is newly tracked, whose head advanced, or that just
-		// became filter-allowed without a push (e.g. draft → ready under a
-		// !pr.draft filter). That last case is easy to miss: in polling mode
-		// nothing else enqueues it, and the staleness backstop skips never-rendered
-		// jobs, so it would sit pending forever.
+		// markOpen (not upsertPR) here because the list is the authoritative open
+		// set: a PR reappearing in it is genuinely open again, so it un-shelves a
+		// previously-merged PR (a reopen) and reports it so we re-render.
+		reopened := s.store.markOpen(pr, !allowed)
+		// Render a PR that is newly tracked, reopened, whose head advanced, or that
+		// just became filter-allowed without a push (e.g. draft → ready under a
+		// !pr.draft filter). That last case is easy to miss: in polling mode nothing
+		// else enqueues it, and the staleness backstop skips never-rendered jobs, so
+		// it would sit pending forever.
 		nowAllowed := known && prev.Hidden && allowed
-		if allowed && (!known || prev.PR.HeadSHA != pr.HeadSHA || nowAllowed) {
+		if allowed && (!known || reopened || prev.PR.HeadSHA != pr.HeadSHA || nowAllowed) {
 			reason := "head advanced"
 			switch {
 			case !known:
 				reason = "new PR"
 				added++
+			case reopened:
+				reason = "reopened"
+				advanced++
 			case nowAllowed:
 				reason = "filter now admits"
 				unhidden++
@@ -728,7 +740,19 @@ func (s *Server) reconcileHeadGone(number int) {
 		s.log.Warn("reconcile head-gone PR failed", "pr", number, "error", err)
 		return
 	}
-	s.reconcileState(pr)
+	if pr.Open && s.prAllowed(pr) {
+		// The pull ref was gone mid-render but the PR is still open and admitted. A
+		// merge keeps refs/pull/N/head (see gitclone), and a deleted PR returns
+		// ErrPRNotFound above — so a missing pull ref on an open PR is the forge not
+		// having materialized it yet for a just-opened PR (an async-ref race), not a
+		// close. Re-enqueue so the first render isn't wedged in JobRunning forever
+		// (renderedAt stays zero, which the staleness backstop skips); it coalesces
+		// into a trailing render and succeeds once the ref appears.
+		s.store.upsertPR(pr, false)
+		s.queue.enqueue(pr)
+		return
+	}
+	s.reconcileState(pr) // merged / closed / no-longer-admitted: shelve or drop
 }
 
 func writeJSON(w http.ResponseWriter, code int, v any) {

--- a/internal/server/queue_test.go
+++ b/internal/server/queue_test.go
@@ -46,6 +46,7 @@ func TestQueue_CoalescesRerun(t *testing.T) {
 	st := newStore()
 	q := newQueue(context.Background(), diff, st, nil, nil, newMetrics(), discardLog(), 2, nil)
 	pr := api.PR{Number: 1}
+	st.upsertPR(pr, false) // record it first, mirroring the real flow (upsert before enqueue)
 
 	q.enqueue(pr)
 	<-started // first render is running
@@ -248,6 +249,8 @@ func TestQueue_RunsConcurrently(t *testing.T) {
 	st := newStore()
 	q := newQueue(context.Background(), diff, st, nil, nil, newMetrics(), discardLog(), 2, nil)
 
+	st.upsertPR(api.PR{Number: 1}, false) // record before enqueue, as the real flow does
+	st.upsertPR(api.PR{Number: 2}, false)
 	q.enqueue(api.PR{Number: 1})
 	q.enqueue(api.PR{Number: 2})
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -65,6 +65,11 @@ type Server struct {
 	queue   *queue
 	runCtx  context.Context
 
+	// listMu serializes refreshList: startup warm, the periodic tick, and a
+	// webhook-driven relist must not overlap, or two divergent open-set snapshots
+	// could interleave an un-shelve (markOpen) with a close (markClosed).
+	listMu sync.Mutex
+
 	// prWrite serializes forge write-backs per PR (see writeBack): the queue can
 	// finish a PR's in-flight and trailing renders back-to-back, each firing a
 	// write-back, and two for the same PR must not race into duplicate comments.

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -53,6 +53,12 @@ type job struct {
 	// interval even when nothing changed; comparing against this skips rewriting
 	// an identical multi-MB diff each time.
 	savedDigest uint64
+	// digest is the same content hash for the CURRENT in-memory diff. Unlike
+	// savedDigest (which only advances on a successful save) it is updated on every
+	// render, so it always reflects what a reader would receive — it backs the diff
+	// ETag, so a changed body revalidates even while persistence is failing. Both
+	// are zero until the first render / after a reload.
+	digest uint64
 }
 
 // store is the in-memory, concurrency-safe record of every known PR and the
@@ -162,7 +168,10 @@ func (s *store) del(number int) {
 
 // upsertPR records (or refreshes) a PR's metadata. A PR seen for the first time
 // starts in the pending state; an already-tracked PR keeps its current status
-// but takes the new metadata (title/labels/head may have changed).
+// (including a merged-shelf freeze) but takes the new metadata (title/labels/head
+// may have changed). It never un-shelves: a stale "open" snapshot from a point
+// fetch (a delayed webhook refreshPR racing a merge) must not revive a just-merged
+// PR — reopens are un-shelved only by the authoritative open-list path (markOpen).
 func (s *store) upsertPR(pr api.PR, hidden bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -173,8 +182,32 @@ func (s *store) upsertPR(pr api.PR, hidden bool) {
 	}
 	j.pr = pr
 	j.hidden = hidden
-	j.closedAt = time.Time{} // seen in the open set again (covers reopen)
 	j.updated = s.now()
+}
+
+// markOpen records a PR the current forge open-list reports as open. Like upsertPR
+// it creates/refreshes the job, but — because the list is the authoritative open
+// set — it also un-shelves a PR previously frozen as merged (a reopen), returning
+// true so the caller re-renders it. Point fetches use upsertPR (which preserves
+// the shelf), so only a full re-list can revive a merged PR; that keeps a stale
+// point "open" snapshot from racing markClosed to un-shelve one. refreshList is
+// serialized, so two overlapping lists can't interleave an un-shelve with a close.
+func (s *store) markOpen(pr api.PR, hidden bool) (reopened bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	j := s.jobs[pr.Number]
+	if j == nil {
+		s.jobs[pr.Number] = &job{pr: pr, status: api.JobPending, updated: s.now(), hidden: hidden}
+		return false
+	}
+	if !j.closedAt.IsZero() {
+		j.closedAt = time.Time{} // reopened — the authoritative open list includes it again
+		reopened = true
+	}
+	j.pr = pr
+	j.hidden = hidden
+	j.updated = s.now()
+	return reopened
 }
 
 // setChecks updates a PR's CI rollup, reporting whether it actually changed so
@@ -220,19 +253,18 @@ func (s *store) prByHeadSHA(sha string) (api.PR, bool) {
 	return api.PR{}, false
 }
 
-// setStatus transitions a PR to status, recording its metadata if new. A PR
-// already frozen on the merged shelf is left untouched, so a render that was
-// enqueued before the PR merged cannot drag it back into a live state.
+// setStatus transitions a known, still-open PR to status. It no-ops for a PR the
+// store no longer knows — one dropped (abandoned/pruned) while its render sat
+// queued behind the semaphore — and for one frozen on the merged shelf: a render
+// enqueued before the PR left the open set must neither recreate nor revive it.
+// (upsertPR/markOpen are the only creators, and a PR is always recorded before it
+// is enqueued, so a nil job here means the PR was removed, never a first render.)
 func (s *store) setStatus(pr api.PR, status api.JobStatus) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	j := s.jobs[pr.Number]
-	if j != nil && !j.closedAt.IsZero() {
+	if j == nil || !j.closedAt.IsZero() {
 		return
-	}
-	if j == nil {
-		j = &job{pr: pr}
-		s.jobs[pr.Number] = j
 	}
 	j.pr = pr
 	j.status = status
@@ -270,7 +302,7 @@ func (s *store) setResult(number int, result api.DiffResult) *api.Signals {
 	// safe to read unlocked — j.result is replaced wholesale, never mutated in
 	// place, and per-PR coalescing means no second setResult for this PR runs
 	// concurrently.
-	s.persistRecord(number, rec, prev)
+	s.persistRecord(j, rec, prev)
 	return sig
 }
 
@@ -281,8 +313,24 @@ func (s *store) setResult(number int, result api.DiffResult) *api.Signals {
 // skipping it as "already on disk" (which would strand stale content that a
 // restart then restores). The costly marshal runs off the store lock; the digest
 // is committed under a brief re-lock.
-func (s *store) persistRecord(number int, rec persist.Record, prev uint64) {
+// persistRecord takes the *job it is persisting (not just the number) so it can
+// tell, after the off-lock save, whether that exact job is still the live one for
+// its number — it may have been dropped (abandoned/pruned) or replaced by a fresh
+// job (a reopen) meanwhile. Both digest commits are guarded on that identity, so a
+// stale render can neither revive a removed PR's ETag nor clobber a replacement
+// job's savedDigest with a hash whose file it then orphans.
+func (s *store) persistRecord(j *job, rec persist.Record, prev uint64) {
+	number := rec.PR.Number
 	d := contentDigest(rec)
+	// Record the in-memory content hash for the ETag first, independent of whether
+	// the save below succeeds — so a changed diff always revalidates (a fresh ETag)
+	// even while persistence is failing on a full/read-only volume.
+	s.mu.Lock()
+	if s.jobs[number] == j {
+		j.digest = d
+	}
+	s.mu.Unlock()
+
 	if d == prev {
 		return // unchanged: nothing to write, and savedDigest is already current
 	}
@@ -290,10 +338,16 @@ func (s *store) persistRecord(number int, rec persist.Record, prev uint64) {
 		return // leave savedDigest as-is so the next render retries the write
 	}
 	s.mu.Lock()
-	if j := s.jobs[number]; j != nil {
+	if s.jobs[number] == j {
 		j.savedDigest = d
+		s.mu.Unlock()
+		return
 	}
 	s.mu.Unlock()
+	// j was dropped or replaced while this save ran off the lock: the file just
+	// written belongs to a job that is no longer live, and a restart would resurrect
+	// it. Delete it — a replacement job persists its own render separately.
+	s.del(number)
 }
 
 // computeSignals reduces a diff to its at-a-glance counts for the PR list.
@@ -351,7 +405,7 @@ func (s *store) get(number int) (api.DiffEnvelope, bool) {
 		Error:        j.errMsg,
 		RefreshError: j.refreshErr,
 		Hidden:       j.hidden,
-		Digest:       j.savedDigest,
+		Digest:       j.digest,
 	}, true
 }
 
@@ -444,7 +498,7 @@ func (s *store) markClosed(number int, when time.Time) {
 
 	// Re-record with the merge stamp so the shelf survives a restart — off the
 	// lock; the merge always changes the content, so this writes.
-	s.persistRecord(number, rec, prev)
+	s.persistRecord(j, rec, prev)
 }
 
 // remove drops a PR from the store entirely (used for abandoned PRs and by

--- a/internal/server/store_lifecycle_test.go
+++ b/internal/server/store_lifecycle_test.go
@@ -1,0 +1,148 @@
+package server
+
+import (
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/home-operations/konflate/internal/api"
+	"github.com/home-operations/konflate/internal/gitclone"
+	"github.com/home-operations/konflate/internal/persist"
+)
+
+// #2 — a render enqueued before its PR was dropped must not recreate it.
+func TestStore_SetStatusDoesNotResurrectRemovedPR(t *testing.T) {
+	t.Parallel()
+	st := newStore()
+	st.upsertPR(api.PR{Number: 1, Open: true}, false)
+	st.remove(1) // abandoned/pruned while its render sat queued behind the semaphore
+
+	st.setStatus(api.PR{Number: 1, Open: true}, api.JobRunning)
+	if _, ok := st.get(1); ok {
+		t.Fatal("setStatus resurrected a removed PR")
+	}
+	if sig := st.setResult(1, api.DiffResult{PRNumber: 1}); sig != nil {
+		t.Fatal("setResult returned signals for a removed PR")
+	}
+	if _, ok := st.get(1); ok {
+		t.Fatal("setResult resurrected a removed PR")
+	}
+}
+
+// #3 — a stale point "open" snapshot must not un-shelve a merged PR; only the
+// authoritative open-list path (markOpen) un-shelves a genuine reopen.
+func TestStore_MergedShelfSurvivesStaleOpenSnapshot(t *testing.T) {
+	t.Parallel()
+	st := newStore()
+	st.upsertPR(api.PR{Number: 1, Open: true}, false)
+	st.markClosed(1, st.now())
+
+	st.upsertPR(api.PR{Number: 1, Open: true}, false) // delayed refreshPR racing the merge
+	if prStatus(st, 1).ClosedAt == nil {
+		t.Fatal("upsertPR un-shelved a merged PR from a stale open snapshot")
+	}
+
+	if !st.markOpen(api.PR{Number: 1, Open: true}, false) {
+		t.Fatal("markOpen should report the reopen of a shelved PR")
+	}
+	if prStatus(st, 1).ClosedAt != nil {
+		t.Fatal("markOpen should have un-shelved the reopened PR")
+	}
+}
+
+// #4 — the diff ETag digest must track the in-memory body even when the persist
+// write fails, so a changed diff still revalidates (no stale 304).
+func TestStore_ETagDigestUpdatesEvenWhenPersistFails(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	p, err := persist.New(dir, discardLog())
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := newStore()
+	st.loadFrom(p, discardLog())
+	st.upsertPR(api.PR{Number: 1, Open: true}, false)
+
+	st.setResult(1, api.DiffResult{PRNumber: 1, HeadSHA: "a", Resources: []api.DiffResource{{ID: "r0"}}})
+	env1, _ := st.get(1)
+
+	// Make persistence fail (a full / read-only volume) — Save's temp file can no
+	// longer be created — then render a different body.
+	_ = os.RemoveAll(dir)
+	st.setResult(1, api.DiffResult{PRNumber: 1, HeadSHA: "b", Resources: []api.DiffResource{{ID: "r0"}, {ID: "r1"}}})
+	env2, _ := st.get(1)
+
+	if env1.Digest == 0 || env2.Digest == 0 {
+		t.Fatal("expected a non-zero content digest after each render")
+	}
+	if env1.Digest == env2.Digest {
+		t.Fatal("the ETag digest must change when the diff body changes, even if the persist write failed")
+	}
+}
+
+// #5 — a save that lands off-lock for a PR that was removed and reopened as a
+// fresh job must neither clobber the replacement's savedDigest nor leave a zombie
+// file a restart resurrects.
+func TestStore_StaleSaveDoesNotClobberOrOrphanReplacedPR(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	p, err := persist.New(dir, discardLog())
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := newStore()
+	st.loadFrom(p, discardLog())
+
+	// A stale render's save lands off the lock after PR #7 was removed and reopened
+	// as a fresh job. persistRecord (prev=0 forces the write) must neither clobber
+	// the replacement job's savedDigest with the stale hash nor leave its own
+	// now-orphaned file for a restart to resurrect.
+	stale := &job{pr: api.PR{Number: 7, Open: true}, status: api.JobReady}
+	st.markOpen(api.PR{Number: 7, Open: true}, false) // the live replacement job for #7
+	rec := persist.Record{
+		PR:     api.PR{Number: 7, Open: true},
+		Status: api.JobReady,
+		Result: &api.DiffResult{PRNumber: 7, HeadSHA: "a"},
+	}
+	st.persistRecord(stale, rec, 0)
+
+	if live := st.jobs[7]; live == nil || live.savedDigest != 0 {
+		t.Fatalf("stale save clobbered the replacement job's savedDigest: %+v", live)
+	}
+	fresh, err := persist.New(dir, discardLog())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range fresh.Load() {
+		if r.PR.Number == 7 {
+			t.Fatal("persistRecord left a zombie file for a replaced PR")
+		}
+	}
+}
+
+// #1 — a head-gone render on a still-open PR (the just-opened pull-ref race) must
+// retry rather than wedge the PR in JobRunning forever.
+func TestServer_HeadGoneOnOpenPRRetriesInsteadOfWedging(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	eng := &fakeEngine{fn: func(pr api.PR) (api.DiffResult, error) {
+		if calls.Add(1) == 1 {
+			return api.DiffResult{}, gitclone.ErrHeadRefGone // pull ref not yet materialized
+		}
+		return api.DiffResult{PRNumber: pr.Number, HeadSHA: "abc"}, nil
+	}}
+	pr := api.PR{Number: 1, Open: true, HeadRef: "f", BaseRef: "main"}
+	prov := &fakeProvider{prs: []api.PR{pr}} // GetPR reports it open — a transient race, not a close
+	s := newTestServer(t, ghCfg("tok"), prov, eng)
+
+	s.store.upsertPR(pr, false)
+	s.queue.enqueue(pr)
+
+	env := waitFor(t, s, 1)
+	if env.Status != api.JobReady {
+		t.Fatalf("head-gone on an open PR should retry to JobReady, got %s", env.Status)
+	}
+	if n := calls.Load(); n < 2 {
+		t.Fatalf("expected a re-render after the transient head-gone, got %d render calls", n)
+	}
+}


### PR DESCRIPTION
## What

Closes the five **PR-lifecycle state-machine** bugs the project review confirmed (the highest-severity cluster) — races and wedges in the `store` / reconcile / persist layer. Each is fixed narrowly and covered by a regression test.

| # | Bug | Fix |
|---|---|---|
| 1 | A head-gone render on a **still-open** PR wedged it in `JobRunning` forever (`renderedAt` zero → the staleness backstop skips it, and nothing re-enqueues) | `reconcileHeadGone` re-enqueues when the re-fetched PR is open+allowed. Safe from spinning: a merge keeps `refs/pull/N/head` (per gitclone) and a deleted PR returns `ErrPRNotFound`→drop, so a missing pull ref on an open PR is the just-opened async-ref race, which resolves on retry. |
| 2 | A render still queued when its PR was **dropped** (abandoned/pruned) resurrected it via `setStatus` recreating the job (then `setResult` persisted it as open/ready + fired write-back on a closed PR) | `setStatus` no-ops when the job is unknown. `upsertPR`/`markOpen` are the only creators and always run before an enqueue, so a nil job here is always a removed PR. |
| 3 | A stale point **"open" snapshot** (a delayed webhook `refreshPR` racing a merge) un-shelved a just-merged PR — `upsertPR` cleared `closedAt` unconditionally | `upsertPR` preserves `closedAt`. A new `store.markOpen` (used only by the authoritative open-**list**) un-shelves genuine reopens, and `refreshList` is serialized by `s.listMu` so two overlapping lists can't interleave an un-shelve with a close. |
| 4 | After a **failed persist**, the diff **ETag** used the on-disk `savedDigest` (unchanged), so a changed diff served a stale `304` | `persistRecord` sets an in-memory `job.digest` (the ETag source, returned by `get()`) *before* the save, independent of whether it succeeds. |
| 5 | A save landing off-lock for a PR **removed/replaced** meanwhile left a **zombie file** a restart resurrects | `persistRecord` takes the `*job` and commits `savedDigest` only when `s.jobs[n]` is still that exact instance; otherwise it deletes the orphaned file. |

## Tests
`internal/server/store_lifecycle_test.go` — one regression test per bug (setStatus-no-resurrect, merged-shelf-survives-stale-open + markOpen-unshelves, ETag-updates-on-failed-persist, stale-save-doesn't-clobber-or-orphan-a-replaced-PR, head-gone-on-open-retries). #4 and #5 were revert-verified to fail without their fix; #1's wedge is caught by `waitFor` timing out. The two `queue_test.go` harness edits add the `upsertPR`-before-`enqueue` the real flow always does (they'd previously leaned on the #2 bug).

## Safety
Happy path is unchanged. An adversarial 3-angle review (new races/deadlocks, completeness, test validity) came back clean after these fixes — it confirmed `s.listMu` is deadlock/starvation-safe and flagged the replaced-job `persistRecord` case, now closed by the pointer-identity guard.

Verified: `go test -race ./...`, `vet`, `lint` (0), `fmt-check`, `tidy-check`. No UI/chart changes.

PR A of the review's fix batching (B: write-back robustness · C: engine/lint correctness · D: UI + types drift · E: markdown escape · F: perf + quality).
