### PR TITLE
feat(config): expose kube version for chart capabilities

### DIFF
--- a/charts/konflate/README.md
+++ b/charts/konflate/README.md
@@ -56,6 +56,7 @@ Kubernetes: `>=1.25.0-0`
 | config.helmRenderCacheMb | string | `""` | Advanced: persistent on-disk Helm render cache in MiB, reused across renders/PRs/restarts. Empty = default (1024); "0" disables. |
 | config.helmTemplateCacheMb | string | `""` | Advanced: in-memory Helm template cache in MiB (the biggest CPU saver). Empty = auto (256 ÷ render concurrency, so it doesn't scale with the CPU limit); "0" disables. |
 | config.imageVerifyTimeout | string | `""` | Timeout for a single registry existence check (see `verifyImages`). Empty = default (5s). |
+| config.kubeVersion | string | `""` | Kubernetes version charts see as `.Capabilities.KubeVersion`. Empty = the version bundled with the helm SDK konflate was built against, which may be newer than your cluster — a chart gated on the cluster version then renders differently here than in-cluster. Set `"{{ .Capabilities.KubeVersion.Version }}"` to track the cluster this release installs into, or pin a literal (e.g. `"1.33.4"`). |
 | config.logFormat | string | `"json"` | Log format: json or text. |
 | config.logLevel | string | `"info"` | Log level: debug, info, warn, or error. |
 | config.maxDiffConcurrency | int | `0` | Max concurrent diff renders; 0 = auto (from the CPU limit, capped at 4). |

--- a/charts/konflate/templates/deployment.tpl
+++ b/charts/konflate/templates/deployment.tpl
@@ -120,6 +120,13 @@ spec:
             - name: KONFLATE_MAX_DIFF_RESOURCES
               value: {{ tpl (toString .Values.config.maxDiffResources) $ | quote }}
             {{- end }}
+            {{- /* tpl resolves against the release, so
+                   "{{ .Capabilities.KubeVersion.Version }}" tracks the cluster
+                   this release installs into. */}}
+            {{- with .Values.config.kubeVersion }}
+            - name: KONFLATE_KUBE_VERSION
+              value: {{ tpl . $ | quote }}
+            {{- end }}
             {{- /* toString, not `with`: an explicit 0 (disable a cache) must
                    still emit — `with` would treat int 0 as empty and drop it,
                    silently reviving the default. Empty string = use the default.

--- a/charts/konflate/tests/deployment_test.yaml
+++ b/charts/konflate/tests/deployment_test.yaml
@@ -246,6 +246,37 @@ tests:
             name: KONFLATE_MAX_DIFF_RESOURCES
             value: "0"
 
+  - it: omits KONFLATE_KUBE_VERSION when kubeVersion is empty (helm's bundled version)
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: KONFLATE_KUBE_VERSION
+
+  - it: emits a literal KONFLATE_KUBE_VERSION when kubeVersion is set
+    set:
+      config.kubeVersion: "1.33.4"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KONFLATE_KUBE_VERSION
+            value: "1.33.4"
+
+  - it: resolves a templated kubeVersion against the release's capabilities
+    capabilities:
+      majorVersion: 1
+      minorVersion: 33
+    set:
+      config.kubeVersion: "{{ .Capabilities.KubeVersion.Version }}"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KONFLATE_KUBE_VERSION
+            value: "v1.33.0"
+
   - it: emits KONFLATE_CACHE_TTL when cacheTtl is set
     set:
       config.cacheTtl: 24h

--- a/charts/konflate/values.schema.json
+++ b/charts/konflate/values.schema.json
@@ -78,6 +78,12 @@
           "title": "imageVerifyTimeout",
           "type": "string"
         },
+        "kubeVersion": {
+          "default": "",
+          "description": "Kubernetes version charts see as `.Capabilities.KubeVersion`. Empty = the version bundled with the helm SDK konflate was built against, which may be newer than your cluster — a chart gated on the cluster version then renders differently here than in-cluster. Set `\"{{ .Capabilities.KubeVersion.Version }}\"` to track the cluster this release installs into, or pin a literal (e.g. `\"1.33.4\"`).",
+          "title": "kubeVersion",
+          "type": "string"
+        },
         "logFormat": {
           "default": "json",
           "description": "Log format: json or text.",

--- a/charts/konflate/values.yaml
+++ b/charts/konflate/values.yaml
@@ -113,6 +113,8 @@ config:
   imageVerifyTimeout: ""
   # -- Cap on resources fully rendered per diff (each carries highlighted rows — the main payload cost); a larger PR is truncated and flagged in the UI, while the impact banner still shows the true total. Empty = default (500); "0" disables.
   maxDiffResources: ""
+  # -- Kubernetes version charts see as `.Capabilities.KubeVersion`. Empty = the version bundled with the helm SDK konflate was built against, which may be newer than your cluster — a chart gated on the cluster version then renders differently here than in-cluster. Set `"{{ .Capabilities.KubeVersion.Version }}"` to track the cluster this release installs into, or pin a literal (e.g. `"1.33.4"`).
+  kubeVersion: ""
   # --- flate render tuning (advanced) ---------------------------------------
   # Caps for flate's caches plus its fetch behavior. The defaults (shown) match
   # flate's own CLI and suit most setups — leave these empty to use them. The

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	gitlab.com/gitlab-org/api/client-go/v2 v2.51.0
 	golang.org/x/sync v0.22.0
+	helm.sh/helm/v4 v4.2.3
 	k8s.io/apimachinery v0.36.3
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -202,7 +203,6 @@ require (
 	gopkg.in/ini.v1 v1.67.2 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gotest.tools/v3 v3.5.2 // indirect
-	helm.sh/helm/v4 v4.2.3 // indirect
 	k8s.io/api v0.36.2 // indirect
 	k8s.io/apiextensions-apiserver v0.36.2 // indirect
 	k8s.io/apiserver v0.36.2 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/caarlos0/env/v11"
+	"helm.sh/helm/v4/pkg/chart/common"
 
 	"github.com/home-operations/konflate/internal/prfilter"
 )
@@ -265,6 +266,16 @@ type Config struct {
 	// These map onto flate's orchestrator config; the defaults mirror flate's
 	// own CLI so an embedder gets the same caching the `flate` binary does.
 
+	// KubeVersion overrides .Capabilities.KubeVersion for every Helm chart a
+	// render templates. Empty (the default) uses the version helm bundles — the
+	// Kubernetes release the vendored helm SDK was built against — which is not
+	// necessarily the version of the cluster the repo actually deploys to, so a
+	// chart gated on the cluster's version renders differently here than it does
+	// in-cluster. Set it to the target cluster's version to match. Accepts
+	// anything helm does, so the chart can pass .Capabilities.KubeVersion.Version
+	// ("v1.33.4", suffixes and all) straight through; validated at startup.
+	KubeVersion string `env:"KONFLATE_KUBE_VERSION"`
+
 	// HelmTemplateCacheMB caps flate's in-memory Helm template-output cache —
 	// repeat HelmReleases with identical inputs skip re-templating, the single
 	// largest CPU/allocation cost of a render. In MiB. 0 disables it; a negative
@@ -475,6 +486,15 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("config: KONFLATE_REPO: %w", err)
 	}
 	cfg.Forge = forge
+
+	// Parse the kube version here so a typo fails at startup. flate parses it
+	// per chart, where the error would instead surface as a render failure on
+	// every PR — the same misconfiguration, found much later.
+	if cfg.KubeVersion != "" {
+		if _, err := common.ParseKubeVersion(cfg.KubeVersion); err != nil {
+			return nil, fmt.Errorf("config: KONFLATE_KUBE_VERSION: %w", err)
+		}
+	}
 
 	if cfg.CacheDir == "" {
 		cfg.CacheDir = filepath.Join(xdgCacheHome(), "konflate")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -337,6 +337,38 @@ func TestLoad_HelmTemplateCacheMB(t *testing.T) {
 	}
 }
 
+func TestLoad_KubeVersion(t *testing.T) {
+	t.Setenv("KONFLATE_REPO", "github://owner/repo")
+
+	// Unset: empty, so flate leaves helm's bundled capabilities alone.
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.KubeVersion != "" {
+		t.Errorf("unset KubeVersion = %q, want empty", cfg.KubeVersion)
+	}
+
+	// Anything helm parses is accepted verbatim, including the "v" prefix and
+	// distro suffix a chart's .Capabilities.KubeVersion.Version carries.
+	for _, v := range []string{"1.33", "1.33.4", "v1.33.4", "v1.33.4-gke.1245000"} {
+		t.Setenv("KONFLATE_KUBE_VERSION", v)
+		cfg, err = Load()
+		if err != nil {
+			t.Fatalf("Load with KONFLATE_KUBE_VERSION=%q: %v", v, err)
+		}
+		if cfg.KubeVersion != v {
+			t.Errorf("KubeVersion = %q, want %q", cfg.KubeVersion, v)
+		}
+	}
+
+	// An unparseable version fails at startup rather than per render.
+	t.Setenv("KONFLATE_KUBE_VERSION", "not-a-version")
+	if _, err := Load(); err == nil {
+		t.Fatal("Load with a malformed KONFLATE_KUBE_VERSION should error")
+	}
+}
+
 func TestLoad_UnsetsSecrets(t *testing.T) {
 	// Secrets load into the Config, then are removed from the process
 	// environment (the `,unset` tag) so a later in-process env dump can't leak

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	flatediff "github.com/home-operations/flate/pkg/diff"
+	"github.com/home-operations/flate/pkg/helm"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/orchestrator"
 	"github.com/home-operations/flate/pkg/source"
@@ -70,6 +71,9 @@ type flateEngine struct {
 	sourceRetry            source.RetryConfig
 	diffTimeout            time.Duration
 	maxDiffResources       int
+	// kubeVersion overrides .Capabilities.KubeVersion for every chart rendered;
+	// empty leaves helm's bundled version (see config.KubeVersion).
+	kubeVersion string
 	// restrictEgress turns on flate's SSRF egress guard for source fetches (see
 	// config.EgressRestricted): on by default while rendering untrusted fork PRs.
 	restrictEgress bool
@@ -107,6 +111,7 @@ func New(cfg *config.Config, gitToken gitclone.TokenFunc) Engine {
 		},
 		diffTimeout:      cfg.DiffTimeout,
 		maxDiffResources: cfg.MaxDiffResources,
+		kubeVersion:      cfg.KubeVersion,
 		restrictEgress:   cfg.EgressRestricted(),
 	}
 }
@@ -231,6 +236,11 @@ func renderUsable(base, head orchestrator.Rendered, err error) bool {
 //     would clone its full history (disk/CPU exhaustion). Matches flate's own
 //     CLI default; commit-pinned refs still full-clone as flate requires.
 //
+// HelmOptions carries only the kube version (see config.KubeVersion); the
+// skip-* knobs stay off, since a reviewer needs every rendered resource. flate
+// keys both Helm template caches on the kube version, so changing it can't
+// serve a render templated at the old one.
+//
 // e.cache is the long-lived source cache reused across every PR; CacheDir
 // roots flate's persistent on-disk Helm caches on the same (operator-mounted)
 // volume so they survive restarts. (flate 0.3.4 renders kustomize stages in
@@ -243,6 +253,7 @@ func (e *flateEngine) renderCfg() orchestrator.Config {
 		WipeSecrets:            true,
 		AllowMissingSecrets:    true,
 		GitDepth:               1,
+		HelmOptions:            helm.Options{KubeVersion: e.kubeVersion},
 		HelmTemplateCacheBytes: e.helmTemplateCacheBytes,
 		HelmRenderCacheBytes:   e.helmRenderCacheBytes,
 		Concurrency:            e.concurrency,

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/home-operations/flate/pkg/store"
 
 	"github.com/home-operations/konflate/internal/api"
+	"github.com/home-operations/konflate/internal/config"
 	"github.com/home-operations/konflate/internal/diff"
 )
 
@@ -26,6 +27,23 @@ func res(kind, ns, name string, extra map[string]any) map[string]any {
 		m[k] = v
 	}
 	return m
+}
+
+// The kube version is the one HelmOption konflate sets, and it reaches flate
+// only through renderCfg — an empty config must leave it unset so helm's own
+// bundled capabilities apply.
+func TestRenderCfg_KubeVersion(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{Repo: "github://owner/repo"}
+	if got := New(cfg, nil).(*flateEngine).renderCfg().HelmOptions.KubeVersion; got != "" {
+		t.Errorf("unset KubeVersion = %q, want empty", got)
+	}
+
+	cfg.KubeVersion = "v1.33.4"
+	if got := New(cfg, nil).(*flateEngine).renderCfg().HelmOptions.KubeVersion; got != "v1.33.4" {
+		t.Errorf("KubeVersion = %q, want v1.33.4", got)
+	}
 }
 
 func TestRenderUsable(t *testing.T) {


### PR DESCRIPTION
Closes #368.

## Why

konflate never set `HelmOptions`, so every chart rendered against helm's default capabilities — the Kubernetes release the vendored helm SDK was built against (`k8s.io/client-go v0.36.2`, so **1.36**), not the cluster the repo actually deploys to. A chart gated on the cluster's version therefore renders differently under review than it does in-cluster, which is what #368 hit.

The issue proposed exposing `FLATE_KUBE_VERSION` via `extraEnv`. That can't work: konflate embeds flate as a library (`pkg/orchestrator`), and the `FLATE_*` env vars are a pflag binding in flate's cobra CLI, which konflate never runs — the variable would be silently inert. This takes the issue's alternative instead, a konflate-native var.

## What

`KONFLATE_KUBE_VERSION` / chart value `config.kubeVersion` sets `.Capabilities.KubeVersion` for every chart a render templates. Empty (the default) keeps current behavior.

- Parsed at startup with helm's own `ParseKubeVersion`, so a typo fails there instead of surfacing as a render failure on every PR.
- Accepts anything helm does — the `v` prefix and distro suffixes included — so a chart can pass `.Capabilities.KubeVersion.Version` straight through. The chart already `tpl`s its env values, so `config.kubeVersion: "{{ .Capabilities.KubeVersion.Version }}"` tracks the cluster the release installs into.
- No cache work needed: flate keys both the in-memory and on-disk Helm template caches on the kube version, so changing it can't serve a render templated at the old one.
- `helm.sh/helm/v4` moves from an indirect to a direct dependency (already in the build graph) for the startup validation.

Only the kube version is exposed; the `skip-*` templating knobs stay off, since a reviewer needs every rendered resource.

## Verification

Beyond the committed tests, I rendered a real chart through konflate's own `renderCfg()` — an offline fixture with a `file://` GitRepository serving a chart whose template emits `.Capabilities.KubeVersion.Version`:

| `KONFLATE_KUBE_VERSION` | what the chart saw |
| --- | --- |
| unset | helm's bundled default |
| `1.28.7` | `v1.28.7` |
| `v1.33.4-gke.1245000` | `v1.33.4-gke.1245000` |

Committed coverage: config parse/accept/reject, an engine assertion that the value reaches `HelmOptions`, and three chart unit tests — one of which proves the `{{ .Capabilities.KubeVersion.Version }}` recipe resolves through `tpl` (`v1.33.0` under simulated capabilities).

Local gates green: `fmt-check`, `vet`, `lint` (0 issues), `go test ./internal/...`, `helm-lint`, `helm-unittest` (70 passed), `tidy-check`, `generate-check`.

## Deliberately not included

- **No auto-default to the cluster's version.** Defaulting `config.kubeVersion` to `.Capabilities.KubeVersion.Version` is arguably more correct, but it bakes a value at install time that goes stale after a cluster upgrade until the release re-renders. Shipping it opt-in with the recipe documented; worth revisiting as a default later.
- **No per-cluster versions.** A single var can't describe a repo holding several clusters on different versions — consistent with `KONFLATE_CLUSTER_PATH` being singular.
- **No `KONFLATE_API_VERSIONS`.** Charts gating on `.Capabilities.APIVersions.Has` have the same problem and it's the same one-line plumb, but it's out of scope here.
