### PR TITLE
fix(web): resync on ws reconnect, unstick row previews, fix nav order and type drift

### DIFF
--- a/internal/web/src/lib/List.svelte
+++ b/internal/web/src/lib/List.svelte
@@ -3,9 +3,7 @@
   import {
     store,
     filteredPRs,
-    matchesStatus,
-    statusFromQuery,
-    sortPRs,
+    visiblePRs,
     openPR,
     ensurePreview,
     type StatusFilter,
@@ -51,13 +49,11 @@
   // count, so the counts hold steady while a pill is active), then the active
   // pill narrows and the sort orders what's shown.
   const prs = $derived(filteredPRs());
-  // The active pill (or default = open, non-hidden) selects what's shown, then
-  // the sort orders it. Rendered as one flat list — merged and hidden PRs are
-  // reached via their pills, not a separate group. A typed `status:` facet acts
-  // like the matching pill, so `status:hidden` / `status:merged` in the search
-  // box reveal those sections instead of being re-hidden by the default pill.
-  const effectiveStatus = $derived(statusFromQuery(store.query) ?? store.statusFilter);
-  const shown = $derived(sortPRs(prs.filter((p) => matchesStatus(p, effectiveStatus))));
+  // What's shown: the query-filtered set narrowed by the active pill (or a typed
+  // `status:` facet — so `status:hidden` / `status:merged` reveal those sections)
+  // and sorted, rendered as one flat list. Delegated to visiblePRs, the store's
+  // single source of truth, so the review's prev/next navigation walks the same set.
+  const shown = $derived(visiblePRs());
   // The full open, non-hidden set — for the default-base heuristic and the pill
   // counts (which hold steady while a pill narrows what's shown).
   const openPrs = $derived(prs.filter((p) => p.open && !p.hidden));

--- a/internal/web/src/lib/store.svelte.ts
+++ b/internal/web/src/lib/store.svelte.ts
@@ -250,6 +250,16 @@ export function sortPRs(list: PRStatus[]): PRStatus[] {
   });
 }
 
+// visiblePRs is the exact list the List view renders: the text-query-filtered
+// set, narrowed by the active status pill (or a `status:` facet in the query),
+// in the selected sort order. It is the single source of truth for "what's on
+// screen" — the List reads it, and adjacentPR walks it so the review's prev/next
+// navigation steps through PRs in the same order and subset the user sees.
+export function visiblePRs(): PRStatus[] {
+  const effective = statusFromQuery(store.query) ?? store.statusFilter;
+  return sortPRs(filteredPRs().filter((p) => matchesStatus(p, effective)));
+}
+
 export function currentPR(): PRStatus | null {
   const r = router.route;
   if (r.name !== 'review') return null;
@@ -281,9 +291,12 @@ export function selectables(): string[] {
 export function adjacentPR(delta: number): void {
   const r = router.route;
   if (r.name !== 'review') return;
-  const i = store.prs.findIndex((p) => p.number === r.pr);
+  // Walk the on-screen list (filtered + sorted), not the raw server order, so
+  // prev/next lands on the visually adjacent PR and never a filtered-out one.
+  const list = visiblePRs();
+  const i = list.findIndex((p) => p.number === r.pr);
   const j = i + delta;
-  if (i >= 0 && j >= 0 && j < store.prs.length) openPR(store.prs[j].number);
+  if (i >= 0 && j >= 0 && j < list.length) openPR(list[j].number);
 }
 
 // Move the selection by delta through [Summary, ...resources], clamped at the
@@ -339,6 +352,7 @@ export function ensureDiff(n: number): void {
   store.diffFor = n;
   store.diff = null;
   store.diffError = '';
+  store.diffRefreshError = ''; // clear the previous PR's refresh error until this one's envelope lands
   store.diffMergeCommand = '';
   store.diffHidden = false;
   store.loading = true;
@@ -364,7 +378,10 @@ async function loadDiff(n: number): Promise<void> {
 // auto-retry loop); reopen the PR for the live view.
 export function ensurePreview(n: number, headSha: string): void {
   const cur = store.previews[n];
-  if (cur && cur.headSha === headSha) return;
+  // A settled (ready/error) preview for this sha is served from cache; a still-
+  // 'pending' one is refetched — the render may have finished since it was first
+  // opened, and this call (a user re-expand) is the retrigger.
+  if (cur && cur.headSha === headSha && cur.state !== 'pending') return;
   store.previews[n] = { state: 'loading', headSha };
   void loadPreview(n, headSha);
 }
@@ -441,6 +458,14 @@ export function connectWS(): void {
   const ws = new WebSocket(`${proto}://${location.host}/ws`);
   ws.addEventListener('open', () => {
     store.connected = true;
+    // A reconnect (not the first connect) means we were disconnected: any events
+    // that fired during the gap were missed, so re-pull the authoritative list,
+    // meta, and the open diff rather than trusting the now-stale local state.
+    if (wsAttempt > 0) {
+      void loadMeta();
+      void loadPRs();
+      if (store.diffFor !== null) void loadDiff(store.diffFor);
+    }
     wsAttempt = 0; // reset the backoff once we're connected
   });
   ws.addEventListener('message', (e) => {
@@ -493,5 +518,9 @@ function onEvent(ev: WSEvent): void {
   if (ev.status === 'ready' || ev.status === 'error') {
     void loadPRs();
     if (ev.number === store.diffFor) void loadDiff(ev.number);
+    // A row whose preview was opened mid-render is cached 'pending'; now that it
+    // settled, refresh it in place so an open panel updates without a re-expand.
+    const pv = store.previews[ev.number];
+    if (pv && pv.state === 'pending') void loadPreview(ev.number, pv.headSha);
   }
 }

--- a/internal/web/src/lib/types.ts
+++ b/internal/web/src/lib/types.ts
@@ -21,6 +21,7 @@ export interface PR {
   headRef: string;
   headSha: string;
   baseRef: string;
+  fork: boolean; // head is in a different repo than the base (an untrusted cross-repo PR)
   labels: Label[] | null;
   url: string;
 }
@@ -161,6 +162,7 @@ export interface DiffResult {
   images: ImageChange[] | null;
   failures: RenderFailure[] | null;
   warnings: Warning[] | null;
+  routine: boolean; // only image/chart-version metadata changed, nothing flagged (diff-shape, not a safety verdict)
   chromaCss: string;
   tree: DiffTreeParent[] | null;
   resources: DiffResource[] | null;

--- a/internal/web/tests/fixtures.ts
+++ b/internal/web/tests/fixtures.ts
@@ -24,6 +24,7 @@ export const samplePRs: PRStatus[] = [
     headRef: 'renovate/rook-ceph',
     headSha: 'a1b2c3d4e5f6',
     baseRef: 'main',
+    fork: false,
     createdAt: '2026-06-01T09:00:00Z',
     labels: [{ name: 'area/storage', color: '0e8a16' }],
     url: 'https://github.com/acme/home-ops/pull/142',
@@ -43,6 +44,7 @@ export const samplePRs: PRStatus[] = [
     headRef: 'chore/scale-web',
     headSha: 'f6e5d4c3',
     baseRef: 'staging',
+    fork: false,
     createdAt: '2026-06-03T08:00:00Z',
     labels: [],
     url: 'https://github.com/acme/home-ops/pull/138',
@@ -61,6 +63,7 @@ export const samplePRs: PRStatus[] = [
     headRef: 'fix/plex',
     headSha: 'deadbeef',
     baseRef: 'main',
+    fork: false,
     createdAt: '2026-05-30T10:00:00Z',
     labels: [{ name: 'area/media', color: 'd93f0b' }],
     url: 'https://github.com/acme/home-ops/pull/131',
@@ -81,6 +84,7 @@ export const samplePRs: PRStatus[] = [
     headRef: 'feat/loki',
     headSha: 'cafe1234',
     baseRef: 'main',
+    fork: false,
     createdAt: '2026-06-01T08:00:00Z',
     labels: [{ name: 'area/observability', color: '1d76db' }],
     url: 'https://github.com/acme/home-ops/pull/128',
@@ -128,6 +132,7 @@ export const sampleDiff: DiffResult = {
       detail: 'replicas set to 0 — the workload will be scaled to zero',
     },
   ],
+  routine: false, // has warnings + failures → not a routine bump
   chromaCss,
   tree: [
     {

--- a/internal/web/tests/ui.spec.ts
+++ b/internal/web/tests/ui.spec.ts
@@ -1491,3 +1491,67 @@ test("'/' finds text across lazy-mounted diff sections and jumps to hits", async
   await page.keyboard.press('Escape');
   await expect(page).toHaveURL(/#\/$|\/$/);
 });
+
+test('] review navigation walks the on-screen sorted list, not raw server order', async ({ page }) => {
+  await stubApi(page); // 142's diff is stubbed; add the one the nav lands on.
+  await page.route('**/api/prs/131/diff', (r) =>
+    r.fulfill({ json: { status: 'error', pr: samplePRs[2], error: 'render failed' } }),
+  );
+  await page.goto('/');
+  await expect(page.locator('.card')).toHaveCount(3); // list loaded → store.prs populated
+
+  // Default sort is newest-first by created, so the visible order is
+  // [138 (Jun 3), 142 (Jun 1), 131 (May 30)] — deliberately unlike the raw
+  // /api/prs order [142, 138, 131]. From a settled 142, ] must land on the next
+  // *visible* PR (131), never 138 (which is next only in the raw server order).
+  await page.locator('.card-shell[data-pr="142"]').click();
+  await expect(page).toHaveURL(/#\/pr\/142$/);
+  await page.keyboard.press(']');
+  await expect(page).toHaveURL(/#\/pr\/131$/);
+});
+
+test('a stale refresh-error banner clears when navigating to another PR', async ({ page }) => {
+  await page.route('**/api/meta', (r) => r.fulfill({ json: defaultMeta }));
+  await page.route('**/api/prs', (r) => r.fulfill({ json: samplePRs }));
+  await page.routeWebSocket('**/ws', () => {});
+  // 142: last-good diff kept, but the refresh failed (banner). 131: errored with
+  // nothing to keep (carries no refresh error of its own).
+  await page.route('**/api/prs/142/diff', (r) =>
+    r.fulfill({ json: { ...diffEnvelope, refreshError: 'forge unreachable' } }),
+  );
+  await page.route('**/api/prs/131/diff', (r) =>
+    r.fulfill({ json: { status: 'error', pr: samplePRs[2], error: 'render failed' } }),
+  );
+  await page.goto('/');
+  await expect(page.locator('.card')).toHaveCount(3);
+  await page.locator('.card-shell[data-pr="142"]').click();
+  await expect(page.locator('.refresh-strip')).toContainText("Couldn't refresh");
+
+  // In-app nav to the next visible PR (131) — the previous PR's banner must not linger.
+  await page.keyboard.press(']');
+  await expect(page).toHaveURL(/#\/pr\/131$/);
+  await expect(page.locator('.refresh-strip')).toHaveCount(0);
+});
+
+test('a row preview left "pending" refetches on re-expand instead of sticking', async ({ page }) => {
+  await page.route('**/api/meta', (r) => r.fulfill({ json: defaultMeta }));
+  await page.route('**/api/prs', (r) => r.fulfill({ json: samplePRs }));
+  await page.routeWebSocket('**/ws', () => {});
+  // First summary fetch: still rendering (pending); the next: the finished diff.
+  let calls = 0;
+  await page.route('**/api/prs/142/summary', (r) => {
+    calls++;
+    return calls === 1
+      ? r.fulfill({ json: { status: 'pending', pr: samplePRs[0] } })
+      : r.fulfill({ json: diffEnvelope });
+  });
+  await page.goto('/');
+
+  const card = page.locator('.card-li:has(.card-shell[data-pr="142"])');
+  await card.locator('.card-expand').click(); // expand → pending
+  await expect(card.locator('.card-preview .pv-msg')).toContainText('Still rendering');
+
+  await card.locator('.card-expand').click(); // collapse
+  await card.locator('.card-expand').click(); // re-expand → must refetch (not serve the cached pending)
+  await expect(card.locator('.card-preview .pv-caution')).toHaveCount(2);
+});


### PR DESCRIPTION
## What

The **UI store + types drift** batch from the project review — five client-side staleness/contract bugs, all in `internal/web/src/lib`.

| # | Bug | Fix |
|---|---|---|
| D1 | After a websocket **reconnect** the client kept its pre-disconnect state — every `removed`/`checks`/`sync`/`status` event that fired during the gap was lost. | The `open` handler re-pulls `loadMeta` + `loadPRs` + the open diff on a **reconnect** (`wsAttempt > 0`); the first connect (already covered by the mount load) is untouched. |
| D2 | A row preview opened mid-render cached as `pending` and **never updated** — `ensurePreview` cache-hit the same sha, so a re-expand didn't refetch. | `ensurePreview` refetches a `pending` entry; and a `ready`/`error` status event refreshes an open preview in place (live, no re-expand). |
| D3 | `ensureDiff` didn't clear `diffRefreshError` on PR switch (only `applyEnvelope`'s `ready` branch sets it), so opening a **pending/errored** PR showed the *previous* PR's "couldn't refresh" strip. | Reset it alongside the other per-diff fields in `ensureDiff`. |
| D4 | `adjacentPR` (`[` / `]`) walked the **raw server order**, not the filtered + sorted list shown on screen — prev/next jumped to filtered-out PRs / the wrong direction under a sort. | New `visiblePRs()` is the single source of truth for the on-screen list; both `List` (`shown`) and `adjacentPR` read it. |
| D5 | `types.ts` was missing `PR.fork` and `DiffResult.routine`, which the Go API always serializes (no `omitempty`). | Added both (required, matching the wire). |

## Tests
Three Playwright regressions in `internal/web/tests/ui.spec.ts`, each non-vacuous (fails if its fix is reverted):
- **D4** — from a settled PR #142, `]` lands on the next *visible* PR (#131) under the default newest-first sort, never #138 (which is next only in raw server order).
- **D3** — a #142 review showing the refresh banner, then `]` to #131 (errored) — the banner is gone.
- **D2** — a preview whose first `/summary` is `pending` shows "Still rendering"; a re-expand refetches and renders the finished summary (2 cautions), not the stuck pending.

D1 (ws reconnect) and D5 (types) aren't practical to assert in Playwright (WS-reconnect timing / type-only); D5 is enforced by `svelte-check` and D1 is a small, reconnect-gated resync.

Verified: `ui-typecheck` (0 errors), `ui-test` (79 passed), `ui-build`. No Go or chart changes.

PR D of the review's fix batching (A #310 · B #311 · C #312 · **D: UI + types drift** · E: markdown escape · F: perf + quality).
