### PR TITLE
docs: point the CI badge at ci.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 **Review your GitOps pull requests as _rendered_ Flux diffs — not raw file diffs.**
 
-[![Tests](https://img.shields.io/github/actions/workflow/status/home-operations/konflate/tests.yaml?branch=main&label=tests)](https://github.com/home-operations/konflate/actions/workflows/tests.yaml)
-[![Lint](https://img.shields.io/github/actions/workflow/status/home-operations/konflate/lint.yaml?branch=main&label=lint)](https://github.com/home-operations/konflate/actions/workflows/lint.yaml)
+[![CI](https://img.shields.io/github/actions/workflow/status/home-operations/konflate/ci.yaml?branch=main&label=ci)](https://github.com/home-operations/konflate/actions/workflows/ci.yaml)
 [![Release](https://img.shields.io/github/actions/workflow/status/home-operations/konflate/release.yaml?branch=main&label=release)](https://github.com/home-operations/konflate/actions/workflows/release.yaml)
 [![License](https://img.shields.io/github/license/home-operations/konflate)](https://github.com/home-operations/konflate/blob/main/LICENSE)
 


### PR DESCRIPTION
## Overview

The `Tests`, `Lint` and `E2E` workflows were consolidated into `ci.yaml`, so the
README badges pointed at workflow files that no longer exist and rendered as
"no status". They collapse into a single `CI` badge.

Missed in the consolidation PR — the badges are Markdown, so nothing in
`actionlint`/`zizmor` or the workflow diff surfaced them.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: YES — change and description written by an AI agent (Claude Code) under maintainer direction.
