### PR TITLE
fix(helm): stamp Chart.yaml version on release

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -95,7 +95,8 @@ description = "Install the chart into the current cluster (e.g. a kind context) 
 # The e2e workflow builds the PR's image, kind-loads it, and sets
 # KONFLATE_TEST_IMAGE_TAG=e2e + pull policy Never so the test runs the code under
 # review; locally these default to the published `latest` for a quick chart check
-# (the chart appVersion is a release-time placeholder, so a tag is always needed).
+# (the stamped appVersion would also resolve, but `latest` needs no bump to stay
+# current).
 # config.repo is a placeholder; startup doesn't block on it.
 run = """
 set -e

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -7,30 +7,37 @@ backend = "aqua:dadav/helm-schema"
 [tools."aqua:dadav/helm-schema"."platforms.linux-arm64"]
 checksum = "sha256:f45e427aef848a1565a1341e3d2468840c64dc1d2c0f3b276982b852d587abe8"
 url = "https://github.com/dadav/helm-schema/releases/download/0.23.4/helm-schema_0.23.4_Linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/dadav/helm-schema/releases/assets/437194950"
 
 [tools."aqua:dadav/helm-schema"."platforms.linux-arm64-musl"]
 checksum = "sha256:f45e427aef848a1565a1341e3d2468840c64dc1d2c0f3b276982b852d587abe8"
 url = "https://github.com/dadav/helm-schema/releases/download/0.23.4/helm-schema_0.23.4_Linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/dadav/helm-schema/releases/assets/437194950"
 
 [tools."aqua:dadav/helm-schema"."platforms.linux-x64"]
 checksum = "sha256:02d7aeb3b915b431a007402778f338daf77839d563cea62d9b375896028a72c7"
 url = "https://github.com/dadav/helm-schema/releases/download/0.23.4/helm-schema_0.23.4_Linux_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/dadav/helm-schema/releases/assets/437194947"
 
 [tools."aqua:dadav/helm-schema"."platforms.linux-x64-musl"]
 checksum = "sha256:02d7aeb3b915b431a007402778f338daf77839d563cea62d9b375896028a72c7"
 url = "https://github.com/dadav/helm-schema/releases/download/0.23.4/helm-schema_0.23.4_Linux_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/dadav/helm-schema/releases/assets/437194947"
 
 [tools."aqua:dadav/helm-schema"."platforms.macos-arm64"]
 checksum = "sha256:e0075eab02f304a8d11bf8a94480fa34ec4f2db2460978d656738bf22f1106d4"
 url = "https://github.com/dadav/helm-schema/releases/download/0.23.4/helm-schema_0.23.4_Darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/dadav/helm-schema/releases/assets/437194961"
 
 [tools."aqua:dadav/helm-schema"."platforms.macos-x64"]
 checksum = "sha256:568945c206f746d45bb366369b257dd3ea25fdb8597a6c34ef678fb688b12ebf"
 url = "https://github.com/dadav/helm-schema/releases/download/0.23.4/helm-schema_0.23.4_Darwin_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/dadav/helm-schema/releases/assets/437194962"
 
 [tools."aqua:dadav/helm-schema"."platforms.windows-x64"]
 checksum = "sha256:261f93081473ae8d465b29320f55282d979af9aa2c0585ad82dbc10db4d89175"
 url = "https://github.com/dadav/helm-schema/releases/download/0.23.4/helm-schema_0.23.4_Windows_x86_64.zip"
+url_api = "https://api.github.com/repos/dadav/helm-schema/releases/assets/437194958"
 
 [[tools.cosign]]
 version = "3.1.2"
@@ -117,36 +124,43 @@ backend = "aqua:golangci/golangci-lint"
 [tools.golangci-lint."platforms.linux-arm64"]
 checksum = "sha256:44cd40a8c76c86755375adfeea52cfd3533cb43d7bd647771e0ae065e166df3a"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470996"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.linux-arm64-musl"]
 checksum = "sha256:44cd40a8c76c86755375adfeea52cfd3533cb43d7bd647771e0ae065e166df3a"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470996"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.linux-x64"]
 checksum = "sha256:8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-amd64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413471054"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.linux-x64-musl"]
 checksum = "sha256:8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-amd64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413471054"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.macos-arm64"]
 checksum = "sha256:a9c54498731b3128f79e090be6110f3e5fffccc617b08142ed244d4126c73f29"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-darwin-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470950"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.macos-x64"]
 checksum = "sha256:f6f06d94b6241521c53d15450c5209b028270bf966f842afb11c030c79f5bc16"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-darwin-amd64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470980"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.windows-x64"]
 checksum = "sha256:bd42e3ebc8cb4ececb86941983baaf1dc221bbb04d838e94ce63b49cc91e02bb"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-windows-amd64.zip"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413471017"
 provenance = "github-attestations"
 
 [[tools.helm]]
@@ -188,30 +202,37 @@ backend = "aqua:norwoodj/helm-docs"
 [tools.helm-docs."platforms.linux-arm64"]
 checksum = "sha256:c3787212332386dcd122debef7848feb165aa701467ae3e3442df7638f3ac4e4"
 url = "https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/norwoodj/helm-docs/releases/assets/178327216"
 
 [tools.helm-docs."platforms.linux-arm64-musl"]
 checksum = "sha256:c3787212332386dcd122debef7848feb165aa701467ae3e3442df7638f3ac4e4"
 url = "https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/norwoodj/helm-docs/releases/assets/178327216"
 
 [tools.helm-docs."platforms.linux-x64"]
 checksum = "sha256:a8cf72ada34fad93285ba2a452b38bdc5bd52cc9a571236244ec31022928d6cc"
 url = "https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/norwoodj/helm-docs/releases/assets/178327210"
 
 [tools.helm-docs."platforms.linux-x64-musl"]
 checksum = "sha256:a8cf72ada34fad93285ba2a452b38bdc5bd52cc9a571236244ec31022928d6cc"
 url = "https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/norwoodj/helm-docs/releases/assets/178327210"
 
 [tools.helm-docs."platforms.macos-arm64"]
 checksum = "sha256:2d8399db5b33d240d5f8985241bcf5483563150b968e3229823822979f3e4b8b"
 url = "https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/norwoodj/helm-docs/releases/assets/178327215"
 
 [tools.helm-docs."platforms.macos-x64"]
 checksum = "sha256:b2f1ffd0feef8dc0901a38a2053481d1d67b63ca30da4ac774166c6b52fa2245"
 url = "https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Darwin_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/norwoodj/helm-docs/releases/assets/178327211"
 
 [tools.helm-docs."platforms.windows-x64"]
 checksum = "sha256:3c54fd78d99e2769cf83a0faf12cf6cd4de1cac6ed7bee8d908a2c8fc23f538c"
 url = "https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Windows_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/norwoodj/helm-docs/releases/assets/178327219"
 
 [[tools.lefthook]]
 version = "2.1.10"
@@ -302,30 +323,44 @@ backend = "aqua:mikefarah/yq"
 [tools.yq."platforms.linux-arm64"]
 checksum = "sha256:578648e463a11c1b6db6010cbf41eafed6bee79466fcffa1bb446672cf7945ea"
 url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_arm64"
+url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/440146727"
+provenance = "cosign"
 
 [tools.yq."platforms.linux-arm64-musl"]
 checksum = "sha256:578648e463a11c1b6db6010cbf41eafed6bee79466fcffa1bb446672cf7945ea"
 url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_arm64"
+url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/440146727"
+provenance = "cosign"
 
 [tools.yq."platforms.linux-x64"]
 checksum = "sha256:fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4"
 url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_amd64"
+url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/440146735"
+provenance = "cosign"
 
 [tools.yq."platforms.linux-x64-musl"]
 checksum = "sha256:fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4"
 url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_amd64"
+url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/440146735"
+provenance = "cosign"
 
 [tools.yq."platforms.macos-arm64"]
 checksum = "sha256:877de31753a4dd2401aa048937aa9a7fc4d5f6ce858cf31508c5802954297213"
 url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_darwin_arm64"
+url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/440146762"
+provenance = "cosign"
 
 [tools.yq."platforms.macos-x64"]
 checksum = "sha256:b4ba1ecce3c47f00803f4f964de38394326c7a32eb6540616e04fb2935a0f08d"
 url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_darwin_amd64"
+url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/440146744"
+provenance = "cosign"
 
 [tools.yq."platforms.windows-x64"]
 checksum = "sha256:e279bc506a452eeafcdf364f91a025455e402a8001169083caf01f4b64a544e2"
 url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_windows_amd64.exe"
+url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/440146721"
+provenance = "cosign"
 
 [[tools.zizmor]]
 version = "1.28.0"

--- a/charts/konflate/Chart.yaml
+++ b/charts/konflate/Chart.yaml
@@ -6,9 +6,11 @@ type: application
 # Floor matching the chart's surface: restricted Pod Security (seccompProfile),
 # networking.k8s.io/v1 Ingress, and the Gateway API v1 HTTPRoute.
 kubeVersion: ">=1.25.0-0"
-# version + appVersion are overridden at package time from the release tag.
-version: 0.0.0
-appVersion: "0.0.0"
+# Stamped by release-please on every release so a git-sourced install deploys a
+# real image tag (the release workflow re-stamps both at package time anyway;
+# these keep the repo copy from going stale).
+version: 0.4.2 # x-release-please-version
+appVersion: "0.4.2" # x-release-please-version
 home: https://github.com/home-operations/konflate
 icon: https://raw.githubusercontent.com/home-operations/konflate/main/internal/web/public/favicon.svg
 sources:

--- a/charts/konflate/README.md
+++ b/charts/konflate/README.md
@@ -1,6 +1,8 @@
 # konflate
 
-![Version: 0.0.0](https://img.shields.io/badge/Version-0.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version](https://img.shields.io/static/v1?label=Version&message=0.4.2&color=informational&style=flat-square) <!-- x-release-please-version -->
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message=0.4.2&color=informational&style=flat-square) <!-- x-release-please-version -->
 
 A web UI for reviewing GitOps pull requests as rendered Flux diffs
 

--- a/charts/konflate/README.md.gotmpl
+++ b/charts/konflate/README.md.gotmpl
@@ -1,6 +1,14 @@
 {{ template "chart.header" . }}
 
-{{ template "chart.badgesSection" . }}
+{{- /* Hand-rolled badges instead of chart.badgesSection so release-please can
+stamp the version: its updater replaces only the first semver on an annotated
+line and would swallow a `-color` suffix as a prerelease, so each version badge
+uses the static/v1 query form (version followed by `&`), keeps the version out
+of its alt text, and carries its own annotation. Keeps the committed README in
+sync with the stamped Chart.yaml. */}}
+![Version](https://img.shields.io/static/v1?label=Version&message={{ .Version }}&color=informational&style=flat-square) <!-- x-release-please-version -->
+![Type: {{ .Type }}](https://img.shields.io/badge/Type-{{ .Type }}-informational?style=flat-square)
+![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message={{ .AppVersion }}&color=informational&style=flat-square) <!-- x-release-please-version -->
 
 {{ template "chart.description" . }}
 

--- a/charts/konflate/tests/deployment_test.yaml
+++ b/charts/konflate/tests/deployment_test.yaml
@@ -4,11 +4,13 @@ templates:
 set:
   config.repo: github://owner/repo
 tests:
+  # The tag floats with the release-please-stamped appVersion; assert the
+  # repo:semver shape rather than a hardcoded version.
   - it: defaults the image to repository:appVersion when no digest or tag is set
     asserts:
-      - equal:
+      - matchRegex:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/home-operations/konflate:0.0.0
+          pattern: ^ghcr\.io/home-operations/konflate:\d+\.\d+\.\d+$
 
   - it: defaults to the Recreate update strategy (in-memory singleton + RWO cache)
     asserts:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,11 @@
       "include-component-in-tag": false,
       "include-v-in-tag": false,
       "include-v-in-release-name": false,
-      "always-update": true
+      "always-update": true,
+      "extra-files": [
+        { "type": "generic", "path": "charts/konflate/Chart.yaml" },
+        "charts/konflate/README.md"
+      ]
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
Ports home-operations/tuppr#414 + home-operations/tuppr#415 to konflate.

## Why

The in-repo `charts/konflate/Chart.yaml` carried a `0.0.0` placeholder for both `version` and `appVersion`. Only the *packaged* chart ever got a real version, injected by the release workflow (`helm package --version --app-version`), so a git-sourced install — or anyone just reading the chart in the repo — saw a version and a default image tag that resolve to nothing.

## What

`version` and `appVersion` are now annotated with `x-release-please-version` and the chart is listed in `extra-files`, so release-please stamps the committed copy on every release. The release workflow still re-stamps at package time; this only keeps the repo copy honest.

`extra-files` uses the **typed** form for Chart.yaml:

```json
"extra-files": [
  { "type": "generic", "path": "charts/konflate/Chart.yaml" },
  "charts/konflate/README.md"
]
```

That is the crux, and it is why this is two upstream commits rather than one. A plain string path is dispatched by file extension; `.yaml` gets a composite YAML updater that reparses and re-serializes the whole document — stripping every comment (including the annotations that make the stamping work) and leaving `appVersion` unstamped. `{ "type": "generic" }` touches only annotated lines. `README.md` stays a plain string because `.md` already falls through to the generic updater.

Two consequences:

- The chart README badges move off helm-docs' `chart.badgesSection` to the annotated `static/v1` form, so the generated README stays in sync with the stamped Chart.yaml. The version has to sit in a query parameter (followed by `&`) and out of the alt text — the updater replaces only the first semver on an annotated line, and the old badge URL's `-informational` suffix would be swallowed as a prerelease.
- `deployment_test.yaml` asserted `ghcr.io/home-operations/konflate:0.0.0`. That tag now floats with `appVersion`, so it asserts the `repo:semver` shape instead.

Also refreshed a comment in the `helm-test` mise task that justified passing an explicit tag by calling `appVersion` "a release-time placeholder" — no longer true.

## Verification

`mise run helm-lint`, `mise run helm-unittest` (73 passed), and `mise run generate-check` all pass; the regenerated README badges render `0.4.2` from the stamped chart.

Beyond local gates, the pattern is already proven in production: tuppr's 0.4.1 release (home-operations/tuppr@494cd5f) stamped both `Chart.yaml` fields and both README badges cleanly, with comments and annotations intact — that release is what confirms the typed-updater form behaves as intended end to end.
