### PR TITLE
fix(engine,diff): dedup coincident image moves and recognize build-metadata chart labels

### DIFF
--- a/internal/diff/lint.go
+++ b/internal/diff/lint.go
@@ -187,15 +187,21 @@ func imageBumpWarnings(images []api.ImageChange) []api.Warning {
 
 // chartLabelRe splits a "helm.sh/chart" label ("<name>-<version>") into name and
 // version. The version is the trailing "[v]<major>.<minor>…" run, so a chart
-// name that itself contains hyphens (e.g. "cert-manager") stays intact.
-var chartLabelRe = regexp.MustCompile(`^(.*)-(v?\d+\.\d+[0-9A-Za-z.+-]*)$`)
+// name that itself contains hyphens (e.g. "cert-manager") stays intact. The class
+// includes "_" because Helm renders the label as
+// `{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}`, so a build-metadata
+// version ("1.2.3+build" → label "…-1.2.3_build") carries an underscore.
+var chartLabelRe = regexp.MustCompile(`^(.*)-(v?\d+\.\d+[0-9A-Za-z._+-]*)$`)
 
 func splitChart(label string) (name, version string) {
 	m := chartLabelRe.FindStringSubmatch(label)
 	if m == nil {
 		return "", ""
 	}
-	return m[1], m[2]
+	// Undo Helm's "+"→"_" label sanitization so the version is valid semver again
+	// (chart names contain no "_", so the only "_" is the build separator) — else
+	// majorOf's strict semver parse rejects it and the bump silently never fires.
+	return m[1], strings.ReplaceAll(m[2], "_", "+")
 }
 
 // isMajorBump reports whether two semver-ish versions differ in their major

--- a/internal/diff/lint_test.go
+++ b/internal/diff/lint_test.go
@@ -241,6 +241,30 @@ func TestLint_MajorChartBump(t *testing.T) {
 	}
 }
 
+// TestLint_MajorChartBump_BuildMetadata: Helm renders the helm.sh/chart label with
+// build metadata sanitized ("1.0.0+build.5" → "1.0.0_build.5"). splitChart must
+// still recognize the version (regex) and hand majorOf valid semver (de-sanitize),
+// or the bump silently never fires.
+func TestLint_MajorChartBump_BuildMetadata(t *testing.T) {
+	t.Parallel()
+	changes := []Change{
+		{Status: "changed", Kind: "Deployment", Name: "a", Parent: "HelmRelease app",
+			OldChart: "app-1.0.0_build.5", NewChart: "app-2.0.0_build.9", Old: map[string]any{}, New: map[string]any{}},
+	}
+	n, w := countRule(Lint(changes, nil, nil), "major-chart-bump")
+	if n != 1 {
+		t.Fatalf("major-chart-bump count = %d, want 1 (a build-metadata label must still fire)", n)
+	}
+	if w.Resource != "app" {
+		t.Errorf("major-chart-bump resource = %q, want app", w.Resource)
+	}
+	// splitChart must un-sanitize the underscore back to a "+" so the version is
+	// valid semver in the detail (and for majorOf).
+	if _, ver := splitChart("app-1.0.0_build.5"); ver != "1.0.0+build.5" {
+		t.Errorf("splitChart version = %q, want 1.0.0+build.5", ver)
+	}
+}
+
 func TestMajorOf(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -405,6 +405,35 @@ func TestImageChanges_AmbiguousNotMerged(t *testing.T) {
 	}
 }
 
+// TestImageChanges_MergedMoveFoldsIntoRealBump: one resource bumps an image in
+// place (A→B) while a rename relocates the same image at the same versions on
+// another (a pure removal at A + a pure addition at B). The reconciled move
+// (A→B) coincides with the real bump, so it must fold into that single entry
+// (unioning refs) — not append a duplicate that lists the image, and flags its
+// major bump, twice.
+func TestImageChanges_MergedMoveFoldsIntoRealBump(t *testing.T) {
+	t.Parallel()
+	changes := []diff.Change{
+		{Status: "changed", Kind: "Deployment", Namespace: "apps", Name: "web",
+			Old: deploy("apps", "web", "reg/app:1.0.0"), New: deploy("apps", "web", "reg/app:2.0.0")},
+		{Status: "removed", Kind: "Deployment", Namespace: "apps", Name: "old",
+			Old: deploy("apps", "old", "reg/app:1.0.0"), New: nil},
+		{Status: "added", Kind: "Deployment", Namespace: "apps", Name: "new",
+			Old: nil, New: deploy("apps", "new", "reg/app:2.0.0")},
+	}
+	got := imageChanges(changes)
+	if len(got) != 1 {
+		t.Fatalf("a merged move coinciding with a real bump must fold into one entry, got %d: %+v", len(got), got)
+	}
+	c := got[0]
+	if c.Name != "reg/app" || c.From != "1.0.0" || c.To != "2.0.0" {
+		t.Errorf("got %+v, want reg/app 1.0.0→2.0.0", c)
+	}
+	if len(c.Refs) != 3 {
+		t.Errorf("folded entry should union all three referencing resources, got %v", c.Refs)
+	}
+}
+
 // splitImageRef's behavior now lives in flate's image.Split (tested in
 // flate); konflate's collectImages composes image.Extract + image.Split,
 // exercised end to end by TestImageChanges above.

--- a/internal/engine/images.go
+++ b/internal/engine/images.go
@@ -124,7 +124,20 @@ func reconcileRelocations(in []api.ImageChange) []api.ImageChange {
 			out = append(out, ic)
 		}
 	}
-	return append(out, merged...)
+	// A merged move can coincide with a real transition already present — the same
+	// repo bumped in place on another resource that wasn't part of the rename. Fold
+	// it into that entry (union refs) by (name,from,to) rather than appending a
+	// duplicate, so the image isn't listed — and its major bump flagged — twice.
+	for _, m := range merged {
+		if i := slices.IndexFunc(out, func(e api.ImageChange) bool {
+			return e.Name == m.Name && e.From == m.From && e.To == m.To
+		}); i >= 0 {
+			out[i].Refs = mergeRefs(out[i].Refs, m.Refs)
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
 }
 
 // mergeRefs unions two already-sorted reference lists into one sorted, deduped list.


### PR DESCRIPTION
## What

The **engine/lint correctness** batch from the project review. Two confirmed signal bugs, each fixed with a regression test. The batch's third candidate was investigated and **refuted** (details below) — so this PR is two fixes, not three.

| # | Bug | Fix |
|---|---|---|
| C2 | `reconcileRelocations` folds a rename's pure removal + pure addition into one `A→B` move, then **appended** it unconditionally. When that reconciled move coincided with a **real in-place bump** of the same repository on another resource, the Images list carried two entries with the same `name/from/to` — and `major-image-bump` fired **twice** for the one transition. | Fold each merged move into the matching existing entry (union refs) by `(name, from, to)`; append only when there's no match. (`internal/engine/images.go`) |
| C3 | Helm renders the `helm.sh/chart` label as `<name>-{{ .Version \| replace "+" "_" }}`, so a **build-metadata** version (`1.2.3+build` → label `…-1.2.3_build`) carries `_`. `chartLabelRe`'s version class omitted `_` → `splitChart` returned `("","")` → **`major-chart-bump` silently never fired**. And even once matched, `majorOf`'s strict `semver.NewVersion` rejects `_`. | Add `_` to the version class **and** un-sanitize `_`→`+` in `splitChart` to recover valid semver (chart names forbid `_`, so the only `_` is the build separator). (`internal/diff/lint.go`) |

## The refuted third finding (C1)

The review flagged that `blastRadius` / `danglingDependsOn` consume `head.Result.DependsOn`, which — it claimed — under flate's changed-only render misses `HR→HR` edges from un-re-rendered parents, silencing those signals.

Tracing flate v0.4.10: `Bootstrap` runs `discovery.Run` (loads the **full** tree into the store — the change filter isn't built yet), then `failDependsOnCycles → rebuildDependencyGraphFromStore` builds the declared dependsOn graph over **all** store objects, and only **then** `buildChangeFilter` builds the reconcile keep-set. That keep-set gates **rendering**, not loading — and `Result.DependsOn = depGraph.Edges()` is documented as "the declared graph verbatim … independent of render filters." So an un-re-rendered (unchanged) parent is still discovered, loaded, and present in `DependsOn` with its edges. The failure mode isn't reachable; **no code change**. An adversarial pass that tried to reconstruct the missing-edge scenario also found none.

## Tests
`internal/engine/engine_test.go::TestImageChanges_MergedMoveFoldsIntoRealBump` (a bump + a coincident same-version rename → one folded entry with all three refs, not a duplicate) and `internal/diff/lint_test.go::TestLint_MajorChartBump_BuildMetadata` (a `_build.5` label still fires the caution; `splitChart` un-sanitizes to `1.0.0+build.5`). Both are non-vacuous — they fail if the respective fix is reverted.

Verified: `go test -race ./...`, `vet`, `lint` (0), `fmt-check`, `tidy-check`. No UI or chart changes.

PR C of the review's fix batching (A: lifecycle races #310 · B: write-back robustness #311 · **C: engine/lint** · D: UI + types drift · E: markdown escape · F: perf + quality).
