### PR TITLE
style: indent markdown at 2 to match embedded yaml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.md]
-indent_size = 4
+indent_size = 2
 trim_trailing_whitespace = false
 
 [Dockerfile]

--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ front.
    Kustomization really deletes the resource in-cluster, a non-pruning one
    orphans it, silently left running.
 
-    The **image changes** signal lists the `container` and `initContainer` image
-    references that changed across _every rendered workload_ — so it captures
-    whatever the charts and kustomizations actually deploy: app images, sidecars,
-    and controller images pulled in by OCI Helm charts alike, each keyed to the
-    workloads that reference it. (A chart's own OCI **artifact** version bump
-    shows up as a changed `HelmRelease`/`OCIRepository` resource in the diff; its
-    effect on the running images surfaces here.)
+   The **image changes** signal lists the `container` and `initContainer` image
+   references that changed across _every rendered workload_ — so it captures
+   whatever the charts and kustomizations actually deploy: app images, sidecars,
+   and controller images pulled in by OCI Helm charts alike, each keyed to the
+   workloads that reference it. (A chart's own OCI **artifact** version bump
+   shows up as a changed `HelmRelease`/`OCIRepository` resource in the diff; its
+   effect on the running images surfaces here.)
 
 5. The three-panel web UI renders it — PRs on the left, changed resources in the
    middle, the diff on the right — and updates live over a websocket as renders
@@ -299,7 +299,7 @@ at a ConfigMap (or Secret) whose entries are PEM CA certificates:
 
 ```yaml
 tls:
-    extraCaCertsConfigMap: internal-ca
+  extraCaCertsConfigMap: internal-ca
 ```
 
 The chart mounts it at `/etc/ssl/konflate` and sets
@@ -448,11 +448,11 @@ With the Helm chart, put the template **content** in `config.prCommentTemplate` 
 
 ```yaml
 config:
-    prComments: true
-    # Passed to konflate verbatim — write plain Go-template braces, no escaping.
-    prCommentTemplate: |
-        ## konflate · #{{ .PR.Number }} — {{ .PR.Title }}
-        {{ .Summary }}
+  prComments: true
+  # Passed to konflate verbatim — write plain Go-template braces, no escaping.
+  prCommentTemplate: |
+    ## konflate · #{{ .PR.Number }} — {{ .PR.Title }}
+    {{ .Summary }}
 ```
 
 ## HTTP endpoints
@@ -642,10 +642,10 @@ Tests come in four tiers:
 - **Integration** (`-tags integration`, env-gated) — renders a real PR with the
   real engine; skips unless `KONFLATE_REPO` + `KONFLATE_INTEGRATION_PR` are set:
 
-    ```bash
-    KONFLATE_REPO=github://owner/repo KONFLATE_INTEGRATION_PR=123 \
-      mise run test-integration
-    ```
+  ```bash
+  KONFLATE_REPO=github://owner/repo KONFLATE_INTEGRATION_PR=123 \
+    mise run test-integration
+  ```
 
 ## Security
 


### PR DESCRIPTION
Mirrors the canonical change in home-operations/.github#37.

`oxfmt` applies a markdown file's `tabWidth` to embedded code blocks. With `[*.md] indent_size = 4`, yaml examples inside the docs get rewritten to 4-space indentation while the yaml files they document stay at 2 under `[*] indent_size = 2`. Anyone copying from the README gets the wrong style. This sets `[*.md] indent_size = 2`.

The reformat is cosmetic: verified across the org that rendered markdown structure is unchanged (no new indented-code-blocks, identical list nesting) and that embedded yaml parses to identical values, block scalars included. Reindented here with the repo's pinned oxfmt.