### PR TITLE
fix(provider): make write-back survive rate limits, big diffs, and >30 checks

### DIFF
--- a/internal/provider/checks_test.go
+++ b/internal/provider/checks_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	forgejo "codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
 	"github.com/google/go-github/v88/github"
 
 	"github.com/home-operations/konflate/internal/api"
@@ -61,5 +62,65 @@ func TestGitHubProvider_ChecksNoSHA(t *testing.T) {
 	got, err := p.Checks(context.Background(), api.PR{Number: 1})
 	if err != nil || got.State != api.CheckNone {
 		t.Fatalf("got %+v, %v; want none / no error", got, err)
+	}
+}
+
+// TestForgejoProvider_ChecksPagesAndDedups verifies the rollup walks ALL pages of
+// commit statuses (GetCombinedStatus couldn't page, silently dropping contexts past
+// the server's default page size) and reduces to the latest status per context —
+// highest id wins — matching the combined endpoint's server-side dedup.
+func TestForgejoProvider_ChecksPagesAndDedups(t *testing.T) {
+	t.Parallel()
+	const sha = "deadbeefcafe"
+	var combinedHit bool
+	mux := http.NewServeMux()
+	// The old, unpaged combined-status endpoint must no longer be used. (The Forgejo
+	// SDK prefixes every path with /api/v1.)
+	mux.HandleFunc("/api/v1/repos/acme/web/commits/"+sha+"/status", func(w http.ResponseWriter, _ *http.Request) {
+		combinedHit = true
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("/api/v1/repos/acme/web/commits/"+sha+"/statuses", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") == "2" {
+			_, _ = w.Write([]byte(`[` +
+				`{"id":4,"status":"pending","context":"ci/lint"},` +
+				`{"id":2,"status":"warning","context":"ci/warn"}]`))
+			return
+		}
+		// Page 1 advertises a next page via the Link header (what the SDK reads). It
+		// also lists ci/build twice: the newer (id 5, success) must win over the
+		// stale (id 1, pending), or the pending count would be wrong.
+		w.Header().Set("Link", `<?page=2>; rel="next"`)
+		_, _ = w.Write([]byte(`[` +
+			`{"id":1,"status":"pending","context":"ci/build"},` +
+			`{"id":5,"status":"success","context":"ci/build"},` +
+			`{"id":3,"status":"failure","context":"ci/test"}]`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client, err := forgejo.NewClient(srv.URL,
+		forgejo.SetForgejoVersion(forgejo.Version()), forgejo.SetToken("tok"))
+	if err != nil {
+		t.Fatalf("forgejo.NewClient: %v", err)
+	}
+	p := &forgejoProvider{client: client, owner: "acme", repo: "web"}
+
+	got, err := p.Checks(context.Background(), api.PR{Number: 7, HeadSHA: sha})
+	if err != nil {
+		t.Fatalf("Checks: %v", err)
+	}
+	if combinedHit {
+		t.Error("Checks still hit the unpaged combined-status endpoint")
+	}
+	// ci/build→success + ci/warn→warning (both passed), ci/test→failure, ci/lint→pending.
+	// Total 4 (not 5) proves the stale ci/build pending was deduped away; passed 2 and a
+	// present failure prove the second page wasn't dropped.
+	if got.Total != 4 || got.Passed != 2 || got.Failed != 1 {
+		t.Errorf("rollup = %+v, want total 4 / passed 2 / failed 1", got)
+	}
+	if got.State != api.CheckFailure {
+		t.Errorf("state = %q, want failure (a failed context is present)", got.State)
 	}
 }

--- a/internal/provider/forgejo.go
+++ b/internal/provider/forgejo.go
@@ -92,15 +92,34 @@ func (p *forgejoProvider) Checks(ctx context.Context, pr api.PR) (api.CheckRollu
 	if pr.HeadSHA == "" {
 		return api.CheckRollup{}, nil
 	}
-	cs, resp, err := p.client.GetCombinedStatus(p.owner, p.repo, pr.HeadSHA)
-	if err != nil {
-		if resp != nil && resp.StatusCode == http.StatusNotFound {
-			return api.CheckRollup{}, nil
+	// GetCombinedStatus can't page (the SDK method takes no ListOptions), so a
+	// commit with more contexts than the server's default page size would silently
+	// drop the rest of the rollup. List the raw statuses across all pages instead
+	// and reduce to the latest per context ourselves — what the combined endpoint
+	// does server-side — using the same all-pages loop ListPRs uses. Status IDs are
+	// monotonic (a DB auto-increment), so the highest ID for a context is its latest.
+	latest := map[string]*forgejo.Status{}
+	opts := forgejo.ListStatusesOption{ListOptions: forgejo.ListOptions{PageSize: 50}}
+	for {
+		statuses, resp, err := p.client.ListStatuses(p.owner, p.repo, pr.HeadSHA, opts)
+		if err != nil {
+			if resp != nil && resp.StatusCode == http.StatusNotFound {
+				return api.CheckRollup{}, nil // the commit simply has no statuses
+			}
+			return api.CheckRollup{}, fmt.Errorf("forgejo: list statuses #%d: %w", pr.Number, err)
 		}
-		return api.CheckRollup{}, fmt.Errorf("forgejo: combined status #%d: %w", pr.Number, err)
+		for _, s := range statuses {
+			if cur, ok := latest[s.Context]; !ok || s.ID > cur.ID {
+				latest[s.Context] = s
+			}
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
 	}
 	var passed, failed, pending int
-	for _, s := range cs.Statuses {
+	for _, s := range latest {
 		switch string(s.State) {
 		case stateSuccess, "warning":
 			passed++

--- a/internal/provider/writer.go
+++ b/internal/provider/writer.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	forgejo "codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
 	"github.com/golang-jwt/jwt/v5"
@@ -404,7 +405,9 @@ func (w *githubWriter) ChecksSupported() bool { return w.app }
 // elapsed time and GitHub should display none.
 func (w *githubWriter) CheckRun(ctx context.Context, pr api.PR, res CheckResult) error {
 	completed, now := "completed", github.Timestamp{Time: time.Now()}
-	output := &github.CheckRunOutput{Title: &res.Title, Summary: &res.Summary}
+	title := clamp(res.Title, githubTitleMax, "…")
+	summary := clamp(res.Summary, githubBodyMax, bodyTruncMarker)
+	output := &github.CheckRunOutput{Title: &title, Summary: &summary}
 
 	id, err := w.findCheckRun(ctx, pr.HeadSHA, res.Name)
 	if err != nil {
@@ -438,7 +441,7 @@ func (w *githubWriter) CheckRun(ctx context.Context, pr api.PR, res CheckResult)
 		req.Header.Set("Accept", "application/vnd.github.antiope-preview+json")
 		resp, err := w.client.Do(req, nil)
 		if err != nil {
-			return rejectedIf(githubStatus(resp, err), fmt.Errorf("github: update check run #%d: %w", pr.Number, err))
+			return githubReject(resp, fmt.Errorf("github: update check run #%d: %w", pr.Number, err))
 		}
 		return nil
 	}
@@ -453,7 +456,7 @@ func (w *githubWriter) CheckRun(ctx context.Context, pr api.PR, res CheckResult)
 		Output:      output,
 	})
 	if err != nil {
-		return rejectedIf(githubStatus(resp, err), fmt.Errorf("github: create check run #%d: %w", pr.Number, err))
+		return githubReject(resp, fmt.Errorf("github: create check run #%d: %w", pr.Number, err))
 	}
 	return nil
 }
@@ -471,7 +474,7 @@ func (w *githubWriter) findCheckRun(ctx context.Context, sha, name string) (int6
 		ListOptions: github.ListOptions{PerPage: 1},
 	})
 	if err != nil {
-		return 0, rejectedIf(githubStatus(resp, err), fmt.Errorf("github: list check runs: %w", err))
+		return 0, githubReject(resp, fmt.Errorf("github: list check runs: %w", err))
 	}
 	for _, r := range runs.CheckRuns {
 		return r.GetID(), nil
@@ -480,6 +483,7 @@ func (w *githubWriter) findCheckRun(ctx context.Context, sha, name string) (int6
 }
 
 func (w *githubWriter) UpsertComment(ctx context.Context, pr api.PR, marker, body string) error {
+	body = clamp(body, githubBodyMax, bodyTruncMarker) // GitHub 422s an over-length body; clamp so the outcome still posts
 	self, err := w.self.get(ctx)
 	if err != nil {
 		return fmt.Errorf("github: %w", err)
@@ -515,7 +519,7 @@ func (w *githubWriter) Verify(ctx context.Context) error {
 	if err == nil {
 		return nil
 	}
-	return rejectedIf(githubStatus(resp, err), fmt.Errorf("github: verify %s/%s: %w", w.owner, w.repo, err))
+	return githubReject(resp, fmt.Errorf("github: verify %s/%s: %w", w.owner, w.repo, err))
 }
 
 // githubStatus extracts the HTTP status behind a write-client error: the API
@@ -530,6 +534,48 @@ func githubStatus(resp *github.Response, err error) int {
 		return apiErr.Response.StatusCode
 	}
 	return 0
+}
+
+// githubReject classifies a github write-back error's permanence. A rate limit —
+// primary or a secondary/abuse limit, both of which surface as HTTP 403 — is
+// transient: it clears when the window resets, so it must NOT be latched as a
+// permanent credential rejection that disables write-back (a temporary 403 would
+// otherwise wedge it off for good). Any other genuine auth status (401/403/404)
+// is wrapped ErrWriteAuthRejected so the caller can fall back to a commit status.
+// err is matched through its wrapped chain, so callers pass their annotated error.
+func githubReject(resp *github.Response, err error) error {
+	if _, ok := RateLimit(err); ok {
+		return err
+	}
+	return rejectedIf(githubStatus(resp, err), err)
+}
+
+// GitHub rejects a check-run output summary over 65535 chars, an output title
+// over 255, or an issue-comment body over 65536, with a 422 — which isn't an auth
+// rejection, so it wouldn't fall back to a commit status and the whole render
+// outcome would go unreported. Clamp each to its cap before posting. Byte caps are
+// conservative against GitHub's character limits (bytes >= chars).
+const (
+	githubBodyMax   = 65535 // check-run output summary / issue-comment body
+	githubTitleMax  = 255   // check-run output title
+	bodyTruncMarker = "\n\n_…(truncated)_"
+)
+
+// clamp truncates s to at most max bytes on a rune boundary, appending marker (a
+// short string that must itself fit within max) so a clamped value is visibly
+// incomplete rather than silently cut.
+func clamp(s string, max int, marker string) string {
+	if len(s) <= max {
+		return s
+	}
+	cut := max - len(marker)
+	if cut < 0 {
+		cut = 0
+	}
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut-- // don't split a multi-byte rune
+	}
+	return s[:cut] + marker
 }
 
 // --- Forgejo ---

--- a/internal/provider/writer_test.go
+++ b/internal/provider/writer_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	forgejo "codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
 	"github.com/golang-jwt/jwt/v5"
@@ -113,6 +114,40 @@ func TestGitHubWriter_CheckRun(t *testing.T) {
 		}
 		if created.StartedAt == "" || created.StartedAt != created.CompletedAt {
 			t.Errorf("create started_at=%q completed_at=%q, want equal and non-empty", created.StartedAt, created.CompletedAt)
+		}
+	})
+
+	t.Run("clamps an over-length title and summary", func(t *testing.T) {
+		t.Parallel()
+		var created struct {
+			Output struct{ Title, Summary string } `json:"output"`
+		}
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/acme/web/commits/"+sha+"/check-runs", func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"total_count":0,"check_runs":[]}`))
+		})
+		mux.HandleFunc("/repos/acme/web/check-runs", func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewDecoder(r.Body).Decode(&created)
+			_, _ = w.Write([]byte(`{"id":1}`))
+		})
+		srv := httptest.NewServer(mux)
+		t.Cleanup(srv.Close)
+
+		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", app: true}
+		err := wr.CheckRun(context.Background(), api.PR{Number: 7, HeadSHA: sha}, CheckResult{
+			Name:       "konflate",
+			Conclusion: CheckNeutral,
+			Title:      strings.Repeat("t", githubTitleMax+50),  // GitHub caps title at 255
+			Summary:    strings.Repeat("s", githubBodyMax+5000), // and summary at 65535
+		})
+		if err != nil {
+			t.Fatalf("CheckRun: %v", err)
+		}
+		if len(created.Output.Title) > githubTitleMax {
+			t.Errorf("posted title is %d chars; GitHub caps it at %d", len(created.Output.Title), githubTitleMax)
+		}
+		if len(created.Output.Summary) > githubBodyMax {
+			t.Errorf("posted summary is %d chars; GitHub caps it at %d", len(created.Output.Summary), githubBodyMax)
 		}
 	})
 
@@ -508,6 +543,23 @@ func TestGitHubWriter_UpsertComment(t *testing.T) {
 		}
 		assertNoop(t, sink)
 	})
+	t.Run("clamps an over-length body to the GitHub cap", func(t *testing.T) {
+		t.Parallel()
+		var sink commentSink
+		srv := httptest.NewServer(commentCapture(`[]`, &sink))
+		t.Cleanup(srv.Close)
+		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
+		huge := upsertMarker + "\n" + strings.Repeat("x", githubBodyMax+5000)
+		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, huge); err != nil {
+			t.Fatalf("UpsertComment: %v", err)
+		}
+		if !sink.created {
+			t.Fatal("want a created comment")
+		}
+		if len(sink.body) > githubBodyMax {
+			t.Errorf("posted body is %d bytes; GitHub rejects anything over %d", len(sink.body), githubBodyMax)
+		}
+	})
 }
 
 func TestGitlabWriter_UpsertComment(t *testing.T) {
@@ -664,6 +716,62 @@ func TestRejectedIf(t *testing.T) {
 		if err := rejectedIf(s, base); errors.Is(err, ErrWriteAuthRejected) || !errors.Is(err, base) {
 			t.Errorf("status %d: want a plain (transient) error, got %v", s, err)
 		}
+	}
+}
+
+// TestGitHubReject: a rate limit surfaces as HTTP 403 but is transient, so it must
+// NOT be latched as a permanent credential rejection (which would disable write-back
+// until a restart); a genuine 403/404 still is, and a 5xx stays transient.
+func TestGitHubReject(t *testing.T) {
+	t.Parallel()
+	// Even with a 403 response in hand, a primary rate-limit error stays transient.
+	rlResp := &github.Response{Response: &http.Response{StatusCode: http.StatusForbidden}}
+	rl := &github.RateLimitError{Rate: github.Rate{Reset: github.Timestamp{Time: time.Now().Add(time.Minute)}}}
+	if err := githubReject(rlResp, fmt.Errorf("github: verify: %w", rl)); errors.Is(err, ErrWriteAuthRejected) {
+		t.Errorf("a primary rate-limit 403 must stay transient, got a rejection: %v", err)
+	}
+	// A secondary/abuse limit is also a transient 403.
+	ab := &github.AbuseRateLimitError{}
+	if err := githubReject(rlResp, fmt.Errorf("github: verify: %w", ab)); errors.Is(err, ErrWriteAuthRejected) {
+		t.Errorf("a secondary rate-limit 403 must stay transient, got a rejection: %v", err)
+	}
+	// A genuine 403 (missing permission / wrong installation) is a permanent rejection.
+	forbidden := &github.ErrorResponse{Response: &http.Response{StatusCode: http.StatusForbidden}}
+	if err := githubReject(nil, fmt.Errorf("github: verify: %w", forbidden)); !errors.Is(err, ErrWriteAuthRejected) {
+		t.Errorf("a genuine 403 must be a permanent rejection, got %v", err)
+	}
+	// A transient server error stays transient.
+	srvErr := &github.ErrorResponse{Response: &http.Response{StatusCode: http.StatusInternalServerError}}
+	if err := githubReject(nil, fmt.Errorf("github: verify: %w", srvErr)); errors.Is(err, ErrWriteAuthRejected) {
+		t.Errorf("a 500 must stay transient, got a rejection: %v", err)
+	}
+}
+
+// TestClamp: a value over its GitHub cap is truncated on a rune boundary with a
+// visible marker (GitHub 422s an over-length check-run summary/title or comment
+// body, and that 422 wouldn't fall back to a commit status — the outcome would go
+// unreported).
+func TestClamp(t *testing.T) {
+	t.Parallel()
+	if got := clamp("under the cap", githubBodyMax, bodyTruncMarker); got != "under the cap" {
+		t.Errorf("a value under the cap must be returned verbatim, got %q", got)
+	}
+	long := strings.Repeat("x", githubBodyMax+1000)
+	got := clamp(long, githubBodyMax, bodyTruncMarker)
+	if len(got) > githubBodyMax {
+		t.Errorf("clamped body is %d bytes, want <= %d", len(got), githubBodyMax)
+	}
+	if !strings.HasSuffix(got, bodyTruncMarker) {
+		t.Errorf("a clamped body must carry the truncation marker, got tail %q", got[len(got)-16:])
+	}
+	// The tighter title cap (255) is enforced too.
+	if gt := clamp(strings.Repeat("t", githubTitleMax+50), githubTitleMax, "…"); len(gt) > githubTitleMax {
+		t.Errorf("clamped title is %d bytes, want <= %d", len(gt), githubTitleMax)
+	}
+	// A cut landing mid multi-byte rune must not split it — the result stays valid UTF-8.
+	multi := strings.Repeat("é", githubBodyMax) // 2 bytes each → the cap lands mid-rune
+	if !utf8.ValidString(clamp(multi, githubBodyMax, bodyTruncMarker)) {
+		t.Error("clamp split a multi-byte rune (result is not valid UTF-8)")
 	}
 }
 


### PR DESCRIPTION
## What

Closes the **write-back robustness** cluster from the project review — three ways
konflate's forge write-back silently stopped reporting a render outcome. Each is
fixed in `internal/provider` with a regression test.

| # | Bug | Fix |
|---|---|---|
| 1 | A GitHub **rate limit** surfaces as HTTP 403, which the write-error classifier treated as a permanent credential rejection (`ErrWriteAuthRejected`) — latching write-back **off until a restart**. Worst at startup: a boot-time rate limit in `Verify` disabled write-back for the whole run. | New `githubReject` checks `RateLimit(err)` first and keeps a rate limit a plain **transient** error (it clears when the window resets); only a genuine 401/403/404 is permanent. Wired into the four github paths that classify permanence (check-run create/update, `findCheckRun`, `Verify`). GitLab/Forgejo rate-limit as 429 — already transient — so only github needs the exemption. |
| 2 | A check-run output **summary >65535** chars, its **title >255**, or a PR **comment body >65536**, is rejected by GitHub with a **422**. A 422 isn't `ErrWriteAuthRejected`, so it never fell back to a commit status and the whole outcome went **unreported**. | A `clamp` helper truncates each to its cap on a rune boundary with a visible `(truncated)` marker before posting. |
| 3 | Forgejo `Checks` called `GetCombinedStatus`, whose SDK method takes **no `ListOptions`**, so a commit with more contexts than the server's default page size silently **dropped the rest of the rollup** (GitHub/GitLab already request 100/page). | Pages `ListStatuses` to the end (the same `NextPage` loop `ListPRs` uses) and reduces to the **latest status per context** (highest `id`, a monotonic DB key) — matching what the combined endpoint does server-side. |

## Tests
`internal/provider/writer_test.go` — `TestGitHubReject` (a rate-limit 403 stays transient; a genuine 403/404 is still rejected; a 5xx stays transient), `TestClampBody` (under-cap verbatim, over-cap clamped ≤ cap with marker, no split multi-byte rune), and a `TestGitHubWriter_UpsertComment` subtest asserting an over-length body posts clamped. `internal/provider/checks_test.go` — `TestForgejoProvider_ChecksPagesAndDedups` (walks both pages, dedups a superseded context by id, and asserts the old combined endpoint is no longer hit).

## Safety
Behavior-preserving on the happy path. Byte-clamping is conservative vs GitHub's character cap. The Forgejo rollup is recomputed from the same per-state switch as before, just over the fully-paged, self-deduped context set.

Verified: `go test -race ./...`, `vet`, `lint` (0), `fmt-check`, `tidy-check`. No UI, chart, or config changes.

PR B of the review's fix batching (A: lifecycle races #310 · **B: write-back robustness** · C: engine/lint · D: UI + types drift · E: markdown escape · F: perf + quality).
