### PR TITLE
fix(go): update module github.com/home-operations/flate (v0.5.1 → v0.6.0)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-containerregistry v0.21.9
 	github.com/google/go-github/v90 v90.0.0
-	github.com/home-operations/flate v0.5.1
+	github.com/home-operations/flate v0.6.0
 	github.com/klauspost/compress v1.19.2
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2

--- a/go.sum
+++ b/go.sum
@@ -284,8 +284,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
-github.com/home-operations/flate v0.5.1 h1:rDi4uWFZMVT/ytkjipjy2LD0zqQuTwUwYa0U0McWN6A=
-github.com/home-operations/flate v0.5.1/go.mod h1:ED829dPceBHYDDqGPFJQEJIZBCNhJNncfhPaU5CtOwE=
+github.com/home-operations/flate v0.6.0 h1:QKwIm1bXhVXHTN6SZs3/byRySJgAm7Qap1RaYJVAjL4=
+github.com/home-operations/flate v0.6.0/go.mod h1:XZ0skRwF6X+rhkkWoKyIkiXKds31JLY3avVmUt35wIA=
 github.com/homeport/dyff v1.12.0 h1:1d4T2vdY0hYeWtAxjMLIX9bI8OijBfOuKH3wzfdYZT8=
 github.com/homeport/dyff v1.12.0/go.mod h1:ArdUQcX099hp+uQ7pnimwU0Xgk2ba7E7nqdFv3WBRr8=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=


### PR DESCRIPTION
Updates flate to v0.6.0 (go 1.27 + generic-methods release, home-operations/flate#928).

flate 0.6.0's breaking changes are confined to `pkg/store` and `pkg/controllers/base`; konflate imports neither of the changed symbols (only `store.StatusInfo`), so this is a drop-in bump.

Verified: build, vet, golangci-lint (0 issues), `go test -race ./...` fully green.