### PR TITLE
fix(provider): match GitHub comments by user id so an App rename doesn't orphan them

### DIFF
--- a/internal/provider/writer.go
+++ b/internal/provider/writer.go
@@ -137,27 +137,29 @@ func strOrNil(s string) *string {
 	return &s
 }
 
-// resolvedString memoizes the first successful result of resolve. A failed
+// resolved memoizes the first successful result of resolve. A failed
 // attempt is not cached, so a transient error (e.g. a forge blip while learning
 // konflate's own identity) is retried on the next call rather than wedging the
 // feature — the same lazy, cache-on-success pattern as repoInstallTransport.
-type resolvedString struct {
+type resolved[T any] struct {
 	mu      sync.Mutex
-	val     string
-	resolve func(ctx context.Context) (string, error)
+	val     T
+	ok      bool
+	resolve func(ctx context.Context) (T, error)
 }
 
-func (r *resolvedString) get(ctx context.Context) (string, error) {
+func (r *resolved[T]) get(ctx context.Context) (T, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if r.val != "" {
+	if r.ok {
 		return r.val, nil
 	}
 	v, err := r.resolve(ctx)
 	if err != nil {
-		return "", err
+		var zero T
+		return zero, err
 	}
-	r.val = v
+	r.val, r.ok = v, true
 	return v, nil
 }
 
@@ -166,8 +168,8 @@ func (r *resolvedString) get(ctx context.Context) (string, error) {
 type githubWriter struct {
 	client      *github.Client
 	owner, repo string
-	app         bool            // App-authed ⇒ can post Check Runs (a PAT can't)
-	self        *resolvedString // login of konflate's own comment author; resolved once
+	app         bool             // App-authed ⇒ can post Check Runs (a PAT can't)
+	self        *resolved[int64] // user id of konflate's own comment author; resolved once
 }
 
 func newGitHubWriter(cfg *config.Config) (*githubWriter, error) {
@@ -176,7 +178,7 @@ func newGitHubWriter(cfg *config.Config) (*githubWriter, error) {
 		return nil, err
 	}
 	owner, repo := ownerRepo(cfg.Forge.RepoPath)
-	return &githubWriter{client: client, owner: owner, repo: repo, app: cfg.AppConfigured(), self: &resolvedString{resolve: self}}, nil
+	return &githubWriter{client: client, owner: owner, repo: repo, app: cfg.AppConfigured(), self: &resolved[int64]{resolve: self}}, nil
 }
 
 // newGitHubWriteClient builds the authenticated write client. A fully-configured
@@ -184,7 +186,7 @@ func newGitHubWriter(cfg *config.Config) (*githubWriter, error) {
 // short-lived installation tokens rather than carrying a standing PAT — and a
 // write PAT is the fallback (and the only option on Forgejo/GitLab). A partial
 // App config is an explicit error so it can't silently mask a typo'd key.
-func newGitHubWriteClient(cfg *config.Config) (*github.Client, func(context.Context) (string, error), error) {
+func newGitHubWriteClient(cfg *config.Config) (*github.Client, func(context.Context) (int64, error), error) {
 	switch {
 	case cfg.AppConfigured():
 		return newGitHubAppClient(cfg)
@@ -195,13 +197,14 @@ func newGitHubWriteClient(cfg *config.Config) (*github.Client, func(context.Cont
 		if err != nil {
 			return nil, nil, fmt.Errorf("github: new write client: %w", err)
 		}
-		// The write PAT's own user is konflate's comment-author identity.
-		self := func(ctx context.Context) (string, error) {
+		// The write PAT's own user is konflate's comment-author identity — kept as the
+		// numeric user id, which unlike the login survives an account rename.
+		self := func(ctx context.Context) (int64, error) {
 			u, _, err := client.Users.Get(ctx, "")
 			if err != nil {
-				return "", fmt.Errorf("github: resolve write-token user: %w", err)
+				return 0, fmt.Errorf("github: resolve write-token user: %w", err)
 			}
-			return u.GetLogin(), nil
+			return u.GetID(), nil
 		}
 		return client, self, nil
 	case cfg.AppClientID != "" || cfg.AppPrivateKey != "":
@@ -214,7 +217,7 @@ func newGitHubWriteClient(cfg *config.Config) (*github.Client, func(context.Cont
 // newGitHubAppClient authenticates write-back as a GitHub App installation: it
 // builds the installation-token client (see newGitHubAppInstallClient) and
 // resolves konflate's comment-author identity from the App itself.
-func newGitHubAppClient(cfg *config.Config) (*github.Client, func(context.Context) (string, error), error) {
+func newGitHubAppClient(cfg *config.Config) (*github.Client, func(context.Context) (int64, error), error) {
 	client, apps, err := newGitHubAppInstallClient(cfg)
 	if err != nil {
 		return nil, nil, err
@@ -222,13 +225,20 @@ func newGitHubAppClient(cfg *config.Config) (*github.Client, func(context.Contex
 	// konflate's comments are authored by the App's bot user, "<app-slug>[bot]";
 	// resolve the slug from the App itself (App-JWT auth) so comment write-back only
 	// ever edits konflate's own comment, never one a PR author planted with the
-	// (public) marker.
-	self := func(ctx context.Context) (string, error) {
+	// (public) marker. The identity kept is the bot user's numeric id, not its
+	// login: renaming the App changes the slug (and with it the author login on
+	// every existing comment), which would orphan konflate's comment until a
+	// restart, while the id is stable across renames.
+	self := func(ctx context.Context) (int64, error) {
 		app, _, err := apps.Apps.Get(ctx, "")
 		if err != nil {
-			return "", fmt.Errorf("github: resolve App identity: %w", err)
+			return 0, fmt.Errorf("github: resolve App identity: %w", err)
 		}
-		return app.GetSlug() + "[bot]", nil
+		u, _, err := client.Users.Get(ctx, app.GetSlug()+"[bot]")
+		if err != nil {
+			return 0, fmt.Errorf("github: resolve App bot user: %w", err)
+		}
+		return u.GetID(), nil
 	}
 	return client, self, nil
 }
@@ -491,13 +501,14 @@ func (w *githubWriter) UpsertComment(ctx context.Context, pr api.PR, marker, bod
 	// Find konflate's own comment (the one it authored carrying the hidden marker)
 	// and edit it in place; otherwise post a new one. The marker alone isn't enough:
 	// it's public (the summary API emits it too), so a PR author could plant it to
-	// make konflate adopt their comment — match the author as well. ListCommentsIter
-	// paginates transparently.
+	// make konflate adopt their comment — match the author as well, by numeric user
+	// id (the login changes when the App or user is renamed; the id doesn't).
+	// ListCommentsIter paginates transparently.
 	for c, err := range w.client.Issues.ListCommentsIter(ctx, w.owner, w.repo, pr.Number, nil) {
 		if err != nil {
 			return fmt.Errorf("github: list comments #%d: %w", pr.Number, err)
 		}
-		if c.GetUser().GetLogin() == self && c.Body != nil && strings.Contains(*c.Body, marker) {
+		if c.GetUser().GetID() == self && c.Body != nil && strings.Contains(*c.Body, marker) {
 			if strings.TrimSpace(*c.Body) == strings.TrimSpace(body) {
 				return nil // unchanged — skip the no-op edit so a re-render doesn't mark it "edited"
 			}
@@ -583,7 +594,7 @@ func clamp(s string, max int, marker string) string {
 type forgejoWriter struct {
 	client      *forgejo.Client
 	owner, repo string
-	self        *resolvedString // username of konflate's own comment author; resolved once
+	self        *resolved[string] // username of konflate's own comment author; resolved once
 }
 
 func newForgejoWriter(cfg *config.Config) (*forgejoWriter, error) {
@@ -603,7 +614,7 @@ func newForgejoWriter(cfg *config.Config) (*forgejoWriter, error) {
 		}
 		return u.UserName, nil
 	}
-	return &forgejoWriter{client: client, owner: owner, repo: repo, self: &resolvedString{resolve: self}}, nil
+	return &forgejoWriter{client: client, owner: owner, repo: repo, self: &resolved[string]{resolve: self}}, nil
 }
 
 func (w *forgejoWriter) SetStatus(_ context.Context, pr api.PR, st Status) error {
@@ -674,7 +685,7 @@ func (w *forgejoWriter) Verify(_ context.Context) error {
 type gitlabWriter struct {
 	client  *gitlab.Client
 	project string
-	self    *resolvedString // username of konflate's own note author; resolved once
+	self    *resolved[string] // username of konflate's own note author; resolved once
 }
 
 func newGitLabWriter(cfg *config.Config) (*gitlabWriter, error) {
@@ -692,7 +703,7 @@ func newGitLabWriter(cfg *config.Config) (*gitlabWriter, error) {
 		}
 		return u.Username, nil
 	}
-	return &gitlabWriter{client: client, project: cfg.Forge.RepoPath, self: &resolvedString{resolve: self}}, nil
+	return &gitlabWriter{client: client, project: cfg.Forge.RepoPath, self: &resolved[string]{resolve: self}}, nil
 }
 
 func (w *gitlabWriter) SetStatus(ctx context.Context, pr api.PR, st Status) error {

--- a/internal/provider/writer_test.go
+++ b/internal/provider/writer_test.go
@@ -442,30 +442,40 @@ func commentCapture(listJSON string, sink *commentSink) http.HandlerFunc {
 
 const upsertMarker = "<!-- konflate:pr-7 -->"
 
-// selfLogin is the login the test writers resolve as konflate's own identity (via
-// konflateSelf); the marked comment in markerList is authored by it.
+// selfLogin is the username the Forgejo/GitLab test writers resolve as konflate's
+// own identity (via konflateSelf); the marked comment in markerList is authored by
+// it. selfID is the GitHub equivalent — the GitHub writer matches by the numeric
+// user id, which unlike the login survives an App/user rename.
 const selfLogin = "konflate[bot]"
 
-// konflateSelf is a resolvedString reporting konflate's own identity (selfLogin)
-// with no network call — the test stand-in for the per-forge "who am I" lookup.
-func konflateSelf() *resolvedString {
-	return &resolvedString{resolve: func(context.Context) (string, error) { return selfLogin, nil }}
+const selfID int64 = 8871
+
+// konflateSelf reports konflate's own username (selfLogin) with no network call —
+// the test stand-in for the Forgejo/GitLab "who am I" lookup.
+func konflateSelf() *resolved[string] {
+	return &resolved[string]{resolve: func(context.Context) (string, error) { return selfLogin, nil }}
+}
+
+// konflateSelfID is konflateSelf for the GitHub writer, which resolves the numeric
+// user id (selfID) instead of the login.
+func konflateSelfID() *resolved[int64] {
+	return &resolved[int64]{resolve: func(context.Context) (int64, error) { return selfID, nil }}
 }
 
 // markerList is a one-comment listing (id 99) whose body carries the marker and is
-// authored by konflate itself. It carries both a GitHub/Forgejo-style `user.login`
-// and a GitLab-style `author.username` so the one fixture serves all three forges
-// (each SDK reads its own field).
+// authored by konflate itself. It carries a GitHub-style `user.login`+`user.id`, a
+// Forgejo-style `user.login`, and a GitLab-style `author.username` so the one
+// fixture serves all three forges (each SDK reads its own fields).
 func markerList() string {
-	return fmt.Sprintf(`[{"id":99,"body":%q,"user":{"login":%q},"author":{"username":%q}}]`,
-		upsertMarker+"\nold", selfLogin, selfLogin)
+	return fmt.Sprintf(`[{"id":99,"body":%q,"user":{"login":%q,"id":%d},"author":{"username":%q}}]`,
+		upsertMarker+"\nold", selfLogin, selfID, selfLogin)
 }
 
 // foreignMarkerList is the marker planted by a DIFFERENT author — the comment-
 // hijack attempt. konflate must NOT edit it (it isn't konflate's) and must post
 // its own comment instead.
 func foreignMarkerList() string {
-	return fmt.Sprintf(`[{"id":99,"body":%q,"user":{"login":"attacker"},"author":{"username":"attacker"}}]`,
+	return fmt.Sprintf(`[{"id":99,"body":%q,"user":{"login":"attacker","id":666},"author":{"username":"attacker"}}]`,
 		upsertMarker+"\nplanted")
 }
 
@@ -503,7 +513,7 @@ func TestGitHubWriter_UpsertComment(t *testing.T) {
 		var sink commentSink
 		srv := httptest.NewServer(commentCapture(`[]`, &sink))
 		t.Cleanup(srv.Close)
-		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
+		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelfID()}
 		if err := wr.UpsertComment(t.Context(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nhi"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
@@ -514,7 +524,23 @@ func TestGitHubWriter_UpsertComment(t *testing.T) {
 		var sink commentSink
 		srv := httptest.NewServer(commentCapture(markerList(), &sink))
 		t.Cleanup(srv.Close)
-		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
+		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelfID()}
+		if err := wr.UpsertComment(t.Context(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nnew"); err != nil {
+			t.Fatalf("UpsertComment: %v", err)
+		}
+		assertEdited(t, sink)
+	})
+	t.Run("still edits its own after an App rename", func(t *testing.T) {
+		t.Parallel()
+		// Renaming the App changes the bot login on every existing comment
+		// ("konflate[bot]" → "renamed[bot]") but not the user id — matching by id,
+		// konflate must keep editing its comment instead of stacking duplicates.
+		renamed := fmt.Sprintf(`[{"id":99,"body":%q,"user":{"login":"renamed[bot]","id":%d}}]`,
+			upsertMarker+"\nold", selfID)
+		var sink commentSink
+		srv := httptest.NewServer(commentCapture(renamed, &sink))
+		t.Cleanup(srv.Close)
+		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelfID()}
 		if err := wr.UpsertComment(t.Context(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nnew"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
@@ -525,7 +551,7 @@ func TestGitHubWriter_UpsertComment(t *testing.T) {
 		var sink commentSink
 		srv := httptest.NewServer(commentCapture(foreignMarkerList(), &sink))
 		t.Cleanup(srv.Close)
-		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
+		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelfID()}
 		if err := wr.UpsertComment(t.Context(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nhi"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
 		}
@@ -536,7 +562,7 @@ func TestGitHubWriter_UpsertComment(t *testing.T) {
 		var sink commentSink
 		srv := httptest.NewServer(commentCapture(markerList(), &sink))
 		t.Cleanup(srv.Close)
-		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
+		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelfID()}
 		// Same body as the listed comment — konflate must skip the no-op edit.
 		if err := wr.UpsertComment(t.Context(), api.PR{Number: 7}, upsertMarker, upsertMarker+"\nold"); err != nil {
 			t.Fatalf("UpsertComment: %v", err)
@@ -548,7 +574,7 @@ func TestGitHubWriter_UpsertComment(t *testing.T) {
 		var sink commentSink
 		srv := httptest.NewServer(commentCapture(`[]`, &sink))
 		t.Cleanup(srv.Close)
-		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelf()}
+		wr := &githubWriter{client: newGitHubTestClient(t, srv.URL), owner: "acme", repo: "web", self: konflateSelfID()}
 		huge := upsertMarker + "\n" + strings.Repeat("x", githubBodyMax+5000)
 		if err := wr.UpsertComment(t.Context(), api.PR{Number: 7}, upsertMarker, huge); err != nil {
 			t.Fatalf("UpsertComment: %v", err)


### PR DESCRIPTION
Fixes #339

### Problem

The GitHub writer resolved konflate's comment-author identity once as the login string `<app-slug>[bot]` and memoized it for the process lifetime. Renaming the GitHub App changes the slug, and GitHub retroactively updates the author login on all existing comments - so the cached login never matched again and every re-render posted a duplicate comment instead of editing the existing one, until the process restarted.

### Fix

Match comments by the bot user's numeric id, which is stable across renames, instead of the login:

- **App path**: still resolves the slug fresh from `GET /app` (App-JWT auth, so the marker-planting protection is unchanged), then looks up `GET /users/<slug>[bot]` via the installation client and caches the numeric user id. The slug is fetched live at first use and only the id is cached, so a rename before or after resolution both work.
- **PAT path**: caches the write token user's id instead of its login, so a user account rename can't orphan the comment either.
- `UpsertComment` compares author ids rather than logins.
- The memoizing `resolvedString` helper became a generic `resolved[T]` so the GitHub writer holds an `int64` while the Forgejo/GitLab writers keep their string usernames; those forges are behaviorally untouched.

### Testing

- Added a regression subtest ("still edits its own after an App rename") where the listed comment's login differs from the resolved identity but the id matches - it must edit, not duplicate.
- Updated the shared comment fixtures to carry user ids; the foreign-marker (comment hijack) tests still pass with a mismatched id.
- `go test ./...`, `go vet`, `gofmt` all clean.