### PR TITLE
fix(server): close Markdown injection into konflate's own PR comment and check-run

### DIFF
--- a/internal/server/comment.go
+++ b/internal/server/comment.go
@@ -15,11 +15,18 @@ import (
 // `api` types are the same ones the JSON API exposes.
 type commentTemplateData struct {
 	// PR is the pull request: .PR.Number, .PR.Title, .PR.Author, .PR.HeadRef,
-	// .PR.HeadSHA, .PR.BaseRef, .PR.URL, ...
+	// .PR.HeadSHA, .PR.BaseRef, .PR.URL, ... The free-text fields (Title, Author,
+	// HeadRef, BaseRef, and each Labels[].Name/.Color) are Markdown-escaped so a
+	// forge-controlled value embedded raw in the template can't inject into
+	// konflate's own comment; URL/HeadSHA/Number/State are structural and pass
+	// through unchanged (URL stays usable as a link target).
 	PR api.PR
 	// Diff is the rendered diff: .Diff.Impact.Resources, .Diff.Warnings,
 	// .Diff.Images, .Diff.Failures, ... Comments render on a successful render, so
-	// this is populated.
+	// this is populated. Its text fields (warning details, failure messages, image
+	// refs) are forge-controlled and raw — escape them with the `md`/`mdCode`
+	// template funcs when rendering them directly, or use the pre-escaped
+	// .Summary / .Sections instead.
 	Diff *api.DiffResult
 	// ReviewURL is konflate's review link for the PR, or "" when KONFLATE_PUBLIC_URL
 	// is unset.
@@ -48,7 +55,12 @@ func newCommentTemplate(cfg *config.Config, log *slog.Logger) *template.Template
 			"path", path, "error", err)
 		return nil
 	}
-	t, err := template.New("comment").Option("missingkey=error").Parse(string(src))
+	// md / mdCode let a template author Markdown-escape any raw forge-controlled
+	// field they render themselves (e.g. iterating .Diff.Warnings) — text/template
+	// does no escaping, and this comment is posted under konflate's own identity.
+	// The scalar .PR fields and the pre-rendered .Summary/.Sections are already safe.
+	funcs := template.FuncMap{"md": mdInline, "mdCode": mdCode}
+	t, err := template.New("comment").Funcs(funcs).Option("missingkey=error").Parse(string(src))
 	if err != nil {
 		log.Warn("invalid KONFLATE_PR_COMMENT_TEMPLATE_FILE; using the default comment body",
 			"path", path, "error", err)
@@ -69,8 +81,30 @@ func (s *Server) commentBody(env api.DiffEnvelope) string {
 	if s.commentTmpl == nil {
 		return defaultBody()
 	}
+	// The comment is authored under konflate's own identity, so forge-controlled
+	// free-text PR fields must be Markdown-safe even when a custom template embeds
+	// them raw (text/template does not escape): a fork PR titled "[x](evil)" would
+	// otherwise inject a link. Escape them on a copy (the api.PR contract is
+	// preserved; Number/URL/HeadSHA stay usable as-is — URL is a link target).
+	pr := env.PR
+	pr.Title = mdInline(pr.Title)
+	pr.Author = mdInline(pr.Author)
+	pr.HeadRef = mdInline(pr.HeadRef)
+	pr.BaseRef = mdInline(pr.BaseRef)
+	// Labels are forge-controlled too. The struct copy above aliases the Labels
+	// slice, so deep-copy it before escaping each name/color — otherwise this would
+	// mutate the shared api.PR the rest of the request still reads.
+	if len(pr.Labels) > 0 {
+		labels := make([]api.Label, len(pr.Labels))
+		copy(labels, pr.Labels)
+		for i := range labels {
+			labels[i].Name = mdInline(labels[i].Name)
+			labels[i].Color = mdInline(labels[i].Color)
+		}
+		pr.Labels = labels
+	}
 	data := commentTemplateData{
-		PR:        env.PR,
+		PR:        pr,
 		Diff:      env.Diff,
 		ReviewURL: reviewURL,
 		Summary:   summaryMarkdownBody(env, reviewURL, admonitions),

--- a/internal/server/comment_test.go
+++ b/internal/server/comment_test.go
@@ -28,7 +28,8 @@ func newCommentServer(t *testing.T, src string) *Server {
 		log: discardLog(),
 	}
 	if src != "" {
-		tmpl, err := template.New("comment").Option("missingkey=error").Parse(src)
+		funcs := template.FuncMap{"md": mdInline, "mdCode": mdCode}
+		tmpl, err := template.New("comment").Funcs(funcs).Option("missingkey=error").Parse(src)
 		if err != nil {
 			t.Fatalf("parse template: %v", err)
 		}
@@ -64,6 +65,44 @@ func TestCommentBody_CustomTemplate(t *testing.T) {
 	}
 	if !strings.Contains(body, "### konflate — summary") {
 		t.Errorf("custom body should embed the default summary via .Summary: %q", body)
+	}
+}
+
+// TestCommentBody_CustomTemplateEscapesForgeFields: a custom template that embeds
+// a forge-controlled PR field raw ({{ .PR.Title }}) must not let a malicious title
+// inject Markdown into konflate's own comment — the free-text fields are escaped.
+func TestCommentBody_CustomTemplateEscapesForgeFields(t *testing.T) {
+	t.Parallel()
+	env := readyEnvelope()
+	env.PR.Title = "[click](https://evil.example)"
+	env.PR.Author = "a](b) ![x](c)"
+	env.PR.Labels = []api.Label{{Name: "[lbl](https://evil.example)", Color: "0e8a16"}}
+	body := newCommentServer(t, "T: {{ .PR.Title }}\nA: {{ .PR.Author }}\nL:{{ range .PR.Labels }} {{ .Name }}{{ end }}").
+		commentBody(env)
+	if strings.Contains(body, "[click](") || strings.Contains(body, "![x](") || strings.Contains(body, "[lbl](") {
+		t.Errorf("a forge-controlled PR field/label must not inject a Markdown link/image:\n%s", body)
+	}
+	if !strings.Contains(body, `\[click\]`) || !strings.Contains(body, `\[lbl\]`) {
+		t.Errorf("expected the PR title and label brackets escaped:\n%s", body)
+	}
+	// Escaping the copy must not mutate the caller's slice (aliasing guard).
+	if env.PR.Labels[0].Name != "[lbl](https://evil.example)" {
+		t.Errorf("escaping a label mutated the shared PR.Labels slice: %q", env.PR.Labels[0].Name)
+	}
+}
+
+// TestCommentBody_TemplateMdFuncEscapesRawDiffText: raw forge-controlled .Diff
+// text a template renders itself can be escaped with the `md` func.
+func TestCommentBody_TemplateMdFuncEscapesRawDiffText(t *testing.T) {
+	t.Parallel()
+	env := readyEnvelope()
+	env.Diff.Failures = []api.RenderFailure{{Parent: "HelmRelease ns/app", Message: "[boom](https://evil.example)"}}
+	body := newCommentServer(t, "{{ range .Diff.Failures }}{{ md .Message }}{{ end }}").commentBody(env)
+	if strings.Contains(body, "[boom](") {
+		t.Errorf("the md func must defang a raw Diff message:\n%s", body)
+	}
+	if !strings.Contains(body, `\[boom\]`) {
+		t.Errorf("expected the md-escaped message:\n%s", body)
 	}
 }
 

--- a/internal/server/markdown.go
+++ b/internal/server/markdown.go
@@ -317,14 +317,31 @@ func shortSHA(s string) string {
 
 // mdInline escapes free text (warning details, render messages — possibly
 // forge-controlled and multi-line) for safe inline Markdown: newlines collapse
-// to spaces so a list item stays one item, and HTML/table metacharacters are
-// neutralised.
+// to spaces so a list item stays one item, HTML/table metacharacters are
+// neutralised, and Markdown inline punctuation is backslash-escaped. The last
+// part matters because this text lands in konflate's OWN trusted PR comment and
+// check-run: a render error echoing a fork's template could otherwise inject a
+// clickable link, a remote image, a code span, or emphasis into that authored
+// content. GFM strips the backslash on render, so the escapes are invisible.
 func mdInline(s string) string {
 	s = strings.ReplaceAll(s, "\r\n", " ")
 	s = strings.ReplaceAll(s, "\n", " ")
 	s = strings.ReplaceAll(s, "\r", " ")
-	return strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", "|", `\|`).Replace(s)
+	return mdInlineReplacer.Replace(s)
 }
+
+// mdInlineReplacer runs a single non-overlapping pass (so its own output is never
+// re-escaped): HTML entities for <, >, &; a \| for the table pipe; and a
+// backslash before every Markdown inline metacharacter — the link/image brackets
+// and parens, the code-span backtick, the emphasis/strikethrough runs, the image
+// bang, and the backslash itself (escaped first so it can't consume a following
+// escape). Bare autolinked URLs are left alone: their destination is visible, so
+// they aren't a spoofing vector the way [text](hidden-url) is.
+var mdInlineReplacer = strings.NewReplacer(
+	"&", "&amp;", "<", "&lt;", ">", "&gt;", "|", `\|`,
+	`\`, `\\`, "`", "\\`", "[", `\[`, "]", `\]`, "(", `\(`, ")", `\)`,
+	"*", `\*`, "_", `\_`, "~", `\~`, "!", `\!`,
+)
 
 // mdCode escapes a value rendered inside a `code span` (resource ids, image
 // refs — already constrained charsets, but defended anyway): newlines flattened,
@@ -373,12 +390,40 @@ func reviewURLFromRequest(r *http.Request, number int) string {
 	} else if r.TLS == nil {
 		scheme = "http"
 	}
-	host := r.Header.Get("X-Forwarded-Host")
-	if host == "" {
-		host = r.Host
+	// The scheme and host are request-controlled (X-Forwarded-* / Host), and this
+	// URL is embedded straight into a Markdown link — a value carrying `)` or `[`
+	// would break out and inject a second link. Clamp the scheme to http/https and
+	// require a plain host[:port]; otherwise omit the link rather than emit a
+	// malformed/injected one.
+	if scheme != "http" && scheme != schemeHTTPS {
+		scheme = schemeHTTPS
 	}
-	if host == "" {
+	host := r.Host
+	if xfh := r.Header.Get("X-Forwarded-Host"); xfh != "" {
+		if first, _, _ := strings.Cut(xfh, ","); validHost(strings.TrimSpace(first)) {
+			host = strings.TrimSpace(first)
+		}
+	}
+	if !validHost(host) {
 		return ""
 	}
 	return fmt.Sprintf("%s://%s/#/pr/%d", scheme, host, number)
+}
+
+// validHost reports whether h is a plain host[:port] (or a bracketed IPv6 literal)
+// with no character that could break out of the Markdown link it is embedded in —
+// only letters, digits, and the host punctuation . - : [ ].
+func validHost(h string) bool {
+	if h == "" || len(h) > 260 {
+		return false
+	}
+	for _, c := range h {
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		case c == '.', c == '-', c == ':', c == '[', c == ']':
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/internal/server/markdown_test.go
+++ b/internal/server/markdown_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -154,8 +156,11 @@ func TestSummaryMarkdown_EscapesForgeText(t *testing.T) {
 	// What a malicious PR might craft into a render error: a pipe (table break),
 	// raw HTML (injection), and a newline (would split the list item).
 	env.Diff.Failures = []api.RenderFailure{{
-		Parent:  "HelmRelease ns/app",
-		Message: "boom | <script>alert(1)</script>\nsecond line",
+		Parent: "HelmRelease ns/app",
+		// A pipe (table break), raw HTML, a newline (would split the list item), and
+		// Markdown that — unescaped — would inject a clickable link, a remote image,
+		// and a code span into konflate's own comment/check-run.
+		Message: "boom | <script>alert(1)</script>\nsecond line [click](https://evil.example) ![x](https://evil.example/p.png) `code`",
 	}}
 	md := summaryMarkdown(env, "", true)
 	if strings.Contains(md, "<script>") {
@@ -169,6 +174,33 @@ func TestSummaryMarkdown_EscapesForgeText(t *testing.T) {
 	}
 	if strings.Contains(md, "\nsecond line") {
 		t.Errorf("a newline in a message must collapse to a space:\n%s", md)
+	}
+	// The Markdown link/image syntax must be defanged: the brackets are
+	// backslash-escaped, so no [text](url) link or ![alt](url) image forms.
+	if strings.Contains(md, "[click](") || strings.Contains(md, "![x](") {
+		t.Errorf("forge text must not inject a Markdown link or image:\n%s", md)
+	}
+	if !strings.Contains(md, `\[click\]`) || !strings.Contains(md, `\!\[x\]`) {
+		t.Errorf("expected escaped link/image brackets:\n%s", md)
+	}
+	// A backtick must be escaped so it can't open a code span mid-message.
+	if !strings.Contains(md, "\\`code\\`") {
+		t.Errorf("expected escaped code-span backticks:\n%s", md)
+	}
+}
+
+func TestMdInline_DefangsMarkdown(t *testing.T) {
+	t.Parallel()
+	// Backslash-escaped punctuation renders as the literal character in GFM, so a
+	// link/image/code/emphasis attempt is inert while the text reads unchanged.
+	got := mdInline("a [l](u) ![i](u) `c` *b* _e_ ~s~ | <x>")
+	want := "a \\[l\\]\\(u\\) \\!\\[i\\]\\(u\\) \\`c\\` \\*b\\* \\_e\\_ \\~s\\~ \\| &lt;x&gt;"
+	if got != want {
+		t.Errorf("mdInline mismatch:\n got %q\nwant %q", got, want)
+	}
+	// A lone backslash is escaped first, so it can't consume a following escape.
+	if got := mdInline(`\`); got != `\\` {
+		t.Errorf("a backslash must be escaped, got %q", got)
 	}
 }
 
@@ -229,5 +261,42 @@ func TestShortVer(t *testing.T) {
 		if got := shortVer(c.in); got != c.want {
 			t.Errorf("shortVer(%q) = %q, want %q", c.in, got, c.want)
 		}
+	}
+}
+
+// TestReviewURLFromRequest_RejectsInjection: the request-controlled host/scheme
+// are embedded straight into a Markdown link, so a value carrying link-breakout
+// characters must be rejected (fall back to the request Host, or drop the link),
+// and a forged scheme clamped to https.
+func TestReviewURLFromRequest_RejectsInjection(t *testing.T) {
+	t.Parallel()
+	// A well-formed forwarded host + proto → the normal review URL.
+	r := httptest.NewRequest(http.MethodGet, "/api/prs/7/summary", nil)
+	r.Header.Set("X-Forwarded-Host", "konflate.example")
+	r.Header.Set("X-Forwarded-Proto", "https")
+	if got := reviewURLFromRequest(r, 7); got != "https://konflate.example/#/pr/7" {
+		t.Errorf("valid host/proto: got %q", got)
+	}
+	// An X-Forwarded-Host carrying Markdown link-breakout characters is ignored in
+	// favour of the (clean) request Host, so no second link is injected.
+	r2 := httptest.NewRequest(http.MethodGet, "/api/prs/7/summary", nil)
+	r2.Host = "konflate.example"
+	r2.Header.Set("X-Forwarded-Proto", "https")
+	r2.Header.Set("X-Forwarded-Host", "evil.example) [inject](https://attacker.example")
+	if got := reviewURLFromRequest(r2, 7); got != "https://konflate.example/#/pr/7" {
+		t.Errorf("injected X-Forwarded-Host must fall back to the request Host, got %q", got)
+	}
+	// A forged X-Forwarded-Proto is clamped to https.
+	r3 := httptest.NewRequest(http.MethodGet, "/api/prs/7/summary", nil)
+	r3.Host = "konflate.example"
+	r3.Header.Set("X-Forwarded-Proto", "javascript:alert(1)//")
+	if got := reviewURLFromRequest(r3, 7); got != "https://konflate.example/#/pr/7" {
+		t.Errorf("forged scheme must clamp to https, got %q", got)
+	}
+	// No usable host at all → no link (rather than a malformed one).
+	r4 := httptest.NewRequest(http.MethodGet, "/api/prs/7/summary", nil)
+	r4.Host = "bad host) with (spaces"
+	if got := reviewURLFromRequest(r4, 7); got != "" {
+		t.Errorf("an unusable host must yield no link, got %q", got)
 	}
 }


### PR DESCRIPTION
## What

The **markdown-injection** finding from the project review — closed at every sink that lands forge-controlled text in konflate's **own** authored output (the PR comment + check-run are posted under konflate's bot/App identity, and it renders untrusted fork PRs). Left active, that text can inject a clickable `[text](hidden-url)` link, a remote `![](url)` image (tracking pixel), a code span, or emphasis.

The review's bypass pass confirmed the original `mdInline` gap **and** two sibling sinks; all three are fixed here.

| # | Sink | Fix |
|---|------|-----|
| 1 | `mdInline` (render error, warning detail, failure message) escaped `&`/`<`/`>`/`\|` but left Markdown syntax active. | Also backslash-escapes the inline metacharacters `` \ ` [ ] ( ) * _ ~ ! `` in one non-overlapping `NewReplacer` pass (its output is never re-escaped; `\` escaped first). GFM strips the backslash on render → benign text unchanged. |
| 2 | The custom PR-comment template (`text/template`, no auto-escape) rendered forge PR/Diff fields **raw**. | The free-text PR fields (`Title`, `Author`, `HeadRef`, `BaseRef`, and each `Labels[].Name`/`.Color` — the slice is deep-copied so the shared PR isn't mutated) are Markdown-escaped before the template runs; `md`/`mdCode` template funcs are exposed so an author can escape any raw `.Diff` text they render themselves (`.Summary`/`.Sections` were already pre-escaped). |
| 3 | `reviewURLFromRequest` built a `[View…](url)` link from the request scheme/host (`X-Forwarded-*`/`Host`) with no validation — a `)` in the host breaks out and injects a second link. | Scheme clamped to `http`/`https`; host must be a plain `host[:port]` (or `[ipv6]`), else the link is omitted. |

Scope notes: bare autolinked URLs are left alone (visible destination, not a spoof); `mdCode` is unchanged (Markdown is inert inside code spans, and it drops backticks); the konflate-authored review link and admonition markers (`[!TIP]`/`[!CAUTION]`) are emitted directly, not via `mdInline`. The MCP `list_pull_requests` tool renders a PR title into plain-text tool output — a lower-risk, different surface (client-dependent rendering) — left for a separate change.

## Tests
`markdown_test.go`: `TestMdInline_DefangsMarkdown` (pins the exact escaped output), extended `TestSummaryMarkdown_EscapesForgeText` (link/image/code in a failure message), `TestReviewURLFromRequest_RejectsInjection` (injected host falls back / forged scheme clamps / unusable host → no link). `comment_test.go`: `TestCommentBody_CustomTemplateEscapesForgeFields` (raw `{{ .PR.Title }}` defanged) and `TestCommentBody_TemplateMdFuncEscapesRawDiffText` (the `md` func escapes a raw `.Diff` message). All fail if their fix is reverted.

Verified: `go test -race ./...`, `vet`, `lint` (0), `fmt-check`, `tidy-check`. No UI or chart changes.

PR E of the review's fix batching (A #310 · B #311 · C #312 · D #313 · **E: markdown escape** · F: perf + quality).
