### PR TITLE
fix(test): repair the integration suite build and gate it in CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,10 @@
 version: "2"
 run:
   allow-parallel-runners: true
+  # Without this the build-tagged integration suite is invisible to CI (nothing
+  # else compiles it), and it silently rots against internal/ API changes.
+  build-tags:
+    - integration
 linters:
   default: none
   enable:

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -49,7 +49,14 @@ func TestRenderRealPR(t *testing.T) {
 	}
 	t.Logf("PR #%d %q: %s -> %s", pr.Number, pr.Title, pr.HeadRef, pr.BaseRef)
 
-	res, err := engine.New(cfg).Diff(ctx, pr)
+	// Clone with the same forge identity as the API client above, so a private
+	// KONFLATE_REPO renders (mirrors cmd/konflate).
+	gitToken, err := provider.GitTokenSource(cfg)
+	if err != nil {
+		t.Fatalf("git credential: %v", err)
+	}
+
+	res, err := engine.New(cfg, gitToken).Diff(ctx, pr)
 	if err != nil {
 		t.Fatalf("Diff: %v", err)
 	}


### PR DESCRIPTION
Found while working on #368 / #375, unrelated to that change.

## The break

`test/integration` has not compiled since `engine.New` gained its `gitclone.TokenFunc` parameter:

```
$ go vet -tags integration ./test/...
test/integration/integration_test.go:52:28: not enough arguments in call to engine.New
    have (*config.Config)
    want (*config.Config, gitclone.TokenFunc)
```

So `mise run test-integration` fails at build time, whether or not `KONFLATE_REPO` / `KONFLATE_INTEGRATION_PR` are set — the env gate never gets a chance to skip.

The test now resolves the credential the same way `cmd/konflate` does (`provider.GitTokenSource`, off the provider it already builds) rather than passing `nil`, so a private `KONFLATE_REPO` still renders and the clone isn't capped by the anonymous rate limit.

## Why it rotted unnoticed

Nothing in CI ever compiled the package: `go test ./...` skips the build tag, and golangci-lint doesn't analyze tagged files unless told to. So this rots on any `internal/` signature change and only surfaces when someone tries an integration run.

Adding `integration` to the linter's `run.build-tags` puts it under the lint job that already runs in CI, with no new job or step. Verified the gate actually bites — reintroducing the stale call fails `mise run lint`:

```
have (*config.Config)
want (*config.Config, gitclone.TokenFunc) (typecheck)
1 issues:
* typecheck: 1
```

and passes again once fixed (`0 issues`).

## Checks

`go vet -tags integration ./...` clean, `mise run lint` 0 issues, `mise run fmt-check`, `go test ./internal/...` all pass. The integration test itself still needs a real forge and PR to run, so it is not exercised here beyond compiling.
