### PR TITLE
perf(server): skip redundant re-renders, bound MCP diff work, dedup summary blocks

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -92,8 +92,8 @@ func (c *Client) Exists(ctx context.Context, ref string) (bool, error) {
 // isNotFound reports whether err is the registry definitively saying the
 // tag/digest is absent (HTTP 404), as opposed to an auth or transport failure.
 func isNotFound(err error) bool {
-	var te *transport.Error
-	return errors.As(err, &te) && te.StatusCode == http.StatusNotFound
+	te, ok := errors.AsType[*transport.Error](err)
+	return ok && te.StatusCode == http.StatusNotFound
 }
 
 func (c *Client) cached(ref string) (found, ok bool) {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -386,7 +386,7 @@ func (s *Server) handlePush(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid PR number")
 		return
 	}
-	if err := s.refreshPR(r.Context(), number, "push"); err != nil {
+	if err := s.refreshPR(r.Context(), number, "push", true); err != nil {
 		s.log.Warn("push: fetch PR failed", "pr", number, "error", err)
 		writeError(w, http.StatusBadGateway, "could not fetch PR from forge")
 		return
@@ -397,7 +397,7 @@ func (s *Server) handlePush(w http.ResponseWriter, r *http.Request) {
 // refreshPR fetches a single PR from the forge and enqueues its diff. Shared by
 // the push endpoint (synchronous, surfaces fetch errors) and the webhook
 // (fire-and-forget).
-func (s *Server) refreshPR(ctx context.Context, number int, reason string) error {
+func (s *Server) refreshPR(ctx context.Context, number int, reason string, force bool) error {
 	pr, err := s.prov.GetPR(ctx, number)
 	if err != nil {
 		return err
@@ -409,7 +409,23 @@ func (s *Server) refreshPR(ctx context.Context, number int, reason string) error
 		s.reconcileState(pr)
 		return nil
 	}
+	// Read the last-rendered state BEFORE upserting this PR's metadata, so the gate
+	// compares against what was actually rendered, not the values just written.
+	prev, hadPrev := s.store.get(number)
 	s.store.upsertPR(pr, false)
+	// Skip the re-render only when the head SHA AND the base ref are both unchanged
+	// and already rendered — a metadata-only webhook (labeled/edited/assigned/…),
+	// where the upserted metadata (labels/title) is all that changed. A new push
+	// (advanced head), a retarget (base changed → a different merge-base → a
+	// different diff), a first sighting, a prior error/pending, or a newly-allowed
+	// PR all fall through and enqueue. force skips the gate: the push endpoint is an
+	// explicit "re-render now" honouring a base-branch move or manual retry the head
+	// SHA can't reflect.
+	if !force && hadPrev && prev.Status == api.JobReady && prev.Diff != nil &&
+		prev.Diff.HeadSHA == pr.HeadSHA && prev.PR.BaseRef == pr.BaseRef && pr.HeadSHA != "" {
+		s.log.Debug("skipping render; head and base unchanged and already rendered", "pr", number, "reason", reason)
+		return nil
+	}
 	s.log.Info("queuing render", "pr", number, "reason", reason)
 	s.queue.enqueue(pr)
 	return nil
@@ -505,7 +521,7 @@ func (s *Server) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		s.requestCheckRefresh(ev.HeadSHA)
 	case ev.PR > 0 && !ev.Relist:
 		go func() {
-			if err := s.refreshPR(s.runCtx, ev.PR, "webhook"); err != nil {
+			if err := s.refreshPR(s.runCtx, ev.PR, "webhook", false); err != nil {
 				s.log.Warn("webhook: refresh PR failed", "pr", ev.PR, "error", err)
 			}
 		}()
@@ -560,13 +576,15 @@ func (s *Server) refreshList(ctx context.Context) {
 		// set: a PR reappearing in it is genuinely open again, so it un-shelves a
 		// previously-merged PR (a reopen) and reports it so we re-render.
 		reopened := s.store.markOpen(pr, !allowed)
-		// Render a PR that is newly tracked, reopened, whose head advanced, or that
+		// Render a PR that is newly tracked, reopened, whose head advanced or whose
+		// base was retargeted (a different merge-base → a different diff), or that
 		// just became filter-allowed without a push (e.g. draft → ready under a
-		// !pr.draft filter). That last case is easy to miss: in polling mode nothing
-		// else enqueues it, and the staleness backstop skips never-rendered jobs, so
-		// it would sit pending forever.
+		// !pr.draft filter). Those last two are easy to miss: in polling mode nothing
+		// else enqueues them, and the staleness backstop skips never-rendered jobs, so
+		// they would sit pending / stale forever.
 		nowAllowed := known && prev.Hidden && allowed
-		if allowed && (!known || reopened || prev.PR.HeadSHA != pr.HeadSHA || nowAllowed) {
+		retargeted := known && prev.PR.BaseRef != pr.BaseRef
+		if allowed && (!known || reopened || prev.PR.HeadSHA != pr.HeadSHA || retargeted || nowAllowed) {
 			reason := "head advanced"
 			switch {
 			case !known:
@@ -578,7 +596,10 @@ func (s *Server) refreshList(ctx context.Context) {
 			case nowAllowed:
 				reason = "filter now admits"
 				unhidden++
+			case prev.PR.HeadSHA != pr.HeadSHA:
+				advanced++
 			default:
+				reason = "base retarget"
 				advanced++
 			}
 			s.log.Debug("queuing render", "pr", pr.Number, "reason", reason)

--- a/internal/server/markdown.go
+++ b/internal/server/markdown.go
@@ -186,68 +186,65 @@ func sectionRoutine(d *api.DiffResult, admonitions bool) string {
 // check (see checkConclusion). Red [!CAUTION], the top of the ramp, above the
 // amber cautions. Empty unless a rule emitted a LevelBlocking warning (none do
 // yet).
-func sectionBlocking(d *api.DiffResult, admonitions bool) string {
-	ws := api.WarningsByLevel(d.Warnings, api.LevelBlocking)
-	if len(ws) == 0 {
+// mdItem is one "- `code` — detail" line in a summary block.
+type mdItem struct{ code, detail string }
+
+// mdBlock renders a summary block: a header — a GitHub admonition (> [!ALERT] +
+// bold line) when admonitions, else a plain bold line — then one "- `code` —
+// detail" item per entry (mdCode/mdInline escape the forge-controlled halves).
+// The admonition and plain headers can differ: the plain form carries the
+// severity glyph the admonition box would otherwise supply. Empty when no items.
+func mdBlock(admonitions bool, alert, admonitionHeader, plainHeader string, items []mdItem) string {
+	if len(items) == 0 {
 		return ""
 	}
 	var b strings.Builder
+	prefix := "- "
 	if admonitions {
-		fmt.Fprintf(&b, "> [!CAUTION]\n> **⛔ %s**\n", plural(len(ws), "Blocker", "Blockers"))
-		for _, wn := range ws {
-			fmt.Fprintf(&b, "> - `%s` — %s\n", mdCode(wn.Resource), mdInline(wn.Detail))
-		}
+		fmt.Fprintf(&b, "> [!%s]\n> **%s**\n", alert, admonitionHeader)
+		prefix = "> - "
 	} else {
-		fmt.Fprintf(&b, "**⛔ %s**\n", plural(len(ws), "Blocker", "Blockers"))
-		for _, wn := range ws {
-			fmt.Fprintf(&b, "- `%s` — %s\n", mdCode(wn.Resource), mdInline(wn.Detail))
-		}
+		fmt.Fprintf(&b, "**%s**\n", plainHeader)
+	}
+	for _, it := range items {
+		fmt.Fprintf(&b, "%s`%s` — %s\n", prefix, mdCode(it.code), mdInline(it.detail))
 	}
 	return strings.TrimRight(b.String(), "\n")
+}
+
+// warningItems maps warnings to block items (Resource → code, Detail → detail).
+func warningItems(ws []api.Warning) []mdItem {
+	items := make([]mdItem, len(ws))
+	for i, wn := range ws {
+		items[i] = mdItem{code: wn.Resource, detail: wn.Detail}
+	}
+	return items
+}
+
+func sectionBlocking(d *api.DiffResult, admonitions bool) string {
+	ws := api.WarningsByLevel(d.Warnings, api.LevelBlocking)
+	// Red [!CAUTION] — a blocker is the top of the severity ramp.
+	h := fmt.Sprintf("⛔ %s", plural(len(ws), "Blocker", "Blockers"))
+	return mdBlock(admonitions, "CAUTION", h, h, warningItems(ws))
 }
 
 func sectionCautions(d *api.DiffResult, admonitions bool) string {
 	ws := api.WarningsByLevel(d.Warnings, api.LevelCaution)
-	if len(ws) == 0 {
-		return ""
-	}
-	var b strings.Builder
-	if admonitions {
-		// Amber [!WARNING] to match the caution list pill's colour (a notch below
-		// the red [!CAUTION] of a blocker or render failure). The alert header
-		// reads "Warning", so the block names itself.
-		fmt.Fprintf(&b, "> [!WARNING]\n> **⚠ %s**\n", plural(len(ws), "Caution", "Cautions"))
-		for _, wn := range ws {
-			fmt.Fprintf(&b, "> - `%s` — %s\n", mdCode(wn.Resource), mdInline(wn.Detail))
-		}
-	} else {
-		fmt.Fprintf(&b, "**⚠ %s**\n", plural(len(ws), "Caution", "Cautions"))
-		for _, wn := range ws {
-			fmt.Fprintf(&b, "- `%s` — %s\n", mdCode(wn.Resource), mdInline(wn.Detail))
-		}
-	}
-	return strings.TrimRight(b.String(), "\n")
+	// Amber [!WARNING] to match the caution list pill's colour (a notch below the
+	// red of a blocker or render failure); the alert header reads "Warning".
+	h := fmt.Sprintf("⚠ %s", plural(len(ws), "Caution", "Cautions"))
+	return mdBlock(admonitions, "WARNING", h, h, warningItems(ws))
 }
 
 func sectionFailures(d *api.DiffResult, admonitions bool) string {
-	if len(d.Failures) == 0 {
-		return ""
+	items := make([]mdItem, len(d.Failures))
+	for i, f := range d.Failures {
+		items[i] = mdItem{code: f.Parent, detail: f.Message}
 	}
-	var b strings.Builder
-	title := fmt.Sprintf("%d render %s", len(d.Failures), plural(len(d.Failures), "failure", "failures"))
-	if admonitions {
-		// Red [!CAUTION] to match the failure list pill — the top of the severity ramp.
-		fmt.Fprintf(&b, "> [!CAUTION]\n> **%s**\n", title)
-		for _, f := range d.Failures {
-			fmt.Fprintf(&b, "> - `%s` — %s\n", mdCode(f.Parent), mdInline(f.Message))
-		}
-	} else {
-		fmt.Fprintf(&b, "**⛔ Render failures (%d)**\n", len(d.Failures))
-		for _, f := range d.Failures {
-			fmt.Fprintf(&b, "- `%s` — %s\n", mdCode(f.Parent), mdInline(f.Message))
-		}
-	}
-	return strings.TrimRight(b.String(), "\n")
+	// Red [!CAUTION] like a blocker; the plain form adds the ⛔ glyph the box drops.
+	admHeader := fmt.Sprintf("%d render %s", len(d.Failures), plural(len(d.Failures), "failure", "failures"))
+	plainHeader := fmt.Sprintf("⛔ Render failures (%d)", len(d.Failures))
+	return mdBlock(admonitions, "CAUTION", admHeader, plainHeader, items)
 }
 
 func sectionImages(d *api.DiffResult) string {

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -184,7 +184,9 @@ func writePRLine(b *strings.Builder, p api.PRStatus) {
 	if sig := signalSummary(p.Signals); sig != "" {
 		fmt.Fprintf(b, " [%s]", sig)
 	}
-	fmt.Fprintf(b, " %s\n", p.Title)
+	// oneLine flattens the forge-controlled title: a newline/control char would
+	// otherwise break this one-line-per-PR listing (each line is parsed as a PR).
+	fmt.Fprintf(b, " %s\n", oneLine(p.Title))
 }
 
 // signalSummary joins the non-zero rendered-diff signals (omitting any that are
@@ -314,11 +316,18 @@ func (s *Server) mcpPRDiff(_ context.Context, _ *mcp.CallToolRequest, in mcpDiff
 // and the pr-diff resource so both stay consistent and bounded.
 func renderDiffText(resources []api.DiffResource, renderTruncated int) string {
 	var b strings.Builder
+	overflow := false
 	for i := range resources {
 		if i > 0 {
 			b.WriteByte('\n')
 		}
 		writeResourceDiff(&b, resources[i])
+		// Stop once the budget is filled: otherwise a multi-MB diff strips every
+		// row's chroma HTML back to text only to discard all but the first 96 KiB.
+		if b.Len() >= mcpDiffMaxBytes {
+			overflow = i < len(resources)-1 // resources we won't render
+			break
+		}
 	}
 	body := b.String()
 
@@ -329,6 +338,9 @@ func renderDiffText(resources []api.DiffResource, renderTruncated int) string {
 			cut = cut[:nl]
 		}
 		body = cut
+		overflow = true
+	}
+	if overflow {
 		notes = append(notes, "… output truncated; use get_pr_diff with the `resource` argument to fetch one resource at a time …")
 	}
 	if renderTruncated > 0 {
@@ -386,6 +398,9 @@ func (s *Server) mcpReadDiffResource(_ context.Context, req *mcp.ReadResourceReq
 func writeResourceDiff(b *strings.Builder, r api.DiffResource) {
 	fmt.Fprintf(b, "%s %s\n", r.Status, r.Title)
 	for _, row := range r.Unified {
+		if b.Len() >= mcpDiffMaxBytes {
+			break // a single huge resource: don't strip past the budget renderDiffText will trim to
+		}
 		switch {
 		case row.Folded:
 			continue

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -363,3 +363,43 @@ func resourceText(rr *mcp.ReadResourceResult) string {
 	}
 	return b.String()
 }
+
+// TestWritePRLine_FlattensTitle: the MCP list is one line per PR, parsed by line,
+// so a forge-controlled title with a newline/control char must be flattened.
+func TestWritePRLine_FlattensTitle(t *testing.T) {
+	t.Parallel()
+	var b strings.Builder
+	writePRLine(&b, api.PRStatus{
+		PR:     api.PR{Number: 7, Title: "line one\nline two\r\tmore", Open: true},
+		Status: api.JobReady,
+	})
+	out := b.String()
+	if n := strings.Count(out, "\n"); n != 1 || !strings.HasSuffix(out, "\n") {
+		t.Errorf("title not flattened to a single line (%d newlines): %q", n, out)
+	}
+	if strings.Contains(out, "line one\nline two") {
+		t.Errorf("a raw newline survived into the listing: %q", out)
+	}
+}
+
+// TestRenderDiffText_TruncatesLargeDiff: a diff far larger than the MCP byte
+// budget is truncated (with a note) rather than fully stripped-then-discarded.
+func TestRenderDiffText_TruncatesLargeDiff(t *testing.T) {
+	t.Parallel()
+	big := strings.Repeat("x", 4096) // plain text: stripHTML is a no-op
+	var resources []api.DiffResource
+	for i := 0; i < 64; i++ { // ~256 KiB, well over the 96 KiB budget
+		resources = append(resources, api.DiffResource{
+			Status:  "changed",
+			Title:   fmt.Sprintf("Deployment ns/app-%d", i),
+			Unified: []api.UnifiedRow{{Kind: "ctx", HTML: big}},
+		})
+	}
+	out := renderDiffText(resources, 0)
+	if len(out) > mcpDiffMaxBytes+1024 {
+		t.Errorf("output not truncated to the budget: %d bytes", len(out))
+	}
+	if !strings.Contains(out, "output truncated") {
+		t.Errorf("truncated output is missing the note:\n…%s", out[max(0, len(out)-160):])
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1598,3 +1598,131 @@ func TestMeta_FeaturesReflectAuth(t *testing.T) {
 		})
 	}
 }
+
+// TestRefreshPR_SkipsUnchangedRenderedHead verifies a metadata-only webhook
+// (labeled/edited — same head SHA, already rendered) does not re-render, while a
+// genuinely new head SHA does. Avoids a full render per chatty PR-metadata event.
+func TestRefreshPR_SkipsUnchangedRenderedHead(t *testing.T) {
+	t.Parallel()
+	var renders atomic.Int32
+	eng := &fakeEngine{fn: func(pr api.PR) (api.DiffResult, error) {
+		renders.Add(1)
+		return api.DiffResult{PRNumber: pr.Number, HeadSHA: pr.HeadSHA}, nil
+	}}
+	prov := &fakeProvider{}
+	prov.setDetail(api.PR{Number: 1, Open: true, HeadRef: "f", BaseRef: "main", HeadSHA: "abc"})
+	s := newTestServer(t, ghCfg("tok"), prov, eng)
+
+	// First webhook renders the head (no prior render → the gate lets it through).
+	if err := s.refreshPR(s.runCtx, 1, "webhook", false); err != nil {
+		t.Fatalf("refreshPR: %v", err)
+	}
+	if env := waitFor(t, s, 1); env.Status != api.JobReady {
+		t.Fatalf("first render status = %s, want ready", env.Status)
+	}
+	if n := renders.Load(); n != 1 {
+		t.Fatalf("first refresh rendered %d times, want 1", n)
+	}
+
+	// A metadata-only webhook (same head SHA, already rendered) must not re-render.
+	if err := s.refreshPR(s.runCtx, 1, "webhook", false); err != nil {
+		t.Fatalf("refreshPR (metadata): %v", err)
+	}
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if n := renders.Load(); n != 1 {
+			t.Fatalf("a metadata-only refresh re-rendered (count=%d)", n)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// A new head SHA re-renders.
+	prov.setDetail(api.PR{Number: 1, Open: true, HeadRef: "f", BaseRef: "main", HeadSHA: "def"})
+	if err := s.refreshPR(s.runCtx, 1, "webhook", false); err != nil {
+		t.Fatalf("refreshPR (new SHA): %v", err)
+	}
+	renderedDef := func() bool {
+		env, ok := s.store.get(1)
+		return ok && env.Status == api.JobReady && env.Diff != nil && env.Diff.HeadSHA == "def"
+	}
+	dl := time.Now().Add(2 * time.Second)
+	for time.Now().Before(dl) && !renderedDef() {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !renderedDef() {
+		t.Fatal("a new head SHA never re-rendered to def")
+	}
+	if n := renders.Load(); n != 2 {
+		t.Fatalf("total renders = %d, want 2 (initial + new-SHA; the metadata refresh skipped)", n)
+	}
+
+	// A retarget (same head SHA, new base ref → a different merge-base) re-renders.
+	prov.setDetail(api.PR{Number: 1, Open: true, HeadRef: "f", BaseRef: "develop", HeadSHA: "def"})
+	if err := s.refreshPR(s.runCtx, 1, "webhook", false); err != nil {
+		t.Fatalf("refreshPR (retarget): %v", err)
+	}
+	dl = time.Now().Add(2 * time.Second)
+	for time.Now().Before(dl) && renders.Load() < 3 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if n := renders.Load(); n != 3 {
+		t.Fatalf("a base-ref retarget must re-render; renders = %d, want 3", n)
+	}
+
+	// The push endpoint forces a re-render even on an unchanged, already-rendered
+	// head+base (the CI trigger's whole point) — force bypasses the gate.
+	if err := s.refreshPR(s.runCtx, 1, "push", true); err != nil {
+		t.Fatalf("refreshPR (forced): %v", err)
+	}
+	dl = time.Now().Add(2 * time.Second)
+	for time.Now().Before(dl) && renders.Load() < 4 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if n := renders.Load(); n != 4 {
+		t.Fatalf("a forced refresh must re-render an unchanged head; renders = %d, want 4", n)
+	}
+}
+
+// TestRefreshList_RerendersOnBaseRetarget verifies the poll/relist path re-renders
+// a PR whose base was retargeted (same head SHA, new base → new merge-base), the
+// only trigger in webhook-less polling mode besides the staleness backstop.
+func TestRefreshList_RerendersOnBaseRetarget(t *testing.T) {
+	t.Parallel()
+	var renders atomic.Int32
+	eng := &fakeEngine{fn: func(pr api.PR) (api.DiffResult, error) {
+		renders.Add(1)
+		return api.DiffResult{PRNumber: pr.Number, HeadSHA: pr.HeadSHA}, nil
+	}}
+	prov := &fakeProvider{}
+	prov.setPRs(api.PR{Number: 1, Open: true, HeadRef: "f", BaseRef: "main", HeadSHA: "abc"})
+	s := newTestServer(t, ghCfg("tok"), prov, eng)
+
+	s.refreshList(s.runCtx)
+	if env := waitFor(t, s, 1); env.Status != api.JobReady {
+		t.Fatalf("first render status = %s, want ready", env.Status)
+	}
+	if n := renders.Load(); n != 1 {
+		t.Fatalf("first list render count = %d, want 1", n)
+	}
+
+	// An unchanged relist must not re-render.
+	s.refreshList(s.runCtx)
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if n := renders.Load(); n != 1 {
+			t.Fatalf("an unchanged relist re-rendered (count=%d)", n)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// A base retarget (same head, new base) must re-render.
+	prov.setPRs(api.PR{Number: 1, Open: true, HeadRef: "f", BaseRef: "develop", HeadSHA: "abc"})
+	s.refreshList(s.runCtx)
+	dl := time.Now().Add(2 * time.Second)
+	for time.Now().Before(dl) && renders.Load() < 2 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if n := renders.Load(); n != 2 {
+		t.Fatalf("a base retarget via the list must re-render; renders = %d, want 2", n)
+	}
+}


### PR DESCRIPTION
## What

The **perf + quality** batch — the last of the project review. Five focused changes; the review's remaining lower-value/higher-churn items are deferred (below).

| # | Change | Why |
|---|--------|-----|
| 1 | **Webhook re-render gate** (`refreshPR` + `refreshList`) | A metadata-only `pull_request` webhook (labeled/edited/assigned) fired a full re-render despite an unchanged head. `refreshPR` now skips the enqueue only when the PR is already rendered at the same head SHA **and** base ref (metadata is still upserted). A **retarget** (base changed → different merge-base → different diff) re-renders — in both the webhook path and the poll/relist path (`refreshList` previously keyed on head SHA alone, the only trigger in webhook-less polling mode). `refreshPR` gained a `force` param: `handlePush` (the authenticated CI "re-render now" trigger) passes `force=true` so a base-branch move or manual retry — which the head SHA can't reflect — still renders; `handleWebhook` passes `force=false`. |
| 2 | **Bounded MCP diff work** (`renderDiffText`) | It stripped every row's chroma HTML across a multi-MB diff, then discarded all but the first 96 KiB. It now stops stripping once the budget is filled (between resources and within one large resource), then trims + notes as before. |
| 3 | **MCP title flatten** (`writePRLine`) | `oneLine(p.Title)` so a title newline/control char can't split the one-line-per-PR listing an MCP client parses. |
| 4 | **Summary-block dedup** (`markdown.go`) | `sectionBlocking`/`sectionCautions`/`sectionFailures` were triple copy-paste; they now share an `mdBlock` helper. Output is byte-identical (existing verbatim tests guard it). |
| 5 | **`errors.AsType`** (`registry.isNotFound`) | Go 1.26 idiom, behavior-identical. |

## Tests
`server_test.go::TestRefreshPR_SkipsUnchangedRenderedHead` — a metadata refresh doesn't re-render, a new head SHA does, and a `force` (push) refresh re-renders an unchanged head. `mcp_test.go::TestWritePRLine_FlattensTitle` and `TestRenderDiffText_TruncatesLargeDiff`. The dedup + `AsType` are behavior-preserving, guarded by the existing markdown/registry tests.

## Deferred (with rationale)
- **persist double-marshal** — `contentDigest` (timestamps zeroed) and `Save` (real timestamps) marshal the record twice, but only on a genuine content change, off-lock, once per render; deduping needs a persist-package change to thread pre-marshaled bytes. Low value for the risk.
- **Response gzip** — konflate typically sits behind an ingress that compresses; app-level gzip would be largely redundant and is a non-trivial HTTP-layer change.
- **`t.Context()` test sweep** (~85 sites) — mechanical and low-risk, but a large cosmetic diff better kept out of a logic PR.
- **MCP list-title markdown escaping** — the title is now flattened (`oneLine`); full markdown defanging of plain-text tool output is a separate, lower-risk concern.

Verified: `go test -race ./...`, `vet`, `lint` (0), `fmt-check`, `tidy-check`. No UI or chart changes.

PR F of the review's fix batching (A #310 · B #311 · C #312 · D #313 · E #314 · **F: perf + quality**).
