### PR TITLE
fix(go): update to go 1.27.0

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -9,9 +9,9 @@
 [tools]
 actionlint = "1.7.12"
 "aqua:dadav/helm-schema" = "0.23.4"
-go = "1.26.6"
+go = "1.27.0"
 "go:golang.org/x/vuln/cmd/govulncheck" = "v1.7.0"
-golangci-lint = "2.12.2"
+golangci-lint = "2.13.0"
 helm = "4.2.4"
 cosign = "3.1.3"
 helm-docs = "1.14.2"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -64,45 +64,45 @@ url_api = "https://api.github.com/repos/sigstore/cosign/releases/assets/50328620
 provenance = "cosign"
 
 [[tools.go]]
-version = "1.26.6"
+version = "1.27.0"
 backend = "core:go"
 
 [tools.go."platforms.linux-arm64"]
-checksum = "sha256:d0507e9e9d7fe012aae570108cbd76c15de879e17130ab8cb90d4d7445cb1f2e"
-url = "https://dl.google.com/go/go1.26.6.linux-arm64.tar.gz"
+checksum = "sha256:51798d2c42d0e1c6ed7fd9f48728b4193abac9e8aad6dbac2fe96a81f5909bda"
+url = "https://dl.google.com/go/go1.27.0.linux-arm64.tar.gz"
 
 [tools.go."platforms.linux-x64"]
-checksum = "sha256:708effb774be8237570d0add163225abbdfaf4fca28b2611df167beba4feef89"
-url = "https://dl.google.com/go/go1.26.6.linux-amd64.tar.gz"
+checksum = "sha256:675c26c449cbb18fc24b74650de1eabbae6e16f64326fd85a283fb3b58280685"
+url = "https://dl.google.com/go/go1.27.0.linux-amd64.tar.gz"
 
 [tools.go."platforms.macos-arm64"]
-checksum = "sha256:2dc95ce4675829f2df0e86b28bcef3283635902062a5f0580ca659bf570f3204"
-url = "https://dl.google.com/go/go1.26.6.darwin-arm64.tar.gz"
+checksum = "sha256:90493b3bbd5e10f91d12153198bf1994fd756399b4fec93b49b0c6e2acdeeb3e"
+url = "https://dl.google.com/go/go1.27.0.darwin-arm64.tar.gz"
 
 [[tools."go:golang.org/x/vuln/cmd/govulncheck"]]
 version = "1.7.0"
 backend = "go:golang.org/x/vuln/cmd/govulncheck"
 
 [[tools.golangci-lint]]
-version = "2.12.2"
+version = "2.13.0"
 backend = "aqua:golangci/golangci-lint"
 
 [tools.golangci-lint."platforms.linux-arm64"]
-checksum = "sha256:44cd40a8c76c86755375adfeea52cfd3533cb43d7bd647771e0ae065e166df3a"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-arm64.tar.gz"
-url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470996"
+checksum = "sha256:3a91c7bb9c135099a97858bea431d6dd2f54e4bf68d479c776c2350428d60e41"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.13.0/golangci-lint-2.13.0-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/521471362"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.linux-x64"]
-checksum = "sha256:8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-amd64.tar.gz"
-url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413471054"
+checksum = "sha256:a10e8d8359d76b9e2b41da60f9d98bb26fd53c7a453caa82e0a172d6f72fd2ca"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.13.0/golangci-lint-2.13.0-linux-amd64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/521471346"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.macos-arm64"]
-checksum = "sha256:a9c54498731b3128f79e090be6110f3e5fffccc617b08142ed244d4126c73f29"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-darwin-arm64.tar.gz"
-url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470950"
+checksum = "sha256:72eae670097978e61b78a773a25c27439e35d54094fd986cee5eeeb25d7144fd"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.13.0/golangci-lint-2.13.0-darwin-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/521471400"
 provenance = "github-attestations"
 
 [[tools.helm]]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/home-operations/konflate
 
-go 1.26.5
+go 1.27.0
 
 require (
 	cel.dev/cel-go v0.32.0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -565,7 +565,7 @@ func normalizeBasePath(cfg *Config) error {
 	}
 	// net/url parsing would accept "/foo/../bar" as a path; split and check each
 	// segment to reject traversal.
-	for _, seg := range strings.Split(strings.Trim(p, "/"), "/") {
+	for seg := range strings.SplitSeq(strings.Trim(p, "/"), "/") {
 		if seg == "" || seg == "." || seg == ".." {
 			return fmt.Errorf("config: KONFLATE_BASE_PATH must not contain empty, ., or .. segments")
 		}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"maps"
 	"testing"
 
 	"github.com/home-operations/flate/pkg/manifest"
@@ -23,9 +24,7 @@ func res(kind, ns, name string, extra map[string]any) map[string]any {
 		meta["namespace"] = ns
 	}
 	m := map[string]any{"kind": kind, "metadata": meta}
-	for k, v := range extra {
-		m[k] = v
-	}
+	maps.Copy(m, extra)
 	return m
 }
 

--- a/internal/prfilter/prfilter_test.go
+++ b/internal/prfilter/prfilter_test.go
@@ -1,6 +1,7 @@
 package prfilter
 
 import (
+	"maps"
 	"testing"
 	"time"
 )
@@ -54,9 +55,7 @@ func sampleVars(over map[string]any) map[string]any {
 			map[string]any{"name": "cluster/production", "color": "d93f0b"},
 		},
 	}
-	for k, v := range over {
-		pr[k] = v
-	}
+	maps.Copy(pr, over)
 	return pr
 }
 

--- a/internal/provider/forgejo.go
+++ b/internal/provider/forgejo.go
@@ -50,9 +50,9 @@ func (p *forgejoProvider) ListPRs(ctx context.Context) ([]api.PR, error) {
 	// interface and is intentionally unused.
 	_ = ctx
 	opts := forgejo.ListPullRequestsOptions{
-		State:       forgejo.StateOpen,
-		Sort:        "recentupdate",
-		ListOptions: forgejo.ListOptions{PageSize: 50}, // Gitea/Forgejo caps the page size server-side
+		State:    forgejo.StateOpen,
+		Sort:     "recentupdate",
+		PageSize: 50, // Gitea/Forgejo caps the page size server-side
 	}
 	var out []api.PR
 	for {
@@ -99,7 +99,7 @@ func (p *forgejoProvider) Checks(ctx context.Context, pr api.PR) (api.CheckRollu
 	// does server-side — using the same all-pages loop ListPRs uses. Status IDs are
 	// monotonic (a DB auto-increment), so the highest ID for a context is its latest.
 	latest := map[string]*forgejo.Status{}
-	opts := forgejo.ListStatusesOption{ListOptions: forgejo.ListOptions{PageSize: 50}}
+	opts := forgejo.ListStatusesOption{PageSize: 50}
 	for {
 		statuses, resp, err := p.client.ListStatuses(p.owner, p.repo, pr.HeadSHA, opts)
 		if err != nil {

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -82,10 +82,10 @@ func githubEnterpriseOpts(host string) []github.ClientOptionsFunc {
 
 func (p *githubProvider) ListPRs(ctx context.Context) ([]api.PR, error) {
 	opts := &github.PullRequestListOptions{
-		State:       stateOpen,
-		Sort:        "updated",
-		Direction:   "desc",
-		ListOptions: github.ListOptions{PerPage: 100},
+		State:     stateOpen,
+		Sort:      "updated",
+		Direction: "desc",
+		PerPage:   100,
 	}
 	var out []api.PR
 	for {
@@ -141,7 +141,7 @@ func (p *githubProvider) Checks(ctx context.Context, pr api.PR) (api.CheckRollup
 	}
 
 	runs, _, err := p.client.Checks.ListCheckRunsForRef(ctx, p.owner, p.repo, pr.HeadSHA,
-		&github.ListCheckRunsOptions{ListOptions: github.ListOptions{PerPage: 100}})
+		&github.ListCheckRunsOptions{PerPage: 100})
 	if err != nil {
 		return api.CheckRollup{}, fmt.Errorf("github: check runs #%d: %w", pr.Number, err)
 	}

--- a/internal/provider/gitlab.go
+++ b/internal/provider/gitlab.go
@@ -38,9 +38,9 @@ func (p *gitlabProvider) ListPRs(ctx context.Context) ([]api.PR, error) {
 	state := "opened"
 	order := "updated_at"
 	opts := &gitlab.ListProjectMergeRequestsOptions{
-		State:       &state,
-		OrderBy:     &order,
-		ListOptions: gitlab.ListOptions{PerPage: 100},
+		State:   &state,
+		OrderBy: &order,
+		PerPage: 100,
 	}
 	var out []api.PR
 	for {
@@ -78,7 +78,7 @@ func (p *gitlabProvider) Checks(ctx context.Context, pr api.PR) (api.CheckRollup
 		return api.CheckRollup{}, nil
 	}
 	statuses, _, err := p.client.Commits.GetCommitStatuses(p.project, pr.HeadSHA,
-		&gitlab.GetCommitStatusesOptions{ListOptions: gitlab.ListOptions{PerPage: 100}}, gitlab.WithContext(ctx))
+		&gitlab.GetCommitStatusesOptions{PerPage: 100}, gitlab.WithContext(ctx))
 	if err != nil {
 		return api.CheckRollup{}, fmt.Errorf("gitlab: commit statuses !%d: %w", pr.Number, err)
 	}

--- a/internal/provider/writer.go
+++ b/internal/provider/writer.go
@@ -433,15 +433,13 @@ func (w *githubWriter) CheckRun(ctx context.Context, pr api.PR, res CheckResult)
 			github.UpdateCheckRunOptions
 			StartedAt *github.Timestamp `json:"started_at,omitempty"`
 		}{
-			UpdateCheckRunOptions: github.UpdateCheckRunOptions{
-				Name:        res.Name,
-				Status:      &completed,
-				Conclusion:  &res.Conclusion,
-				CompletedAt: &now,
-				DetailsURL:  strOrNil(res.DetailsURL),
-				Output:      output,
-			},
-			StartedAt: &now,
+			Name:        res.Name,
+			Status:      &completed,
+			Conclusion:  &res.Conclusion,
+			CompletedAt: &now,
+			DetailsURL:  strOrNil(res.DetailsURL),
+			Output:      output,
+			StartedAt:   &now,
 		}
 		req, err := w.client.NewRequest(ctx, http.MethodPatch,
 			fmt.Sprintf("repos/%s/%s/check-runs/%d", w.owner, w.repo, id), body)
@@ -480,8 +478,8 @@ func (w *githubWriter) findCheckRun(ctx context.Context, sha, name string) (int6
 		return 0, nil
 	}
 	runs, resp, err := w.client.Checks.ListCheckRunsForRef(ctx, w.owner, w.repo, sha, &github.ListCheckRunsOptions{
-		CheckName:   &name,
-		ListOptions: github.ListOptions{PerPage: 1},
+		CheckName: &name,
+		PerPage:   1,
 	})
 	if err != nil {
 		return 0, githubReject(resp, fmt.Errorf("github: list check runs: %w", err))
@@ -638,7 +636,7 @@ func (w *forgejoWriter) UpsertComment(ctx context.Context, pr api.PR, marker, bo
 	}
 	// The Forgejo SDK can't take a context (see provider ListPRs).
 	idx := int64(pr.Number)
-	opts := forgejo.ListIssueCommentOptions{ListOptions: forgejo.ListOptions{PageSize: 50}}
+	opts := forgejo.ListIssueCommentOptions{PageSize: 50}
 	for {
 		comments, resp, err := w.client.ListIssueComments(w.owner, w.repo, idx, opts)
 		if err != nil {
@@ -725,7 +723,7 @@ func (w *gitlabWriter) UpsertComment(ctx context.Context, pr api.PR, marker, bod
 		return fmt.Errorf("gitlab: %w", err)
 	}
 	mr := int64(pr.Number)
-	opts := &gitlab.ListMergeRequestNotesOptions{ListOptions: gitlab.ListOptions{PerPage: 100}}
+	opts := &gitlab.ListMergeRequestNotesOptions{PerPage: 100}
 	for {
 		notes, resp, err := w.client.Notes.ListMergeRequestNotes(w.project, mr, opts, gitlab.WithContext(ctx))
 		if err != nil {

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -25,14 +25,13 @@ import (
 func (s *Server) mcpHandler() http.Handler {
 	// One server instance serves every request; the SDK tracks per-client sessions.
 	srv := s.mcpServer()
+	h := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return srv }, nil)
 	// CrossOriginProtection rejects cross-origin browser requests (via Sec-Fetch-Site
 	// / Origin) as CSRF defense-in-depth; native MCP clients send neither header and
-	// are unaffected. The SDK additionally rejects DNS-rebinding (a non-localhost Host
+	// are unaffected. Applied as middleware, the SDK's own option for it being
+	// deprecated. The SDK additionally rejects DNS-rebinding (a non-localhost Host
 	// on a localhost request) by default.
-	return mcp.NewStreamableHTTPHandler(
-		func(*http.Request) *mcp.Server { return srv },
-		&mcp.StreamableHTTPOptions{CrossOriginProtection: http.NewCrossOriginProtection()},
-	)
+	return http.NewCrossOriginProtection().Handler(h)
 }
 
 // mcpServer builds the MCP server and registers konflate's read-only tools. Split

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -372,7 +372,7 @@ func TestWritePRLine_DefangsTitle(t *testing.T) {
 	t.Parallel()
 	var b strings.Builder
 	writePRLine(&b, api.PRStatus{
-		PR:     api.PR{Number: 7, Title: "line one\nline two [x](https://evil.example)", Open: true},
+		Number: 7, Title: "line one\nline two [x](https://evil.example)", Open: true,
 		Status: api.JobReady,
 	})
 	out := b.String()
@@ -392,7 +392,7 @@ func TestWritePRLine_DefangsTitle(t *testing.T) {
 	// Angle brackets (autolink / raw HTML) and backticks (code span) are defanged too.
 	var b2 strings.Builder
 	writePRLine(&b2, api.PRStatus{
-		PR:     api.PR{Number: 8, Title: "<https://evil.example> and `code` <script>x</script>", Open: true},
+		Number: 8, Title: "<https://evil.example> and `code` <script>x</script>", Open: true,
 		Status: api.JobReady,
 	})
 	inj := b2.String()
@@ -410,7 +410,7 @@ func TestWritePRLine_DefangsTitle(t *testing.T) {
 
 	// A normal conventional-commit title is left untouched (parens not escaped).
 	var b3 strings.Builder
-	writePRLine(&b3, api.PRStatus{PR: api.PR{Number: 9, Title: "feat(scope): add the_thing", Open: true}, Status: api.JobReady})
+	writePRLine(&b3, api.PRStatus{Number: 9, Title: "feat(scope): add the_thing", Open: true, Status: api.JobReady})
 	if !strings.Contains(b3.String(), "feat(scope): add the_thing") {
 		t.Errorf("a normal title must not be mangled: %q", b3.String())
 	}
@@ -421,8 +421,8 @@ func TestWritePRLine_DefangsTitle(t *testing.T) {
 func TestRenderDiffText_TruncatesLargeDiff(t *testing.T) {
 	t.Parallel()
 	big := strings.Repeat("x", 4096) // plain text: stripHTML is a no-op
-	var resources []api.DiffResource
-	for i := 0; i < 64; i++ { // ~256 KiB, well over the 96 KiB budget
+	resources := make([]api.DiffResource, 0, 64)
+	for i := range 64 { // ~256 KiB, well over the 96 KiB budget
 		resources = append(resources, api.DiffResource{
 			Status:  "changed",
 			Title:   fmt.Sprintf("Deployment ns/app-%d", i),

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -158,6 +159,66 @@ func TestMCP_HTTPEndpoint(t *testing.T) {
 		if err == nil {
 			_ = cs.Close()
 			t.Fatal("connected to /mcp with KONFLATE_MCP off; the endpoint must not be served")
+		}
+	})
+}
+
+// TestMCP_RequestProtections pins /mcp's two request-level defenses over a real
+// listener: the cross-origin middleware (a browser-shaped POST — Sec-Fetch-Site
+// or a mismatched Origin — is rejected, a same-origin one is let through) and
+// the SDK's DNS-rebinding guard (a non-localhost Host on a loopback listener is
+// rejected). Native-client acceptance through the same stack is covered by
+// TestMCP_HTTPEndpoint.
+func TestMCP_RequestProtections(t *testing.T) {
+	t.Parallel()
+	cfg := ghCfg("tok")
+	cfg.MCP = true
+	s := newTestServer(t, cfg, &fakeProvider{}, okEngine())
+	httpSrv := httptest.NewServer(s.mainHandler())
+	t.Cleanup(httpSrv.Close)
+
+	post := func(t *testing.T, shape func(*http.Request)) *http.Response {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodPost, httpSrv.URL+"/mcp", strings.NewReader("{}"))
+		if err != nil {
+			t.Fatalf("build request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		shape(req)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("POST /mcp: %v", err)
+		}
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		return resp
+	}
+
+	t.Run("cross-site fetch is rejected", func(t *testing.T) {
+		resp := post(t, func(r *http.Request) { r.Header.Set("Sec-Fetch-Site", "cross-site") })
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("cross-site POST /mcp: %d, want 403", resp.StatusCode)
+		}
+	})
+
+	t.Run("mismatched Origin is rejected", func(t *testing.T) {
+		resp := post(t, func(r *http.Request) { r.Header.Set("Origin", "https://evil.example") })
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("cross-origin POST /mcp: %d, want 403", resp.StatusCode)
+		}
+	})
+
+	t.Run("same-origin browser request passes the CSRF layer", func(t *testing.T) {
+		resp := post(t, func(r *http.Request) { r.Header.Set("Sec-Fetch-Site", "same-origin") })
+		// The SDK may still reject the bare body, but never with the CSRF 403.
+		if resp.StatusCode == http.StatusForbidden {
+			t.Errorf("same-origin POST /mcp: 403; the CSRF layer must not block same-origin requests")
+		}
+	})
+
+	t.Run("non-localhost Host on a loopback listener is rejected", func(t *testing.T) {
+		resp := post(t, func(r *http.Request) { r.Host = "rebind.example" })
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("rebound-Host POST /mcp: %d, want 403", resp.StatusCode)
 		}
 	})
 }


### PR DESCRIPTION
Rolls konflate to Go 1.27.0, in line with the other home-operations Go repos.

- `.mise/config.toml` + `go.mod` to `go 1.27.0` (lockfile refreshed).
- golangci-lint `2.12.2` → `2.13.0`: 2.12.2 is built with go1.26 and hard-fails on a 1.27 target.
- `go fix ./...` applied and re-run to a fixed point (a second pass makes no further changes): `strings.SplitSeq`, `maps.Copy`, promoted-field struct literals (new 1.27 language feature) on the forge SDK option structs and test literals, and one int range loop.
- Two findings surfaced by the newer staticcheck/prealloc in golangci-lint 2.13.0: the MCP handler now wraps with `http.NewCrossOriginProtection().Handler(...)` instead of the SDK's deprecated `StreamableHTTPOptions.CrossOriginProtection` (same protection, applied as middleware per the SDK's deprecation note), and a test slice is preallocated.

Verified: `go build`, `go vet`, gofmt, golangci-lint 2.13.0 (0 issues), `go test -race ./...` (full suite green), govulncheck (0 affecting vulnerabilities). No Dockerfile changes needed — `GO_VERSION` flows from mise via CI and `golang:1.27.0-alpine` is published.