### PR TITLE
fix(server): stop escaping parens in mdInline

### DIFF
--- a/internal/server/markdown.go
+++ b/internal/server/markdown.go
@@ -329,14 +329,17 @@ func mdInline(s string) string {
 
 // mdInlineReplacer runs a single non-overlapping pass (so its own output is never
 // re-escaped): HTML entities for <, >, &; a \| for the table pipe; and a
-// backslash before every Markdown inline metacharacter — the link/image brackets
-// and parens, the code-span backtick, the emphasis/strikethrough runs, the image
-// bang, and the backslash itself (escaped first so it can't consume a following
-// escape). Bare autolinked URLs are left alone: their destination is visible, so
-// they aren't a spoofing vector the way [text](hidden-url) is.
+// backslash before every Markdown inline metacharacter — the link/image brackets,
+// the code-span backtick, the emphasis/strikethrough runs, the image bang, and
+// the backslash itself (escaped first so it can't consume a following escape).
+// Parens are deliberately NOT escaped: with the brackets and bang neutralised a
+// bare (...) can't form a link or image, and Forgejo treats \(...\) as an inline
+// KaTeX math delimiter, so escaping them mangles plain prose there (#349). Bare
+// autolinked URLs are left alone: their destination is visible, so they aren't a
+// spoofing vector the way [text](hidden-url) is.
 var mdInlineReplacer = strings.NewReplacer(
 	"&", "&amp;", "<", "&lt;", ">", "&gt;", "|", `\|`,
-	`\`, `\\`, "`", "\\`", "[", `\[`, "]", `\]`, "(", `\(`, ")", `\)`,
+	`\`, `\\`, "`", "\\`", "[", `\[`, "]", `\]`,
 	"*", `\*`, "_", `\_`, "~", `\~`, "!", `\!`,
 )
 

--- a/internal/server/markdown_test.go
+++ b/internal/server/markdown_test.go
@@ -194,9 +194,14 @@ func TestMdInline_DefangsMarkdown(t *testing.T) {
 	// Backslash-escaped punctuation renders as the literal character in GFM, so a
 	// link/image/code/emphasis attempt is inert while the text reads unchanged.
 	got := mdInline("a [l](u) ![i](u) `c` *b* _e_ ~s~ | <x>")
-	want := "a \\[l\\]\\(u\\) \\!\\[i\\]\\(u\\) \\`c\\` \\*b\\* \\_e\\_ \\~s\\~ \\| &lt;x&gt;"
+	want := "a \\[l\\](u) \\!\\[i\\](u) \\`c\\` \\*b\\* \\_e\\_ \\~s\\~ \\| &lt;x&gt;"
 	if got != want {
 		t.Errorf("mdInline mismatch:\n got %q\nwant %q", got, want)
+	}
+	// Parens must pass through untouched: \(...\) is Forgejo's inline-math
+	// delimiter, so escaping them turns prose into KaTeX there (#349).
+	if got := mdInline("recreated (or Flux force is enabled)"); got != "recreated (or Flux force is enabled)" {
+		t.Errorf("parens must not be escaped, got %q", got)
 	}
 	// A lone backslash is escaped first, so it can't consume a following escape.
 	if got := mdInline(`\`); got != `\\` {


### PR DESCRIPTION
Forgejo treats `\(...\)` as an inline KaTeX math delimiter, so the escaped parens produced by `mdInlineReplacer` made the immutable-resource caution detail (`(or Flux force is enabled)`) render as math instead of text. GitHub has no `\(...\)` syntax and just drops the backslash, which is why it looked fine there.

The paren escapes (added in #314) are unnecessary for the injection defense: with `[`, `]`, and `!` already escaped, a bare `(...)` cannot form a Markdown link or image. This drops `(` and `)` from the replacer and adds a regression test asserting parens pass through untouched.

Fixes #349