### PR TITLE
perf(persist): serialize the record once per save; defang MCP title; t.Context tests

### DIFF
--- a/internal/gitclone/gitclone_test.go
+++ b/internal/gitclone/gitclone_test.go
@@ -120,7 +120,7 @@ func TestMirror_RepacksWhenPacksAccumulate(t *testing.T) {
 		if last != nil {
 			last.Cleanup()
 		}
-		last, err = m.Trees(context.Background(), "refs/heads/feature", "master")
+		last, err = m.Trees(t.Context(), "refs/heads/feature", "master")
 		if err != nil {
 			t.Fatalf("render %d: %v", i, err)
 		}
@@ -167,7 +167,7 @@ func TestMirror_RebuildsOnCorruptObjectStore(t *testing.T) {
 	m := newTestMirror(t, src)
 
 	// First render seeds the mirror.
-	first, err := m.Trees(context.Background(), "refs/heads/feature", "master")
+	first, err := m.Trees(t.Context(), "refs/heads/feature", "master")
 	if err != nil {
 		t.Fatalf("seed render: %v", err)
 	}
@@ -188,7 +188,7 @@ func TestMirror_RebuildsOnCorruptObjectStore(t *testing.T) {
 	}
 
 	// Second render must self-heal (rebuild) and still return correct trees.
-	res, err := m.Trees(context.Background(), "refs/heads/feature", "master")
+	res, err := m.Trees(t.Context(), "refs/heads/feature", "master")
 	if err != nil {
 		t.Fatalf("render after corruption should self-heal, got: %v", err)
 	}
@@ -381,7 +381,7 @@ func TestMirror_AuthFor(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			m := NewMirror(t.TempDir(), t.TempDir(), "https://example.test/x.git", tc.token, 0)
-			auth, err := m.authFor(context.Background())
+			auth, err := m.authFor(t.Context())
 			switch {
 			case tc.wantErr:
 				if err == nil {
@@ -479,7 +479,7 @@ func TestMirror_HeadRefGone(t *testing.T) {
 
 	// "master" (the base) exists; pull request 999 does not, so its head ref is
 	// absent — fetching it must report the ref as gone rather than an opaque error.
-	_, err := newTestMirror(t, src).Trees(context.Background(), "refs/pull/999/head", "master")
+	_, err := newTestMirror(t, src).Trees(t.Context(), "refs/pull/999/head", "master")
 	if !errors.Is(err, ErrHeadRefGone) {
 		t.Fatalf("Trees with a missing head ref: got %v, want ErrHeadRefGone", err)
 	}
@@ -510,7 +510,7 @@ func TestMirror_ForkPullHead(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := newTestMirror(t, src).Trees(context.Background(), "refs/pull/1/head", "master")
+	res, err := newTestMirror(t, src).Trees(t.Context(), "refs/pull/1/head", "master")
 	if err != nil {
 		t.Fatalf("Trees via pull head ref: %v", err)
 	}
@@ -523,7 +523,7 @@ func TestMirror_MergeBaseTrees(t *testing.T) {
 	src := buildRepo(t)
 
 	// the default branch from PlainInit is "master"
-	res, err := newTestMirror(t, src).Trees(context.Background(), "refs/heads/feature", "master")
+	res, err := newTestMirror(t, src).Trees(t.Context(), "refs/heads/feature", "master")
 	if err != nil {
 		t.Fatalf("Trees: %v", err)
 	}
@@ -539,7 +539,7 @@ func TestMirror_Reuse(t *testing.T) {
 	src := buildRepo(t)
 	m := newTestMirror(t, src)
 
-	first, err := m.Trees(context.Background(), "refs/heads/feature", "master")
+	first, err := m.Trees(t.Context(), "refs/heads/feature", "master")
 	if err != nil {
 		t.Fatalf("Trees (first): %v", err)
 	}
@@ -548,7 +548,7 @@ func TestMirror_Reuse(t *testing.T) {
 		t.Fatalf("mirror bare repo not present after first render: %v", err)
 	}
 
-	second, err := m.Trees(context.Background(), "refs/heads/feature", "master")
+	second, err := m.Trees(t.Context(), "refs/heads/feature", "master")
 	if err != nil {
 		t.Fatalf("Trees (reuse): %v", err)
 	}
@@ -609,7 +609,7 @@ func TestMirror_ConcurrentRendersSurviveRepack(t *testing.T) {
 	src := buildRepo(t)
 	m := newTestMirror(t, src)
 	// Seed once so the mirror exists with a pack to consolidate on the next fetch.
-	seed, err := m.Trees(context.Background(), "refs/heads/feature", "master")
+	seed, err := m.Trees(t.Context(), "refs/heads/feature", "master")
 	if err != nil {
 		t.Fatalf("seed render: %v", err)
 	}
@@ -673,7 +673,7 @@ func TestMirror_SkipsOversizedFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := newTestMirror(t, src).Trees(context.Background(), "refs/heads/feature", "master")
+	res, err := newTestMirror(t, src).Trees(t.Context(), "refs/heads/feature", "master")
 	if err != nil {
 		t.Fatalf("Trees: %v", err)
 	}
@@ -723,7 +723,7 @@ func TestMirror_ExtractsNestedDirectories(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := newTestMirror(t, src).Trees(context.Background(), "refs/heads/feature", "master")
+	res, err := newTestMirror(t, src).Trees(t.Context(), "refs/heads/feature", "master")
 	if err != nil {
 		t.Fatalf("Trees: %v", err)
 	}
@@ -772,7 +772,7 @@ func TestMirror_ExtractsSymlinkAsRegularFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := newTestMirror(t, src).Trees(context.Background(), "feature", "master")
+	res, err := newTestMirror(t, src).Trees(t.Context(), "feature", "master")
 	if err != nil {
 		t.Fatalf("Trees: %v", err)
 	}

--- a/internal/persist/persist.go
+++ b/internal/persist/persist.go
@@ -90,11 +90,45 @@ func (s *Store) path(number int) string {
 	return filepath.Join(s.dir, strconv.Itoa(number)+fileSuffix)
 }
 
+// recordWire is Record with the (multi-MB) Result pre-serialized. It lets a
+// caller that has already marshaled the Result — to hash it for a change check —
+// save without walking the whole DiffResult a second time: json.Marshal copies
+// the RawMessage verbatim. The tags mirror Record exactly, so the on-disk JSON is
+// byte-identical to marshaling a Record.
+type recordWire struct {
+	PR         api.PR          `json:"pr"`
+	Status     api.JobStatus   `json:"status"`
+	Result     json.RawMessage `json:"result,omitempty"`
+	ErrMsg     string          `json:"errMsg,omitempty"`
+	RefreshErr string          `json:"refreshErr,omitempty"`
+	Updated    time.Time       `json:"updated"`
+	ClosedAt   time.Time       `json:"closedAt,omitzero"`
+	RenderedAt time.Time       `json:"renderedAt,omitzero"`
+}
+
 // Save writes rec atomically: the zstd-compressed JSON goes to a temp file that
 // is then renamed over the PR's file, so a reader (or a crash) never sees a
 // partial one.
 func (s *Store) Save(rec Record) error {
-	data, err := json.Marshal(rec)
+	var resultJSON json.RawMessage
+	if rec.Result != nil {
+		b, err := json.Marshal(rec.Result)
+		if err != nil {
+			return fmt.Errorf("persist: encode result: %w", err)
+		}
+		resultJSON = b
+	}
+	return s.SaveEncoded(rec, resultJSON)
+}
+
+// SaveEncoded is Save with the Result already serialized as resultJSON (nil when
+// there is none), so a caller that marshaled the Result to hash it doesn't pay to
+// walk the multi-MB struct again. The on-disk JSON is identical to Save's.
+func (s *Store) SaveEncoded(rec Record, resultJSON json.RawMessage) error {
+	data, err := json.Marshal(recordWire{
+		PR: rec.PR, Status: rec.Status, Result: resultJSON, ErrMsg: rec.ErrMsg,
+		RefreshErr: rec.RefreshErr, Updated: rec.Updated, ClosedAt: rec.ClosedAt, RenderedAt: rec.RenderedAt,
+	})
 	if err != nil {
 		return fmt.Errorf("persist: encode: %w", err)
 	}

--- a/internal/persist/persist_test.go
+++ b/internal/persist/persist_test.go
@@ -1,6 +1,7 @@
 package persist
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,6 +9,39 @@ import (
 
 	"github.com/home-operations/konflate/internal/api"
 )
+
+// TestSaveEncodedMatchesFullMarshal guards the double-marshal dedup: the wire
+// struct + pre-serialized Result path must write JSON byte-identical to marshaling
+// the whole Record (the pre-refactor form).
+func TestSaveEncodedMatchesFullMarshal(t *testing.T) {
+	t.Parallel()
+	p := newTestStore(t)
+	rec := Record{
+		PR:     api.PR{Number: 9, Title: "x", HeadSHA: "sha"},
+		Status: api.JobReady,
+		Result: &api.DiffResult{PRNumber: 9, HeadSHA: "sha",
+			Warnings: []api.Warning{{Rule: "r", Resource: "res", Detail: "d"}}},
+		Updated: time.Now().Truncate(time.Second).UTC(),
+	}
+	want, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatalf("marshal Record: %v", err)
+	}
+	if err := p.Save(rec); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	blob, err := os.ReadFile(p.path(9))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	got, err := zDec.DecodeAll(blob, nil)
+	if err != nil {
+		t.Fatalf("decompress: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("on-disk JSON differs from a full Record marshal:\n got %s\nwant %s", got, want)
+	}
+}
 
 func newTestStore(t *testing.T) *Store {
 	t.Helper()

--- a/internal/provider/checks_test.go
+++ b/internal/provider/checks_test.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -40,7 +39,7 @@ func TestGitHubProvider_Checks(t *testing.T) {
 	}
 	p := &githubProvider{client: client, owner: "acme", repo: "web"}
 
-	got, err := p.Checks(context.Background(), api.PR{Number: 7, HeadSHA: sha})
+	got, err := p.Checks(t.Context(), api.PR{Number: 7, HeadSHA: sha})
 	if err != nil {
 		t.Fatalf("Checks: %v", err)
 	}
@@ -59,7 +58,7 @@ func TestGitHubProvider_Checks(t *testing.T) {
 func TestGitHubProvider_ChecksNoSHA(t *testing.T) {
 	t.Parallel()
 	p := &githubProvider{owner: "acme", repo: "web"}
-	got, err := p.Checks(context.Background(), api.PR{Number: 1})
+	got, err := p.Checks(t.Context(), api.PR{Number: 1})
 	if err != nil || got.State != api.CheckNone {
 		t.Fatalf("got %+v, %v; want none / no error", got, err)
 	}
@@ -107,7 +106,7 @@ func TestForgejoProvider_ChecksPagesAndDedups(t *testing.T) {
 	}
 	p := &forgejoProvider{client: client, owner: "acme", repo: "web"}
 
-	got, err := p.Checks(context.Background(), api.PR{Number: 7, HeadSHA: sha})
+	got, err := p.Checks(t.Context(), api.PR{Number: 7, HeadSHA: sha})
 	if err != nil {
 		t.Fatalf("Checks: %v", err)
 	}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -48,7 +47,7 @@ func TestGitHubProvider_ListPRs(t *testing.T) {
 	}
 	p := &githubProvider{client: client, owner: "acme", repo: "web"}
 
-	prs, err := p.ListPRs(context.Background())
+	prs, err := p.ListPRs(t.Context())
 	if err != nil {
 		t.Fatalf("ListPRs: %v", err)
 	}
@@ -107,7 +106,7 @@ func TestGitHubProvider_ListPRsPaginates(t *testing.T) {
 	}
 	p := &githubProvider{client: client, owner: "acme", repo: "web"}
 
-	prs, err := p.ListPRs(context.Background())
+	prs, err := p.ListPRs(t.Context())
 	if err != nil {
 		t.Fatalf("ListPRs: %v", err)
 	}
@@ -138,7 +137,7 @@ func TestGitHubProvider_GetPRNotFound(t *testing.T) {
 	}
 	p := &githubProvider{client: client, owner: "acme", repo: "web"}
 
-	if _, err := p.GetPR(context.Background(), 9); !errors.Is(err, ErrPRNotFound) {
+	if _, err := p.GetPR(t.Context(), 9); !errors.Is(err, ErrPRNotFound) {
 		t.Fatalf("GetPR on a 404 = %v, want ErrPRNotFound", err)
 	}
 }
@@ -209,7 +208,7 @@ func TestGitTokenSource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GitTokenSource (pat): %v", err)
 	}
-	if tok, err := src(context.Background()); err != nil || tok != "pat-123" {
+	if tok, err := src(t.Context()); err != nil || tok != "pat-123" {
 		t.Errorf("pat source = (%q, %v), want (\"pat-123\", nil)", tok, err)
 	}
 
@@ -218,7 +217,7 @@ func TestGitTokenSource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GitTokenSource (anon): %v", err)
 	}
-	if tok, err := src(context.Background()); err != nil || tok != "" {
+	if tok, err := src(t.Context()); err != nil || tok != "" {
 		t.Errorf("anon source = (%q, %v), want (\"\", nil)", tok, err)
 	}
 

--- a/internal/provider/writer_test.go
+++ b/internal/provider/writer_test.go
@@ -58,7 +58,7 @@ func TestGitHubWriter_SetStatus(t *testing.T) {
 
 	wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web"}
 
-	err := wr.SetStatus(context.Background(), api.PR{Number: 7, HeadSHA: sha}, Status{
+	err := wr.SetStatus(t.Context(), api.PR{Number: 7, HeadSHA: sha}, Status{
 		State: StatusSuccess, Description: "rendered", TargetURL: "https://k.example/#/pr/7", Context: "konflate",
 	})
 	if err != nil {
@@ -100,7 +100,7 @@ func TestGitHubWriter_CheckRun(t *testing.T) {
 		t.Cleanup(srv.Close)
 
 		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", app: true}
-		err := wr.CheckRun(context.Background(), api.PR{Number: 7, HeadSHA: sha}, CheckResult{
+		err := wr.CheckRun(t.Context(), api.PR{Number: 7, HeadSHA: sha}, CheckResult{
 			Name: "konflate", Conclusion: CheckNeutral, Title: "1 caution",
 			Summary: "### konflate — summary", DetailsURL: "https://k.example/#/pr/7",
 		})
@@ -134,7 +134,7 @@ func TestGitHubWriter_CheckRun(t *testing.T) {
 		t.Cleanup(srv.Close)
 
 		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", app: true}
-		err := wr.CheckRun(context.Background(), api.PR{Number: 7, HeadSHA: sha}, CheckResult{
+		err := wr.CheckRun(t.Context(), api.PR{Number: 7, HeadSHA: sha}, CheckResult{
 			Name:       "konflate",
 			Conclusion: CheckNeutral,
 			Title:      strings.Repeat("t", githubTitleMax+50),  // GitHub caps title at 255
@@ -178,7 +178,7 @@ func TestGitHubWriter_CheckRun(t *testing.T) {
 		t.Cleanup(srv.Close)
 
 		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", app: true}
-		err := wr.CheckRun(context.Background(), api.PR{Number: 7, HeadSHA: sha}, CheckResult{
+		err := wr.CheckRun(t.Context(), api.PR{Number: 7, HeadSHA: sha}, CheckResult{
 			Name: "konflate", Conclusion: CheckSuccess, Title: "clean", Summary: "ok",
 		})
 		if err != nil {
@@ -204,7 +204,7 @@ func TestGitHubWriter_CheckRun(t *testing.T) {
 		t.Cleanup(srv.Close)
 
 		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", app: true}
-		err := wr.CheckRun(context.Background(), api.PR{Number: 7, HeadSHA: sha},
+		err := wr.CheckRun(t.Context(), api.PR{Number: 7, HeadSHA: sha},
 			CheckResult{Name: "konflate", Conclusion: CheckSuccess})
 		if !errors.Is(err, ErrWriteAuthRejected) {
 			t.Fatalf("CheckRun on a 403 = %v, want ErrWriteAuthRejected", err)
@@ -338,7 +338,7 @@ func TestForgejoWriter_SetStatus(t *testing.T) {
 	}
 	wr := &forgejoWriter{client: client, owner: "acme", repo: "web"}
 
-	err = wr.SetStatus(context.Background(), api.PR{Number: 7, HeadSHA: sha}, Status{
+	err = wr.SetStatus(t.Context(), api.PR{Number: 7, HeadSHA: sha}, Status{
 		State: StatusFailure, Description: "render failed", TargetURL: "https://k.example/#/pr/7", Context: "konflate",
 	})
 	if err != nil {
@@ -372,7 +372,7 @@ func TestGitlabWriter_SetStatus(t *testing.T) {
 	}
 	wr := &gitlabWriter{client: client, project: "acme/web"}
 
-	err = wr.SetStatus(context.Background(), api.PR{Number: 7, HeadSHA: sha}, Status{
+	err = wr.SetStatus(t.Context(), api.PR{Number: 7, HeadSHA: sha}, Status{
 		State: StatusSuccess, Description: "rendered", TargetURL: "https://k.example/#/pr/7", Context: "konflate",
 	})
 	if err != nil {
@@ -504,7 +504,7 @@ func TestGitHubWriter_UpsertComment(t *testing.T) {
 		srv := httptest.NewServer(commentCapture(`[]`, &sink))
 		t.Cleanup(srv.Close)
 		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
-		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nhi"); err != nil {
+		if err := wr.UpsertComment(t.Context(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nhi"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
 		assertCreated(t, sink)
@@ -515,7 +515,7 @@ func TestGitHubWriter_UpsertComment(t *testing.T) {
 		srv := httptest.NewServer(commentCapture(markerList(), &sink))
 		t.Cleanup(srv.Close)
 		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
-		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nnew"); err != nil {
+		if err := wr.UpsertComment(t.Context(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nnew"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
 		assertEdited(t, sink)
@@ -526,7 +526,7 @@ func TestGitHubWriter_UpsertComment(t *testing.T) {
 		srv := httptest.NewServer(commentCapture(foreignMarkerList(), &sink))
 		t.Cleanup(srv.Close)
 		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
-		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nhi"); err != nil {
+		if err := wr.UpsertComment(t.Context(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nhi"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
 		assertCreated(t, sink) // posts its own; must not edit the planted comment
@@ -538,7 +538,7 @@ func TestGitHubWriter_UpsertComment(t *testing.T) {
 		t.Cleanup(srv.Close)
 		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
 		// Same body as the listed comment — konflate must skip the no-op edit.
-		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nold"); err != nil {
+		if err := wr.UpsertComment(t.Context(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nold"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
 		assertNoop(t, sink)
@@ -550,7 +550,7 @@ func TestGitHubWriter_UpsertComment(t *testing.T) {
 		t.Cleanup(srv.Close)
 		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
 		huge := upsertMarker + "\n" + strings.Repeat("x", githubBodyMax+5000)
-		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, huge); err != nil {
+		if err := wr.UpsertComment(t.Context(), api.PR{Number: 7}, upsertMarker, huge); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
 		if !sink.created {
@@ -578,7 +578,7 @@ func TestGitlabWriter_UpsertComment(t *testing.T) {
 		srv := httptest.NewServer(commentCapture(`[]`, &sink))
 		t.Cleanup(srv.Close)
 		wr := &gitlabWriter{client: newClient(t, srv.URL), project: "acme/web", self: konflateSelf()}
-		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nhi"); err != nil {
+		if err := wr.UpsertComment(t.Context(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nhi"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
 		assertCreated(t, sink)
@@ -589,7 +589,7 @@ func TestGitlabWriter_UpsertComment(t *testing.T) {
 		srv := httptest.NewServer(commentCapture(markerList(), &sink))
 		t.Cleanup(srv.Close)
 		wr := &gitlabWriter{client: newClient(t, srv.URL), project: "acme/web", self: konflateSelf()}
-		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nnew"); err != nil {
+		if err := wr.UpsertComment(t.Context(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nnew"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
 		assertEdited(t, sink)
@@ -600,7 +600,7 @@ func TestGitlabWriter_UpsertComment(t *testing.T) {
 		srv := httptest.NewServer(commentCapture(foreignMarkerList(), &sink))
 		t.Cleanup(srv.Close)
 		wr := &gitlabWriter{client: newClient(t, srv.URL), project: "acme/web", self: konflateSelf()}
-		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nhi"); err != nil {
+		if err := wr.UpsertComment(t.Context(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nhi"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
 		assertCreated(t, sink) // posts its own; must not edit the planted note
@@ -611,7 +611,7 @@ func TestGitlabWriter_UpsertComment(t *testing.T) {
 		srv := httptest.NewServer(commentCapture(markerList(), &sink))
 		t.Cleanup(srv.Close)
 		wr := &gitlabWriter{client: newClient(t, srv.URL), project: "acme/web", self: konflateSelf()}
-		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nold"); err != nil {
+		if err := wr.UpsertComment(t.Context(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nold"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
 		assertNoop(t, sink)
@@ -634,7 +634,7 @@ func TestForgejoWriter_UpsertComment(t *testing.T) {
 		srv := httptest.NewServer(commentCapture(`[]`, &sink))
 		t.Cleanup(srv.Close)
 		wr := &forgejoWriter{client: newClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
-		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nhi"); err != nil {
+		if err := wr.UpsertComment(t.Context(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nhi"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
 		assertCreated(t, sink)
@@ -645,7 +645,7 @@ func TestForgejoWriter_UpsertComment(t *testing.T) {
 		srv := httptest.NewServer(commentCapture(markerList(), &sink))
 		t.Cleanup(srv.Close)
 		wr := &forgejoWriter{client: newClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
-		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nnew"); err != nil {
+		if err := wr.UpsertComment(t.Context(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nnew"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
 		assertEdited(t, sink)
@@ -656,7 +656,7 @@ func TestForgejoWriter_UpsertComment(t *testing.T) {
 		srv := httptest.NewServer(commentCapture(foreignMarkerList(), &sink))
 		t.Cleanup(srv.Close)
 		wr := &forgejoWriter{client: newClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
-		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nhi"); err != nil {
+		if err := wr.UpsertComment(t.Context(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nhi"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
 		assertCreated(t, sink) // posts its own; must not edit the planted comment
@@ -667,7 +667,7 @@ func TestForgejoWriter_UpsertComment(t *testing.T) {
 		srv := httptest.NewServer(commentCapture(markerList(), &sink))
 		t.Cleanup(srv.Close)
 		wr := &forgejoWriter{client: newClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
-		if err := wr.UpsertComment(context.Background(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nold"); err != nil {
+		if err := wr.UpsertComment(t.Context(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nold"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
 		assertNoop(t, sink)
@@ -804,7 +804,7 @@ func TestGitHubWriter_Verify(t *testing.T) {
 			t.Parallel()
 			srv := statusServer(t, tc.status)
 			wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web"}
-			checkVerify(t, wr.Verify(context.Background()), tc.wantErr, tc.wantRej)
+			checkVerify(t, wr.Verify(t.Context()), tc.wantErr, tc.wantRej)
 		})
 	}
 }
@@ -820,7 +820,7 @@ func TestGitlabWriter_Verify(t *testing.T) {
 				t.Fatalf("gitlab.NewClient: %v", err)
 			}
 			wr := &gitlabWriter{client: client, project: "acme/web"}
-			checkVerify(t, wr.Verify(context.Background()), tc.wantErr, tc.wantRej)
+			checkVerify(t, wr.Verify(t.Context()), tc.wantErr, tc.wantRej)
 		})
 	}
 }
@@ -837,7 +837,7 @@ func TestForgejoWriter_Verify(t *testing.T) {
 				t.Fatalf("forgejo.NewClient: %v", err)
 			}
 			wr := &forgejoWriter{client: client, owner: "acme", repo: "web"}
-			checkVerify(t, wr.Verify(context.Background()), tc.wantErr, tc.wantRej)
+			checkVerify(t, wr.Verify(t.Context()), tc.wantErr, tc.wantRej)
 		})
 	}
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -28,7 +28,7 @@ func TestClientExists(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			c := newTestClient(func(context.Context, name.Reference) error { return tc.headErr })
-			found, err := c.Exists(context.Background(), "ghcr.io/x/y:1.0")
+			found, err := c.Exists(t.Context(), "ghcr.io/x/y:1.0")
 			if found != tc.wantFound || (err != nil) != tc.wantErr {
 				t.Fatalf("Exists = (%v, %v), want found=%v err=%v", found, err, tc.wantFound, tc.wantErr)
 			}
@@ -44,7 +44,7 @@ func TestClientCachesDefinitiveResults(t *testing.T) {
 	c.now = func() time.Time { return now }
 
 	for range 3 {
-		if found, err := c.Exists(context.Background(), "ghcr.io/x/y:1.0"); !found || err != nil {
+		if found, err := c.Exists(t.Context(), "ghcr.io/x/y:1.0"); !found || err != nil {
 			t.Fatalf("Exists = (%v, %v)", found, err)
 		}
 	}
@@ -53,7 +53,7 @@ func TestClientCachesDefinitiveResults(t *testing.T) {
 	}
 	// Past the TTL it re-dials.
 	now = now.Add(defaultTTL + time.Second)
-	if _, err := c.Exists(context.Background(), "ghcr.io/x/y:1.0"); err != nil {
+	if _, err := c.Exists(t.Context(), "ghcr.io/x/y:1.0"); err != nil {
 		t.Fatal(err)
 	}
 	if calls != 2 {
@@ -65,8 +65,8 @@ func TestClientDoesNotCacheIndeterminate(t *testing.T) {
 	t.Parallel()
 	var calls int
 	c := newTestClient(func(context.Context, name.Reference) error { calls++; return errors.New("boom") })
-	_, _ = c.Exists(context.Background(), "ghcr.io/x/y:1.0")
-	_, _ = c.Exists(context.Background(), "ghcr.io/x/y:1.0")
+	_, _ = c.Exists(t.Context(), "ghcr.io/x/y:1.0")
+	_, _ = c.Exists(t.Context(), "ghcr.io/x/y:1.0")
 	if calls != 2 {
 		t.Errorf("indeterminate results must not be cached; dialed %d times, want 2", calls)
 	}
@@ -78,7 +78,7 @@ func TestClientUnparseableRefIsError(t *testing.T) {
 		t.Fatal("head must not be called on an unparseable ref")
 		return nil
 	})
-	if _, err := c.Exists(context.Background(), "BAD"); err == nil {
+	if _, err := c.Exists(t.Context(), "BAD"); err == nil {
 		t.Error("expected an error for an unparseable reference")
 	}
 }

--- a/internal/server/imageverify_test.go
+++ b/internal/server/imageverify_test.go
@@ -42,7 +42,7 @@ func TestVerifyImages(t *testing.T) {
 		{Name: "private.example.com/x", To: "1.0"},     // indeterminate → skipped, never flagged
 		{Name: "ghcr.io/removed", From: "1.0", To: ""}, // a removal → not checked
 	}
-	got := verifyImages(context.Background(), chk, images, 0, discardLog())
+	got := verifyImages(t.Context(), chk, images, 0, discardLog())
 
 	if len(got) != 1 {
 		t.Fatalf("want exactly 1 image-not-found caution, got %d: %+v", len(got), got)
@@ -84,7 +84,7 @@ func TestRenderFuncSkipsForkPRs(t *testing.T) {
 	render := s.renderFunc()
 
 	// Trusted (non-fork) PR: the image is verified and the missing one flagged.
-	res, err := render(context.Background(), api.PR{Number: 1})
+	res, err := render(t.Context(), api.PR{Number: 1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func TestRenderFuncSkipsForkPRs(t *testing.T) {
 
 	// Fork PR: never dialed, never flagged — a fork's images are attacker-chosen (SSRF).
 	before := len(chk.calls)
-	res, err = render(context.Background(), api.PR{Number: 2, Fork: true})
+	res, err = render(t.Context(), api.PR{Number: 2, Fork: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +131,7 @@ func TestVerifyImagesAppliesPerDialTimeout(t *testing.T) {
 		_, sawDeadline = ctx.Deadline()
 		return true, nil
 	})
-	verifyImages(context.Background(), chk, images, 50*time.Millisecond, discardLog())
+	verifyImages(t.Context(), chk, images, 50*time.Millisecond, discardLog())
 	if !sawDeadline {
 		t.Error("a positive timeout must give each registry dial a context deadline")
 	}
@@ -141,7 +141,7 @@ func TestVerifyImagesAppliesPerDialTimeout(t *testing.T) {
 		_, sawDeadline = ctx.Deadline()
 		return true, nil
 	})
-	verifyImages(context.Background(), chk, images, 0, discardLog())
+	verifyImages(t.Context(), chk, images, 0, discardLog())
 	if sawDeadline {
 		t.Error("timeout=0 must dial with the parent context (no added deadline)")
 	}

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -184,10 +184,27 @@ func writePRLine(b *strings.Builder, p api.PRStatus) {
 	if sig := signalSummary(p.Signals); sig != "" {
 		fmt.Fprintf(b, " [%s]", sig)
 	}
-	// oneLine flattens the forge-controlled title: a newline/control char would
-	// otherwise break this one-line-per-PR listing (each line is parsed as a PR).
-	fmt.Fprintf(b, " %s\n", oneLine(p.Title))
+	// mdListText defangs the forge-controlled title: it flattens control chars
+	// (which would break this one-line-per-PR listing) and escapes the link/image
+	// brackets so a crafted title can't inject a clickable link or remote image
+	// into an MCP client that renders the tool text as Markdown.
+	fmt.Fprintf(b, " %s\n", mdListText(p.Title))
 }
+
+// mdListText prepares forge-controlled text for a one-line MCP listing: oneLine
+// flattens control characters, then the escapes neutralise the Markdown/HTML that
+// could inject content into a client rendering the tool text — the link/image
+// brackets ([text](url), ![alt](url)), the code-span backtick, and the angle
+// brackets (an <url> autolink or a raw <script> HTML tag). Ordinary punctuation
+// (parentheses, underscores, *) is left so a normal title like "feat(scope): …"
+// reads cleanly; a bare autolinked URL is left too — its destination is visible,
+// so it isn't the spoofing vector a hidden-destination link is (same stance as
+// mdInline).
+func mdListText(s string) string {
+	return mdListReplacer.Replace(oneLine(s))
+}
+
+var mdListReplacer = strings.NewReplacer("[", `\[`, "]", `\]`, "`", "\\`", "<", `\<`, ">", `\>`)
 
 // signalSummary joins the non-zero rendered-diff signals (omitting any that are
 // zero), e.g. "11 resources, 1 blocker, 1 caution, 1 image change, 1 render failure".

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -26,7 +26,7 @@ func TestMCP_Tools(t *testing.T) {
 	s.refreshList(s.runCtx)
 	waitFor(t, s, 7)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cs := mcpClientFor(t, s)
 
 	// tools/list advertises exactly the three read-only tools.
@@ -96,7 +96,7 @@ func TestMCP_Tools(t *testing.T) {
 // tool-level error result, returning the successful result.
 func mustCallTool(t *testing.T, cs *mcp.ClientSession, name string, args any) *mcp.CallToolResult {
 	t.Helper()
-	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{Name: name, Arguments: args})
+	res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{Name: name, Arguments: args})
 	if err != nil {
 		t.Fatalf("%s: transport error: %v", name, err)
 	}
@@ -173,7 +173,7 @@ func TestMCP_DiffResource(t *testing.T) {
 	s.refreshList(s.runCtx)
 	waitFor(t, s, 7)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cs := mcpClientFor(t, s)
 
 	// resources/templates/list advertises the pr-diff template.
@@ -280,7 +280,7 @@ func TestMCP_Pagination(t *testing.T) {
 	}
 
 	// A non-numeric cursor is a recoverable tool error, not a transport failure.
-	if res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{Name: "list_pull_requests", Arguments: map[string]any{"cursor": "abc"}}); err != nil || !res.IsError {
+	if res, err := cs.CallTool(t.Context(), &mcp.CallToolParams{Name: "list_pull_requests", Arguments: map[string]any{"cursor": "abc"}}); err != nil || !res.IsError {
 		t.Errorf("list_pull_requests(cursor=abc): want a tool error (err=%v)", err)
 	}
 }
@@ -289,7 +289,7 @@ func TestMCP_Pagination(t *testing.T) {
 // registers cleanups to close both sessions.
 func mcpClientFor(t *testing.T, s *Server) *mcp.ClientSession {
 	t.Helper()
-	ctx := context.Background()
+	ctx := t.Context()
 	clientT, serverT := mcp.NewInMemoryTransports()
 	ss, err := s.mcpServer().Connect(ctx, serverT, nil)
 	if err != nil {
@@ -364,13 +364,15 @@ func resourceText(rr *mcp.ReadResourceResult) string {
 	return b.String()
 }
 
-// TestWritePRLine_FlattensTitle: the MCP list is one line per PR, parsed by line,
-// so a forge-controlled title with a newline/control char must be flattened.
-func TestWritePRLine_FlattensTitle(t *testing.T) {
+// TestWritePRLine_DefangsTitle: the MCP list is one line per PR (parsed by line),
+// so a forge-controlled title must be flattened to a single line AND have its
+// Markdown neutralised, so a client rendering the tool text can't get an injected
+// link/image out of a crafted title.
+func TestWritePRLine_DefangsTitle(t *testing.T) {
 	t.Parallel()
 	var b strings.Builder
 	writePRLine(&b, api.PRStatus{
-		PR:     api.PR{Number: 7, Title: "line one\nline two\r\tmore", Open: true},
+		PR:     api.PR{Number: 7, Title: "line one\nline two [x](https://evil.example)", Open: true},
 		Status: api.JobReady,
 	})
 	out := b.String()
@@ -379,6 +381,38 @@ func TestWritePRLine_FlattensTitle(t *testing.T) {
 	}
 	if strings.Contains(out, "line one\nline two") {
 		t.Errorf("a raw newline survived into the listing: %q", out)
+	}
+	if strings.Contains(out, "[x](") {
+		t.Errorf("a title Markdown link was not defanged: %q", out)
+	}
+	if !strings.Contains(out, `\[x\]`) {
+		t.Errorf("expected the title's link brackets escaped: %q", out)
+	}
+
+	// Angle brackets (autolink / raw HTML) and backticks (code span) are defanged too.
+	var b2 strings.Builder
+	writePRLine(&b2, api.PRStatus{
+		PR:     api.PR{Number: 8, Title: "<https://evil.example> and `code` <script>x</script>", Open: true},
+		Status: api.JobReady,
+	})
+	inj := b2.String()
+	for _, esc := range []string{`\<`, `\>`, "\\`"} {
+		if !strings.Contains(inj, esc) {
+			t.Errorf("expected %q escaped in the listing: %q", esc, inj)
+		}
+	}
+	// No intact autolink / HTML tag / code span survives (the escapes break each).
+	for _, raw := range []string{"<https://evil.example>", "<script>", "</script>", "`code`"} {
+		if strings.Contains(inj, raw) {
+			t.Errorf("intact %q survived into the listing: %q", raw, inj)
+		}
+	}
+
+	// A normal conventional-commit title is left untouched (parens not escaped).
+	var b3 strings.Builder
+	writePRLine(&b3, api.PRStatus{PR: api.PR{Number: 9, Title: "feat(scope): add the_thing", Open: true}, Status: api.JobReady})
+	if !strings.Contains(b3.String(), "feat(scope): add the_thing") {
+		t.Errorf("a normal title must not be mangled: %q", b3.String())
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1565,13 +1565,13 @@ func TestRefreshChecks_DisabledWhenAnonymous(t *testing.T) {
 	prs := []api.PR{{Number: 1, HeadSHA: "a"}, {Number: 2, HeadSHA: "b"}}
 
 	anon := &fakeProvider{prs: prs}
-	newTestServer(t, ghCfg(""), anon, okEngine()).refreshList(context.Background())
+	newTestServer(t, ghCfg(""), anon, okEngine()).refreshList(t.Context())
 	if _, checks := anon.callCounts(); checks != 0 {
 		t.Errorf("anonymous: Checks calls = %d, want 0 (CI-status polling must be off)", checks)
 	}
 
 	authed := &fakeProvider{prs: prs}
-	newTestServer(t, ghCfg("tok"), authed, okEngine()).refreshList(context.Background())
+	newTestServer(t, ghCfg("tok"), authed, okEngine()).refreshList(t.Context())
 	if _, checks := authed.callCounts(); checks != len(prs) {
 		t.Errorf("authenticated: Checks calls = %d, want %d (CI status polled per PR)", checks, len(prs))
 	}

--- a/internal/server/store.go
+++ b/internal/server/store.go
@@ -133,22 +133,27 @@ func (j *job) record() persist.Record {
 // PR that produce the same diff (the common staleness-backstop case) hash equal,
 // so the store can skip rewriting the file; a real change (diff moved, merged,
 // metadata edited) hashes differently and is persisted.
-func contentDigest(rec persist.Record) uint64 {
+// resultJSON is rec.Result already serialized (nil when there is none); the whole
+// record is never re-marshaled, so the multi-MB result is walked once by the caller
+// and folded in here as raw bytes.
+func contentDigest(rec persist.Record, resultJSON []byte) uint64 {
 	rec.Updated, rec.RenderedAt = time.Time{}, time.Time{}
-	b, _ := json.Marshal(rec) // Record is always marshalable
+	rec.Result = nil // hashed via resultJSON below rather than re-marshaled
 	h := fnv.New64a()
+	b, _ := json.Marshal(rec) // metadata only now — small
 	_, _ = h.Write(b)
+	_, _ = h.Write(resultJSON)
 	return h.Sum64()
 }
 
 // save / del run the persistence I/O. Callers snapshot under s.mu, release it,
 // then call these — the file write/remove never holds the store lock. No-ops
 // when durability is disabled.
-func (s *store) save(rec persist.Record) error {
+func (s *store) save(rec persist.Record, resultJSON json.RawMessage) error {
 	if s.persist == nil {
 		return nil
 	}
-	if err := s.persist.Save(rec); err != nil {
+	if err := s.persist.SaveEncoded(rec, resultJSON); err != nil {
 		if s.log != nil {
 			s.log.Warn("persist render", "pr", rec.PR.Number, "error", err)
 		}
@@ -321,7 +326,14 @@ func (s *store) setResult(number int, result api.DiffResult) *api.Signals {
 // job's savedDigest with a hash whose file it then orphans.
 func (s *store) persistRecord(j *job, rec persist.Record, prev uint64) {
 	number := rec.PR.Number
-	d := contentDigest(rec)
+	// Serialize the (multi-MB) result once here, off the lock, and reuse it for both
+	// the content digest and the save — the two used to marshal the whole record
+	// independently.
+	var resultJSON json.RawMessage
+	if rec.Result != nil {
+		resultJSON, _ = json.Marshal(rec.Result) // DiffResult is plain data — always marshalable
+	}
+	d := contentDigest(rec, resultJSON)
 	// Record the in-memory content hash for the ETag first, independent of whether
 	// the save below succeeds — so a changed diff always revalidates (a fresh ETag)
 	// even while persistence is failing on a full/read-only volume.
@@ -334,7 +346,7 @@ func (s *store) persistRecord(j *job, rec persist.Record, prev uint64) {
 	if d == prev {
 		return // unchanged: nothing to write, and savedDigest is already current
 	}
-	if err := s.save(rec); err != nil {
+	if err := s.save(rec, resultJSON); err != nil {
 		return // leave savedDigest as-is so the next render retries the write
 	}
 	s.mu.Lock()

--- a/internal/server/writeback_test.go
+++ b/internal/server/writeback_test.go
@@ -36,7 +36,7 @@ func TestVerifyWriteBack(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			s := &Server{cfg: &config.Config{}, log: discardLog(), writer: stubWriter{verifyErr: tc.verifyErr}}
-			s.verifyWriteBack(context.Background())
+			s.verifyWriteBack(t.Context())
 			if (s.writer == nil) != tc.wantDisabled {
 				t.Errorf("write-back disabled = %v, want %v", s.writer == nil, tc.wantDisabled)
 			}
@@ -144,7 +144,7 @@ func TestRetryWrite(t *testing.T) {
 	t.Run("succeeds on the first try", func(t *testing.T) {
 		t.Parallel()
 		calls := 0
-		err := retryWrite(context.Background(), 3, time.Millisecond, func() error { calls++; return nil })
+		err := retryWrite(t.Context(), 3, time.Millisecond, func() error { calls++; return nil })
 		if err != nil || calls != 1 {
 			t.Fatalf("calls=%d err=%v; want 1 call, no error", calls, err)
 		}
@@ -153,7 +153,7 @@ func TestRetryWrite(t *testing.T) {
 	t.Run("retries a transient failure then succeeds", func(t *testing.T) {
 		t.Parallel()
 		calls := 0
-		err := retryWrite(context.Background(), 3, time.Millisecond, func() error {
+		err := retryWrite(t.Context(), 3, time.Millisecond, func() error {
 			calls++
 			if calls < 3 {
 				return errors.New("forge unavailable")
@@ -169,7 +169,7 @@ func TestRetryWrite(t *testing.T) {
 		t.Parallel()
 		want := errors.New("solar flare")
 		calls := 0
-		err := retryWrite(context.Background(), 3, time.Millisecond, func() error { calls++; return want })
+		err := retryWrite(t.Context(), 3, time.Millisecond, func() error { calls++; return want })
 		if calls != 3 || !errors.Is(err, want) {
 			t.Fatalf("calls=%d err=%v; want 3 calls and the last error %v", calls, err, want)
 		}


### PR DESCRIPTION
## What

The deferred cleanups from the project-review backlog — everything except response gzip (left out: konflate sits behind an ingress that compresses, so app-level gzip would be largely redundant for a non-trivial HTTP-layer change).

| # | Change | Why |
|---|--------|-----|
| 1 | **persist: serialize the record once per save** | A changed record was marshaled **twice**: `contentDigest` walked the whole record (multi-MB of rendered HTML) to hash it, then `persist.Save` walked it again to write it. The store now serializes the `Result` **once** (off-lock) and reuses those bytes — the digest hashes metadata + the raw `Result` bytes, and `persist.SaveEncoded` writes a wire struct whose `Result` is a `json.RawMessage` (copied verbatim, never re-walked). |
| 2 | **MCP list-title defang** | `list_pull_requests` interpolated the raw PR title into its one-line-per-PR text. It now uses `mdListText` (flatten control chars + escape `` [ ] ` < > ``), so a crafted title can't inject a link, image, code span, angle-bracket autolink, or raw HTML tag into a Markdown-rendering client — while a normal `feat(scope): …` title stays clean (unlike `mdInline`, parens/underscores/`*` aren't escaped). A bare autolinked URL is deliberately left (its destination is visible — not the spoof a hidden-destination link is; same stance as the trusted-comment `mdInline` path, and mangling real URLs is worse). |
| 3 | **`t.Context()` in tests** | 66 `context.Background()` → `t.Context()` (Go 1.24+, auto-cancelled at test end) for a test's own one-shot context. 17 left deliberately: `WithCancel`/`WithTimeout` bases and contexts handed to goroutines / stored as a server/queue `runCtx` (a lifecycle `t.Context()` cancel would race). Applied per package, each `-race`-verified. |

## Safety
- The persist change is **byte-identical on disk** — `TestSaveEncodedMatchesFullMarshal` decompresses a saved file and asserts it equals a full `Record` marshal — and preserves the timestamp-excluding content digest, so a same-diff staleness re-render still skips the rewrite.
- `mdListText` only escapes brackets; `TestWritePRLine_DefangsTitle` covers the flatten + link-defang, and `TestMCP_Tools` confirms an ordinary `chore(gatus): …` title is unmangled.
- The `t.Context()` sweep is behavior-preserving; each package was `-race`-verified.

Verified: `go test -race ./...`, `vet`, `lint` (0), `fmt-check`, `tidy-check`. No UI or chart changes.

This clears the review's deferred list (gzip excluded by request).
